### PR TITLE
NO-ISSUES: Fix headers

### DIFF
--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ANCConfiguration.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ANCConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/AbstractCompilerHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/AbstractCompilerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/AssertHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/AssertHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/CanInlineInANC.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/CanInlineInANC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/CompiledNetwork.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/CompiledNetwork.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/CompiledNetworkSources.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/CompiledNetworkSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/CouldNotCreateAlphaNetworkCompilerException.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/CouldNotCreateAlphaNetworkCompilerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/DebugHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/DebugHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/DeclarationsHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/DeclarationsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/DelegateMethodsHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/DelegateMethodsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/HashedAlphasDeclaration.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/HashedAlphasDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/InlineFieldReferenceInitHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/InlineFieldReferenceInitHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/KieBaseUpdaterANC.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/KieBaseUpdaterANC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/KieBaseUpdaterANCFactory.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/KieBaseUpdaterANCFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ListUtils.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ListUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/MapUtils.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/MapUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ModifyHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ModifyHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/NetworkHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/NetworkHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/NetworkHandlerAdaptor.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/NetworkHandlerAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/NodeCollectorHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/NodeCollectorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ObjectTypeNodeCompiler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ObjectTypeNodeCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ObjectTypeNodeParser.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ObjectTypeNodeParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/PropagatorCompilerHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/PropagatorCompilerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ResultCollectorSink.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ResultCollectorSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/SetNodeReferenceHandler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/SetNodeReferenceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkInitTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkInitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/BaseModelTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/BaseModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/ChildFactWithEnum1.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/ChildFactWithEnum1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/EnumFact1.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/EnumFact1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/KJARUtils.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/KJARUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/LargeAlphaNetworkTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/LargeAlphaNetworkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/MixedConstraintsTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/MixedConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/MultipleIndexableConstraintsTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/MultipleIndexableConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/Person.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/RangeIndexANCTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/RangeIndexANCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/InitialFact.java
+++ b/drools-base/src/main/java/org/drools/base/InitialFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/RuleBase.java
+++ b/drools-base/src/main/java/org/drools/base/RuleBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/RuleBuildContext.java
+++ b/drools-base/src/main/java/org/drools/base/RuleBuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/AcceptsClassObjectType.java
+++ b/drools-base/src/main/java/org/drools/base/base/AcceptsClassObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/AccessorKey.java
+++ b/drools-base/src/main/java/org/drools/base/base/AccessorKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/AccessorKeySupplier.java
+++ b/drools-base/src/main/java/org/drools/base/base/AccessorKeySupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/BaseClassFieldReader.java
+++ b/drools-base/src/main/java/org/drools/base/base/BaseClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/ClassFieldInspector.java
+++ b/drools-base/src/main/java/org/drools/base/base/ClassFieldInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/ClassObjectType.java
+++ b/drools-base/src/main/java/org/drools/base/base/ClassObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/ClassWireable.java
+++ b/drools-base/src/main/java/org/drools/base/base/ClassWireable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/CoreComponentsBuilder.java
+++ b/drools-base/src/main/java/org/drools/base/base/CoreComponentsBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/DroolsQuery.java
+++ b/drools-base/src/main/java/org/drools/base/base/DroolsQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/EnabledBoolean.java
+++ b/drools-base/src/main/java/org/drools/base/base/EnabledBoolean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/FieldAccessor.java
+++ b/drools-base/src/main/java/org/drools/base/base/FieldAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/ObjectType.java
+++ b/drools-base/src/main/java/org/drools/base/base/ObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/ReadAccessorSupplier.java
+++ b/drools-base/src/main/java/org/drools/base/base/ReadAccessorSupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/SalienceInteger.java
+++ b/drools-base/src/main/java/org/drools/base/base/SalienceInteger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/SimpleValueType.java
+++ b/drools-base/src/main/java/org/drools/base/base/SimpleValueType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/ValueResolver.java
+++ b/drools-base/src/main/java/org/drools/base/base/ValueResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/ValueType.java
+++ b/drools-base/src/main/java/org/drools/base/base/ValueType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/XMLSupport.java
+++ b/drools-base/src/main/java/org/drools/base/base/XMLSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/extractors/ArrayElementReader.java
+++ b/drools-base/src/main/java/org/drools/base/base/extractors/ArrayElementReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/extractors/BaseObjectClassFieldReader.java
+++ b/drools-base/src/main/java/org/drools/base/base/extractors/BaseObjectClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/extractors/SelfReferenceClassFieldReader.java
+++ b/drools-base/src/main/java/org/drools/base/base/extractors/SelfReferenceClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/base/field/ObjectFieldImpl.java
+++ b/drools-base/src/main/java/org/drools/base/base/field/ObjectFieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/beliefsystem/Mode.java
+++ b/drools-base/src/main/java/org/drools/base/beliefsystem/Mode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/common/DroolsObjectInput.java
+++ b/drools-base/src/main/java/org/drools/base/common/DroolsObjectInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/common/DroolsObjectInputStream.java
+++ b/drools-base/src/main/java/org/drools/base/common/DroolsObjectInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/common/DroolsObjectOutputStream.java
+++ b/drools-base/src/main/java/org/drools/base/common/DroolsObjectOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/common/DroolsObjectStreamConstants.java
+++ b/drools-base/src/main/java/org/drools/base/common/DroolsObjectStreamConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/common/MissingDependencyException.java
+++ b/drools-base/src/main/java/org/drools/base/common/MissingDependencyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/common/NetworkNode.java
+++ b/drools-base/src/main/java/org/drools/base/common/NetworkNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/common/PartitionsManager.java
+++ b/drools-base/src/main/java/org/drools/base/common/PartitionsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/common/RuleBasePartitionId.java
+++ b/drools-base/src/main/java/org/drools/base/common/RuleBasePartitionId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/definitions/InternalKnowledgePackage.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/InternalKnowledgePackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/definitions/ProcessPackage.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/ProcessPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/definitions/ResourceTypePackageRegistry.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/ResourceTypePackageRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/definitions/impl/KnowledgePackageImpl.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/impl/KnowledgePackageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/definitions/rule/impl/GlobalImpl.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/rule/impl/GlobalImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/definitions/rule/impl/QueryImpl.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/rule/impl/QueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/definitions/rule/impl/RuleImpl.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/rule/impl/RuleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/AccessibleFact.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/AccessibleFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/AnnotationDefinition.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/AnnotationDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/ClassDefinition.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/ClassDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/FieldDefinition.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/FieldDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/GeneratedFact.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/GeneratedFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/Alias.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/Alias.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/CoreWrapper.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/CoreWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/Thing.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/Thing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/Trait.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/Trait.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitConstants.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitFactory.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitField.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitFieldTMS.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitFieldTMS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitType.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitTypeEnum.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitTypeEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitTypeMap.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitTypeMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitTypeMapConstants.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitTypeMapConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/Traitable.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/Traitable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitableBean.java
+++ b/drools-base/src/main/java/org/drools/base/factmodel/traits/TraitableBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/phreak/Reactive.java
+++ b/drools-base/src/main/java/org/drools/base/phreak/Reactive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/phreak/ReactiveObject.java
+++ b/drools-base/src/main/java/org/drools/base/phreak/ReactiveObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/prototype/PrototypeFieldExtractor.java
+++ b/drools-base/src/main/java/org/drools/base/prototype/PrototypeFieldExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/prototype/PrototypeObjectType.java
+++ b/drools-base/src/main/java/org/drools/base/prototype/PrototypeObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/reteoo/AccumulateContextEntry.java
+++ b/drools-base/src/main/java/org/drools/base/reteoo/AccumulateContextEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/reteoo/BaseTerminalNode.java
+++ b/drools-base/src/main/java/org/drools/base/reteoo/BaseTerminalNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/reteoo/BaseTuple.java
+++ b/drools-base/src/main/java/org/drools/base/reteoo/BaseTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/reteoo/InitialFactImpl.java
+++ b/drools-base/src/main/java/org/drools/base/reteoo/InitialFactImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/reteoo/NodeTypeEnums.java
+++ b/drools-base/src/main/java/org/drools/base/reteoo/NodeTypeEnums.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/reteoo/PropertySpecificUtil.java
+++ b/drools-base/src/main/java/org/drools/base/reteoo/PropertySpecificUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/reteoo/SortDeclarations.java
+++ b/drools-base/src/main/java/org/drools/base/reteoo/SortDeclarations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/Accumulate.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Accumulate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/Annotated.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Annotated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/AsyncReceive.java
+++ b/drools-base/src/main/java/org/drools/base/rule/AsyncReceive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/AsyncSend.java
+++ b/drools-base/src/main/java/org/drools/base/rule/AsyncSend.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/Behavior.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Behavior.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/Collect.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Collect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/ConditionalBranch.java
+++ b/drools-base/src/main/java/org/drools/base/rule/ConditionalBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/ConditionalElement.java
+++ b/drools-base/src/main/java/org/drools/base/rule/ConditionalElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/ConsequenceMetaData.java
+++ b/drools-base/src/main/java/org/drools/base/rule/ConsequenceMetaData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/ContextEntry.java
+++ b/drools-base/src/main/java/org/drools/base/rule/ContextEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/Declaration.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Declaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/DialectRuntimeData.java
+++ b/drools-base/src/main/java/org/drools/base/rule/DialectRuntimeData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/DialectRuntimeRegistry.java
+++ b/drools-base/src/main/java/org/drools/base/rule/DialectRuntimeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/Dialectable.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Dialectable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/DuplicateRuleNameException.java
+++ b/drools-base/src/main/java/org/drools/base/rule/DuplicateRuleNameException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/EntryPointId.java
+++ b/drools-base/src/main/java/org/drools/base/rule/EntryPointId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/EvalCondition.java
+++ b/drools-base/src/main/java/org/drools/base/rule/EvalCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/EvalConditionFactory.java
+++ b/drools-base/src/main/java/org/drools/base/rule/EvalConditionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/EvalConditionFactoryImpl.java
+++ b/drools-base/src/main/java/org/drools/base/rule/EvalConditionFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/Forall.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Forall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/From.java
+++ b/drools-base/src/main/java/org/drools/base/rule/From.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/Function.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Function.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/GroupElement.java
+++ b/drools-base/src/main/java/org/drools/base/rule/GroupElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/GroupElementFactory.java
+++ b/drools-base/src/main/java/org/drools/base/rule/GroupElementFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/ImportDeclaration.java
+++ b/drools-base/src/main/java/org/drools/base/rule/ImportDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/IndexableConstraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/IndexableConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/IntervalProviderConstraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/IntervalProviderConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/InvalidPatternException.java
+++ b/drools-base/src/main/java/org/drools/base/rule/InvalidPatternException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/InvalidRuleException.java
+++ b/drools-base/src/main/java/org/drools/base/rule/InvalidRuleException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/InvalidRulePackage.java
+++ b/drools-base/src/main/java/org/drools/base/rule/InvalidRulePackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/KieModuleMetaInfo.java
+++ b/drools-base/src/main/java/org/drools/base/rule/KieModuleMetaInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/LineMappings.java
+++ b/drools-base/src/main/java/org/drools/base/rule/LineMappings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/LogicTransformer.java
+++ b/drools-base/src/main/java/org/drools/base/rule/LogicTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/MapBackedClassLoader.java
+++ b/drools-base/src/main/java/org/drools/base/rule/MapBackedClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/MultiAccumulate.java
+++ b/drools-base/src/main/java/org/drools/base/rule/MultiAccumulate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/MutableTypeConstraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/MutableTypeConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/NamedConsequence.java
+++ b/drools-base/src/main/java/org/drools/base/rule/NamedConsequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/NamedConsequenceInvoker.java
+++ b/drools-base/src/main/java/org/drools/base/rule/NamedConsequenceInvoker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/NoConsequenceException.java
+++ b/drools-base/src/main/java/org/drools/base/rule/NoConsequenceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/Pattern.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/PatternSource.java
+++ b/drools-base/src/main/java/org/drools/base/rule/PatternSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/QueryArgument.java
+++ b/drools-base/src/main/java/org/drools/base/rule/QueryArgument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/QueryElement.java
+++ b/drools-base/src/main/java/org/drools/base/rule/QueryElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/RuleComponent.java
+++ b/drools-base/src/main/java/org/drools/base/rule/RuleComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/RuleConditionElement.java
+++ b/drools-base/src/main/java/org/drools/base/rule/RuleConditionElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/RuleConstructionException.java
+++ b/drools-base/src/main/java/org/drools/base/rule/RuleConstructionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/SingleAccumulate.java
+++ b/drools-base/src/main/java/org/drools/base/rule/SingleAccumulate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/TypeDeclaration.java
+++ b/drools-base/src/main/java/org/drools/base/rule/TypeDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/TypeMetaInfo.java
+++ b/drools-base/src/main/java/org/drools/base/rule/TypeMetaInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/WindowDeclaration.java
+++ b/drools-base/src/main/java/org/drools/base/rule/WindowDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/WindowReference.java
+++ b/drools-base/src/main/java/org/drools/base/rule/WindowReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/XpathBackReference.java
+++ b/drools-base/src/main/java/org/drools/base/rule/XpathBackReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/AcceptsReadAccessor.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/AcceptsReadAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/Accumulator.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/Accumulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/CompiledInvoker.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/CompiledInvoker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/DataProvider.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/DataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/DeclarationScopeResolver.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/DeclarationScopeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/Enabled.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/Enabled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/EvalExpression.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/EvalExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/Evaluator.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/Evaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/FieldValue.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/FieldValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/GlobalExtractor.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/GlobalExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/GlobalResolver.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/GlobalResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/Invoker.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/Invoker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/PatternExtractor.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/PatternExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/ReadAccessor.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/ReadAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/ReturnValueExpression.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/ReturnValueExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/RightTupleValueExtractor.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/RightTupleValueExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/Salience.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/Salience.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/TupleValueExtractor.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/TupleValueExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/Wireable.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/Wireable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/accessor/WriteAccessor.java
+++ b/drools-base/src/main/java/org/drools/base/rule/accessor/WriteAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/consequence/ConflictResolver.java
+++ b/drools-base/src/main/java/org/drools/base/rule/consequence/ConflictResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/consequence/Consequence.java
+++ b/drools-base/src/main/java/org/drools/base/rule/consequence/Consequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/consequence/ConsequenceContext.java
+++ b/drools-base/src/main/java/org/drools/base/rule/consequence/ConsequenceContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/consequence/ConsequenceException.java
+++ b/drools-base/src/main/java/org/drools/base/rule/consequence/ConsequenceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/constraint/AlphaNodeFieldConstraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/constraint/AlphaNodeFieldConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/constraint/BetaConstraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/constraint/BetaConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/constraint/Constraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/constraint/Constraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/constraint/NegConstraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/constraint/NegConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/constraint/QueryNameConstraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/constraint/QueryNameConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/constraint/XpathConstraint.java
+++ b/drools-base/src/main/java/org/drools/base/rule/constraint/XpathConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/rule/package-info.java
+++ b/drools-base/src/main/java/org/drools/base/rule/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/ruleunit/RuleUnitDescriptionLoader.java
+++ b/drools-base/src/main/java/org/drools/base/ruleunit/RuleUnitDescriptionLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/ruleunit/RuleUnitDescriptionRegistry.java
+++ b/drools-base/src/main/java/org/drools/base/ruleunit/RuleUnitDescriptionRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/time/Interval.java
+++ b/drools-base/src/main/java/org/drools/base/time/Interval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/time/JobHandle.java
+++ b/drools-base/src/main/java/org/drools/base/time/JobHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/time/TimeUtils.java
+++ b/drools-base/src/main/java/org/drools/base/time/TimeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/time/Trigger.java
+++ b/drools-base/src/main/java/org/drools/base/time/Trigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/time/impl/Timer.java
+++ b/drools-base/src/main/java/org/drools/base/time/impl/Timer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/util/CloneUtil.java
+++ b/drools-base/src/main/java/org/drools/base/util/CloneUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/util/Drools.java
+++ b/drools-base/src/main/java/org/drools/base/util/Drools.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/util/IndexedValueReader.java
+++ b/drools-base/src/main/java/org/drools/base/util/IndexedValueReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/util/MVELExecutor.java
+++ b/drools-base/src/main/java/org/drools/base/util/MVELExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/util/PropertyReactivityUtil.java
+++ b/drools-base/src/main/java/org/drools/base/util/PropertyReactivityUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/util/TimeIntervalParser.java
+++ b/drools-base/src/main/java/org/drools/base/util/TimeIntervalParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/util/index/ConstraintTypeOperator.java
+++ b/drools-base/src/main/java/org/drools/base/util/index/ConstraintTypeOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-base/src/main/java/org/drools/base/util/index/IndexUtil.java
+++ b/drools-base/src/main/java/org/drools/base/util/index/IndexUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesAbsorption.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesAbsorption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesBeliefSystem.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesBeliefSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesFact.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesHardEvidence.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesHardEvidence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesInstance.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesInstanceManager.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesInstanceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesLikelyhood.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesLikelyhood.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesModeFactory.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesModeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesModeFactoryImpl.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesModeFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesNetwork.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesNetwork.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesProjection.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesProjection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesVariable.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesVariableConstructor.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesVariableConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesVariableState.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/BayesVariableState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/CliqueBitSet.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/CliqueBitSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/CliqueState.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/CliqueState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/EliminationCandidate.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/EliminationCandidate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/GlobalUpdateListener.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/GlobalUpdateListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/JunctionTree.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/JunctionTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/JunctionTreeBuilder.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/JunctionTreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/JunctionTreeClique.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/JunctionTreeClique.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/JunctionTreeSeparator.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/JunctionTreeSeparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/Marginalizer.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/Marginalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/NonConflictingModeSet.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/NonConflictingModeSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/PassMessageListener.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/PassMessageListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/PotentialMultiplier.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/PotentialMultiplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/PropertyReference.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/PropertyReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/SeparatorSet.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/SeparatorSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/SeparatorState.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/SeparatorState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/VarName.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/VarName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/BayesAssemblerService.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/BayesAssemblerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/BayesNetworkAssemblerError.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/BayesNetworkAssemblerError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/BayesPackage.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/BayesPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/JunctionTreeProcessor.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/assembler/JunctionTreeProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Bif.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Bif.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Definition.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Definition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Network.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Network.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Probability.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Probability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Variable.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/Variable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/VariableXml.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/VariableXml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/XmlBifParser.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/model/XmlBifParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntime.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntimeImpl.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntimeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntimeService.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntimeService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/weaver/BayesWeaverService.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/weaver/BayesWeaverService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/Direction.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/Direction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/Edge.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/Edge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/Graph.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/Graph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/GraphNode.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/GraphNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/EdgeImpl.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/EdgeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/GraphImpl.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/GraphImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/GraphNodeImpl.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/GraphNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/GraphStore.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/GraphStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/ListGraphStore.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/ListGraphStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/MapGraphStore.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/graph/impl/MapGraphStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/BayesAbsorbtionTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/BayesAbsorbtionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/BayesProjectionTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/BayesProjectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/GlobalUpdateTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/GlobalUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/GraphTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/GraphTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/JunctionTreeBuilderTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/JunctionTreeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/JunctionTreeTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/JunctionTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/MarginalizerTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/MarginalizerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/PassMessageTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/PassMessageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/example/EarthQuakeTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/example/EarthQuakeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/example/SprinkerTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/example/SprinkerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/AssemblerTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/AssemblerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/BayesBeliefSystemTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/BayesBeliefSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/BayesRuntimeTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/BayesRuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/Garden.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/Garden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/ParserTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/WeaverTest.java
+++ b/drools-beliefs/src/test/java/org/drools/beliefs/bayes/integration/WeaverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/AbstractNewKieContainerCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/AbstractNewKieContainerCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/ChainableRunner.java
+++ b/drools-commands/src/main/java/org/drools/commands/ChainableRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/ConversationContextManager.java
+++ b/drools-commands/src/main/java/org/drools/commands/ConversationContextManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/EndConversationCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/EndConversationCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/EntryPointCreator.java
+++ b/drools-commands/src/main/java/org/drools/commands/EntryPointCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/ExecuteCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/ExecuteCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/FinishedCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/FinishedCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/GetKieContainerCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/GetKieContainerCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/GetSessionClockCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/GetSessionClockCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/GetVariableCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/GetVariableCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/IdentifiableResult.java
+++ b/drools-commands/src/main/java/org/drools/commands/IdentifiableResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/InternalLocalRunner.java
+++ b/drools-commands/src/main/java/org/drools/commands/InternalLocalRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/JoinConversationCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/JoinConversationCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/NewKieSessionCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/NewKieSessionCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/NewKnowledgeBuilderConfigurationCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/NewKnowledgeBuilderConfigurationCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/OutCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/OutCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/RequestContextImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/RequestContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/SetActiveAgendaGroup.java
+++ b/drools-commands/src/main/java/org/drools/commands/SetActiveAgendaGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/SetKieContainerCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/SetKieContainerCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/SetVariableCommandFromCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/SetVariableCommandFromCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/SingleSessionCommandService.java
+++ b/drools-commands/src/main/java/org/drools/commands/SingleSessionCommandService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/StartConversationCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/StartConversationCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/BaseBatchFluent.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/BaseBatchFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/BaseBatchWithProcessFluent.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/BaseBatchWithProcessFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/Batch.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/Batch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/BatchImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/BatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/CommandRegister.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/CommandRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/ExecutableBuilderImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/ExecutableBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/ExecutableImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/ExecutableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/FluentComponentFactory.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/FluentComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/GetCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/GetCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/GetContextCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/GetContextCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/InternalExecutable.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/InternalExecutable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/KieContainerFluentImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/KieContainerFluentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/KieSessionFluentImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/KieSessionFluentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/NewContextCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/NewContextCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/PseudoClockRunner.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/PseudoClockRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/SetCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/SetCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/fluent/SetVarAsRegistryEntry.java
+++ b/drools-commands/src/main/java/org/drools/commands/fluent/SetVarAsRegistryEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/AbstractInterceptor.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/AbstractInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/AsynchronousInterceptor.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/AsynchronousInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/CommandBasedEntryPoint.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/CommandBasedEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/CommandBasedStatefulKnowledgeSessionImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/CommandBasedStatefulKnowledgeSessionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/CommandFactoryServiceImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/CommandFactoryServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/ContextImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/ContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/ContextImplWithEviction.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/ContextImplWithEviction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/ContextManagerImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/ContextManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/ExecutableCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/ExecutableCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/FireAllRulesInterceptor.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/FireAllRulesInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/FluentCommandFactoryServiceImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/FluentCommandFactoryServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/LoggingInterceptor.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/LoggingInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/impl/NotTransactionalCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/impl/NotTransactionalCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbListAdapter.java
+++ b/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbListAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbListWrapper.java
+++ b/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbListWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbMapAdapter.java
+++ b/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbMapAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbObjectObjectPair.java
+++ b/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbObjectObjectPair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbStringObjectPair.java
+++ b/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbStringObjectPair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbUnknownAdapter.java
+++ b/drools-commands/src/main/java/org/drools/commands/jaxb/JaxbUnknownAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/jaxb/ObjectFactory.java
+++ b/drools-commands/src/main/java/org/drools/commands/jaxb/ObjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/AddEventListenerCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/AddEventListenerCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/AdvanceSessionTimeCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/AdvanceSessionTimeCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/BatchExecutionCommandImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/BatchExecutionCommandImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/DestroySessionCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/DestroySessionCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/DisposeCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/DisposeCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/ExecutionResultImpl.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/ExecutionResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/ExecutionResultsMap.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/ExecutionResultsMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/FlatQueryResults.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/FlatQueryResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetCalendarsCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetCalendarsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetChannelsCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetChannelsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetEnvironmentCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetEnvironmentCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetFactCountCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetFactCountCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetFactCountInEntryPointCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetFactCountInEntryPointCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetGlobalCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetGlobalCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetGlobalsCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetGlobalsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetIdCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetIdCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetKieBaseCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetKieBaseCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/GetSessionTimeCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/GetSessionTimeCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/KBuilderSetPropertyCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/KBuilderSetPropertyCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/ObjectFactory.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/ObjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/QueryResultsJaxbAdapter.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/QueryResultsJaxbAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/RegisterChannelCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/RegisterChannelCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/RemoveEventListenerCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/RemoveEventListenerCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/SetGlobalCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/SetGlobalCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/UnregisterChannelCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/UnregisterChannelCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/pmml/ApplyPmmlModelCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/pmml/ApplyPmmlModelCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/pmml/PmmlConstants.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/pmml/PmmlConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/AbortProcessInstanceCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/AbortProcessInstanceCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/AbortWorkItemCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/AbortWorkItemCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/CompleteWorkItemCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/CompleteWorkItemCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/CreateCorrelatedProcessInstanceCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/CreateCorrelatedProcessInstanceCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/CreateProcessInstanceCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/CreateProcessInstanceCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessEventListenersCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessEventListenersCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessIdsCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessIdsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessInstanceByCorrelationKeyCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessInstanceByCorrelationKeyCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessInstanceCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessInstanceCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessInstancesCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/GetProcessInstancesCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/GetWorkItemCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/GetWorkItemCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/GetWorkItemIdsCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/GetWorkItemIdsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/ObjectFactory.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/ObjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/ReTryWorkItemCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/ReTryWorkItemCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/RegisterWorkItemHandlerCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/RegisterWorkItemHandlerCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/SetProcessInstanceVariablesCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/SetProcessInstanceVariablesCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/SignalEventCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/SignalEventCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/StartCorrelatedProcessCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/StartCorrelatedProcessCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/StartProcessCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/StartProcessCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/StartProcessFromNodeIdsCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/StartProcessFromNodeIdsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/process/StartProcessInstanceCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/process/StartProcessInstanceCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/AgendaGroupSetFocusCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/AgendaGroupSetFocusCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/ClearActivationGroupCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/ClearActivationGroupCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/ClearAgendaCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/ClearAgendaCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/ClearAgendaGroupCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/ClearAgendaGroupCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/ClearRuleFlowGroupCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/ClearRuleFlowGroupCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/DeleteCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/DeleteCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/DeleteFromEntryPointCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/DeleteFromEntryPointCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/DeleteObjectCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/DeleteObjectCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/EnableAuditLogCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/EnableAuditLogCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/FireAllRulesCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/FireAllRulesCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/FromExternalFactHandleCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/FromExternalFactHandleCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetAgendaEventListenersCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetAgendaEventListenersCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetEntryPointCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetEntryPointCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetEntryPointsCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetEntryPointsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetFactHandleCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetFactHandleCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetFactHandleInEntryPointCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetFactHandleInEntryPointCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetFactHandlesCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetFactHandlesCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetFactHandlesInEntryPointCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetFactHandlesInEntryPointCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetObjectCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetObjectCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetObjectInEntryPointCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetObjectInEntryPointCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetObjectsCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetObjectsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetObjectsInEntryPointCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetObjectsInEntryPointCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetRuleRuntimeEventListenersCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/GetRuleRuntimeEventListenersCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/HaltCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/HaltCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/InsertElementsCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/InsertElementsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/InsertObjectCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/InsertObjectCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/InsertObjectInEntryPointCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/InsertObjectInEntryPointCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/ModifyCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/ModifyCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/ObjectFactory.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/ObjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/QueryCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/QueryCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/UpdateCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/UpdateCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/main/java/org/drools/commands/runtime/rule/UpdateInEntryPointCommand.java
+++ b/drools-commands/src/main/java/org/drools/commands/runtime/rule/UpdateInEntryPointCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/test/java/org/drools/commands/DeleteCommandTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/DeleteCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/test/java/org/drools/commands/ExecuteCommandDisconnectedTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/ExecuteCommandDisconnectedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/test/java/org/drools/commands/FromExternalFactHandleCommandTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/FromExternalFactHandleCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/test/java/org/drools/commands/GetFactHandlesCommandTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/GetFactHandlesCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-commands/src/test/java/org/drools/commands/InternalExecutableTest.java
+++ b/drools-commands/src/test/java/org/drools/commands/InternalExecutableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/AbstractAssemblerService.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/AbstractAssemblerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/AbstractResourceProcessor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/AbstractResourceProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/DroolsAssemblerContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/DroolsAssemblerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/InternalKnowledgeBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/InternalKnowledgeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/PackageRegistryManager.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/PackageRegistryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/ResourceProcessor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/ResourceProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/conf/DecisionTableConfigurationImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/conf/DecisionTableConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/conf/JaxbConfigurationImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/conf/JaxbConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/AssetFilter.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/AssetFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuildResultCollector.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuildResultCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuildResultCollectorImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuildResultCollectorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuilderConfigurationProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/BuilderConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ClassDefinitionFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ClassDefinitionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ClassHierarchyManager.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ClassHierarchyManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeBuilderConfiguration.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeBuilderConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/DeclaredClassBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/DeclaredClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/DefaultTypeDeclarationBuilderFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/DefaultTypeDeclarationBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/DroolsAssemblerContextImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/DroolsAssemblerContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/EvaluatorRegistry.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/EvaluatorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/GlobalVariableContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/GlobalVariableContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/GlobalVariableContextImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/GlobalVariableContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/HierarchySorter.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/HierarchySorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/InternalKnowledgeBaseProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/InternalKnowledgeBaseProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/JaxbConfigurationFactoryServiceImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/JaxbConfigurationFactoryServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderConfigurationFactories.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderConfigurationFactories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderConfigurationImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderFactoryServiceImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderFactoryServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderFlowConfigurationImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderFlowConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderRulesConfigurationImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderRulesConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeTypeManager.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeTypeManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageAttributeManagerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageAttributeManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageDescrBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageDescrManager.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageDescrManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageRegistryCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageRegistryCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageRegistryManagerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/PackageRegistryManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ResourceBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ResourceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ResourceHandlerManager.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ResourceHandlerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/RootClassLoaderProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/RootClassLoaderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationBuilderFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationCache.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationConfigurator.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationConfigurator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContextImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationManager.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationManagerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationNameResolver.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationNameResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationUtils.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDefinition.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/BeanClassBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/BeanClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/BuildUtils.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/BuildUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/ClassBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/ClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/ClassBuilderFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/ClassBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/EnumClassBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/EnumClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/EnumClassDefinition.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/EnumClassDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/EnumLiteralDefinition.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/classbuilder/EnumLiteralDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/ErrorHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/ErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/FunctionErrorHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/FunctionErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/MissingImplementationException.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/MissingImplementationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/RuleErrorHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/RuleErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/RuleInvokerErrorHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/RuleInvokerErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/SrcError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/SrcError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/SrcErrorHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/errors/SrcErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/AbstractPackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/AbstractPackageCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/AccumulateFunctionCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/AccumulateFunctionCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/AnnotationNormalizer.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/AnnotationNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/CompositePackageCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ConsequenceCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ConsequenceCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/EntryPointDeclarationCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/EntryPointDeclarationCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/FunctionCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/GlobalCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableFunctionCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableFunctionCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableGlobalCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableGlobalCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableRuleCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImmutableRuleCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImportCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ImportCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/IteratingPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/IteratingPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/OtherDeclarationCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/OtherDeclarationCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/PackageCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/PackageCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ReteCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/ReteCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleAnnotationNormalizer.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleAnnotationNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleValidator.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/RuleValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/SinglePackagePhaseFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/SinglePackagePhaseFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/TypeDeclarationAnnotationNormalizer.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/TypeDeclarationAnnotationNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/TypeDeclarationCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/TypeDeclarationCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/TypeDeclarationCompositeCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/TypeDeclarationCompositeCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/WindowDeclarationCompilationPhase.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/WindowDeclarationCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/package-info.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/processors/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/DecisionTableResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/DecisionTableResourceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/DrlResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/DrlResourceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/DslrResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/DslrResourceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/ResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/ResourceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/TemplateResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/TemplateResourceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/YamlResourceHandler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/resources/YamlResourceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ActionError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ActionError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/AnalysisResult.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/AnalysisResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/AnnotationDeclarationError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/AnnotationDeclarationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/BoundIdentifiers.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/BoundIdentifiers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/BuilderResultUtils.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/BuilderResultUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ConfigurableSeverityResult.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ConfigurableSeverityResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DeprecatedResourceTypeWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DeprecatedResourceTypeWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/Dialect.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/Dialect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DialectCompiletimeRegistry.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DialectCompiletimeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DialectConfiguration.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DialectConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsErrorWrapper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsErrorWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsWarningWrapper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DroolsWarningWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DuplicateFunction.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DuplicateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DuplicateRule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DuplicateRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/FunctionError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/FunctionError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/GlobalError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/GlobalError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ImportError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ImportError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/JavaDialectConfiguration.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/JavaDialectConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/MissingDependencyError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/MissingDependencyError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/PackageBuilderErrors.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/PackageBuilderErrors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/PackageBuilderResults.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/PackageBuilderResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/PackageRegistry.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/PackageRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessBuilderFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessBuilderFactoryService.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessBuilderFactoryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessLoadError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessLoadError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ProjectJavaCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ProjectJavaCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ResourceTypeDeclarationWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ResourceTypeDeclarationWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/RuleBuildError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/RuleBuildError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/RuleBuildWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/RuleBuildWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/SerializableDroolsError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/SerializableDroolsError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/TypeDeclarationError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/TypeDeclarationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/TypeDeclarationWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/TypeDeclarationWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/File.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/File.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/FileSystem.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/FileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/FileSystemItem.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/FileSystemItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/Folder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/Folder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFile.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFolder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/package-info.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/MaterializedLambda.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/MaterializedLambda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieScanner.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/BuildContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/BuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/CompilationCacheProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/CompilationCacheProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/CompilationProblemAdapter.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/CompilationProblemAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/DecisionTableConfigurationDelegate.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/DecisionTableConfigurationDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/DiskResourceReader.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/DiskResourceReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/DrlProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/DrlProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/IncrementalResultsImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/IncrementalResultsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModuleProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModuleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieScanner.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieServices.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdater.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaterFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaterImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaterImplContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaterImplContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaterOptions.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaterOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaters.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdaters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdatersContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdatersContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdatersImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBaseUpdatersImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerSessionsPoolImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerSessionsPoolImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieFileSystemImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieFileSystemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieFileSystemScannerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieFileSystemScannerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieMetaInfoBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieMetaInfoBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieModuleKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieModuleKieProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KnowledgePackagesBuildResult.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KnowledgePackagesBuildResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/MemoryKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/MemoryKieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ResultsImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ResultsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ZipKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ZipKieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/AbstractKieServicesEventListerner.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/AbstractKieServicesEventListerner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieModuleDiscovered.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieModuleDiscovered.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieScannerEventSupport.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieScannerEventSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieScannerStatusChangeEventImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieScannerStatusChangeEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieScannerUpdateResultsEventImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieScannerUpdateResultsEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieServicesEventListerner.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/event/KieServicesEventListerner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/util/BeanCreator.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/util/BeanCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/util/ChangeSetBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/util/ChangeSetBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/util/InjectionHelper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/util/InjectionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/util/KieJarChangeSet.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/util/KieJarChangeSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/util/ReflectionBeanCreator.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/util/ReflectionBeanCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/KieModuleException.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/KieModuleException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/ChannelModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/ChannelModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/FileLoggerModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/FileLoggerModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieBaseModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieBaseModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieModuleModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieModuleModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieSessionModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieSessionModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/ListenerModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/ListenerModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/QualifierModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/QualifierModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/RuleTemplateModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/RuleTemplateModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/WorkItemHandlerModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/WorkItemHandlerModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/DescrDumper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/DescrDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/DumperContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/DumperContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/ExpressionRewriter.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/ExpressionRewriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/ReflectiveVisitor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/ReflectiveVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/Visitor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/Visitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/CompositePackageDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/CompositePackageDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/management/KieContainerMonitor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/management/KieContainerMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/AccumulateBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/AccumulateBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/CollectBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/CollectBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/ConditionalBranchBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/ConditionalBranchBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/ConsequenceBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/ConsequenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/ConstraintBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/ConstraintBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EnabledBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EnabledBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EngineElementBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EngineElementBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EntryPointBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EntryPointBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EvaluatorDefinition.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EvaluatorWrapper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/EvaluatorWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/ForallBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/ForallBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/FromBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/FromBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/FunctionBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/FunctionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/GroupByBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/GroupByBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/GroupElementBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/GroupElementBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/JavaRuleClassBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/JavaRuleClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/NamedConsequenceBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/NamedConsequenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PackageBuildContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PackageBuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilderForAbductiveQuery.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilderForAbductiveQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilderForQuery.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilderForQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/QueryElementBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/QueryElementBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/RuleBuildContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/RuleBuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/RuleBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/RuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/RuleClassBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/RuleClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/RuleConditionBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/RuleConditionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/SalienceBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/SalienceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/WindowReferenceBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/WindowReferenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectUtil.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/AbstractJavaBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/AbstractJavaBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/AbstractJavaContainerBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/AbstractJavaContainerBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaCatchBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaCatchBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaContainerBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaContainerBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaElseBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaElseBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaExitPointsDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaExitPointsDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaFinalBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaFinalBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaForBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaForBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaIfBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaIfBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaInterfacePointsDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaInterfacePointsDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaLexer.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaLocalDeclarationDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaLocalDeclarationDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaModifyBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaModifyBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaParser.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaRootBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaRootBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaStatementBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaStatementBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaThrowBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaThrowBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaTryBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaTryBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaWhileBlockDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/parser/JavaWhileBlockDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/AccumulateUtil.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/AccumulateUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/AnnotationFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/AnnotationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/ConstraintUtil.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/ConstraintUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/PackageBuilderUtil.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/PackageBuilderUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/PatternBuilderUtil.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/PatternBuilderUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/runtime/pipeline/impl/DroolsJaxbHelperProviderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/runtime/pipeline/impl/DroolsJaxbHelperProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/testframework/RuleCoverageListener.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/testframework/RuleCoverageListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/main/java/org/drools/compiler/testframework/TestingEventListener.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/testframework/TestingEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/acme/healthcare/Claim.java
+++ b/drools-compiler/src/test/java/org/acme/healthcare/Claim.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/acme/healthcare/Exception.java
+++ b/drools-compiler/src/test/java/org/acme/healthcare/Exception.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/acme/insurance/Approve.java
+++ b/drools-compiler/src/test/java/org/acme/insurance/Approve.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/acme/insurance/Driver.java
+++ b/drools-compiler/src/test/java/org/acme/insurance/Driver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/acme/insurance/Policy.java
+++ b/drools-compiler/src/test/java/org/acme/insurance/Policy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/acme/insurance/Rejection.java
+++ b/drools-compiler/src/test/java/org/acme/insurance/Rejection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/acme/sensors/SensorReading.java
+++ b/drools-compiler/src/test/java/org/acme/sensors/SensorReading.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/drools/compiler/CompilerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/CompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/drools/compiler/builder/impl/KnowledgeBuilderImplCompilerFJPoolTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/builder/impl/KnowledgeBuilderImplCompilerFJPoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/drools/compiler/lang/descr/CompositePackageDescrTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/lang/descr/CompositePackageDescrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-compiler/src/test/java/org/drools/compiler/lang/descr/PackageDescrTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/lang/descr/PackageDescrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/ActivationListenerFactory.java
+++ b/drools-core/src/main/java/org/drools/core/ActivationListenerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/BaseConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/BaseConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/BaseConfigurationFactories.java
+++ b/drools-core/src/main/java/org/drools/core/BaseConfigurationFactories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/BeliefSystemType.java
+++ b/drools-core/src/main/java/org/drools/core/BeliefSystemType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/ClassObjectSerializationFilter.java
+++ b/drools-core/src/main/java/org/drools/core/ClassObjectSerializationFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/ClockType.java
+++ b/drools-core/src/main/java/org/drools/core/ClockType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/CompositeSessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/CompositeSessionConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/EntryPointsManager.java
+++ b/drools-core/src/main/java/org/drools/core/EntryPointsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/FlowBaseConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/FlowBaseConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/FlowSessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/FlowSessionConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/KieBaseConfigurationImpl.java
+++ b/drools-core/src/main/java/org/drools/core/KieBaseConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/QueryActivationListenerFactory.java
+++ b/drools-core/src/main/java/org/drools/core/QueryActivationListenerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/QueryResultsImpl.java
+++ b/drools-core/src/main/java/org/drools/core/QueryResultsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/QueryResultsRowImpl.java
+++ b/drools-core/src/main/java/org/drools/core/QueryResultsRowImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/RuleActivationListenerFactory.java
+++ b/drools-core/src/main/java/org/drools/core/RuleActivationListenerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleSessionConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/SessionConfigurationFactories.java
+++ b/drools-core/src/main/java/org/drools/core/SessionConfigurationFactories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/TimerJobFactoryType.java
+++ b/drools-core/src/main/java/org/drools/core/TimerJobFactoryType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/WorkItemHandlerNotFoundException.java
+++ b/drools-core/src/main/java/org/drools/core/WorkItemHandlerNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/WorkingMemory.java
+++ b/drools-core/src/main/java/org/drools/core/WorkingMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/WorkingMemoryEntryPoint.java
+++ b/drools-core/src/main/java/org/drools/core/WorkingMemoryEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/WorkingMemoryEventManager.java
+++ b/drools-core/src/main/java/org/drools/core/WorkingMemoryEventManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/AbstractQueryViewListener.java
+++ b/drools-core/src/main/java/org/drools/core/base/AbstractQueryViewListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/ArrayElements.java
+++ b/drools-core/src/main/java/org/drools/core/base/ArrayElements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/BaseClassFieldWriter.java
+++ b/drools-core/src/main/java/org/drools/core/base/BaseClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/CalendarsImpl.java
+++ b/drools-core/src/main/java/org/drools/core/base/CalendarsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/ClassFieldAccessorCache.java
+++ b/drools-core/src/main/java/org/drools/core/base/ClassFieldAccessorCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/DroolsQueryImpl.java
+++ b/drools-core/src/main/java/org/drools/core/base/DroolsQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/FieldAccessorFactory.java
+++ b/drools-core/src/main/java/org/drools/core/base/FieldAccessorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/FieldNameSupplier.java
+++ b/drools-core/src/main/java/org/drools/core/base/FieldNameSupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/InternalViewChangedEventListener.java
+++ b/drools-core/src/main/java/org/drools/core/base/InternalViewChangedEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/MapGlobalResolver.java
+++ b/drools-core/src/main/java/org/drools/core/base/MapGlobalResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/NonCloningQueryViewListener.java
+++ b/drools-core/src/main/java/org/drools/core/base/NonCloningQueryViewListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/QueryRowWithSubruleIndex.java
+++ b/drools-core/src/main/java/org/drools/core/base/QueryRowWithSubruleIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/RuleNameEndsWithAgendaFilter.java
+++ b/drools-core/src/main/java/org/drools/core/base/RuleNameEndsWithAgendaFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/RuleNameEqualsAgendaFilter.java
+++ b/drools-core/src/main/java/org/drools/core/base/RuleNameEqualsAgendaFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/RuleNameMatchesAgendaFilter.java
+++ b/drools-core/src/main/java/org/drools/core/base/RuleNameMatchesAgendaFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/RuleNameStartsWithAgendaFilter.java
+++ b/drools-core/src/main/java/org/drools/core/base/RuleNameStartsWithAgendaFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/StandardQueryViewChangedEventListener.java
+++ b/drools-core/src/main/java/org/drools/core/base/StandardQueryViewChangedEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/TraitHelper.java
+++ b/drools-core/src/main/java/org/drools/core/base/TraitHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/UndefinedCalendarExcption.java
+++ b/drools-core/src/main/java/org/drools/core/base/UndefinedCalendarExcption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/AbstractAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/AbstractAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/AverageAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/AverageAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/BigDecimalAverageAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/BigDecimalAverageAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/BigDecimalMaxAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/BigDecimalMaxAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/BigDecimalMinAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/BigDecimalMinAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/BigDecimalSumAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/BigDecimalSumAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/BigIntegerMaxAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/BigIntegerMaxAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/BigIntegerMinAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/BigIntegerMinAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/BigIntegerSumAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/BigIntegerSumAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/CollectAccumulator.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/CollectAccumulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/CollectListAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/CollectListAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/CollectSetAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/CollectSetAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/CountAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/CountAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerMaxAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerMaxAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerMinAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerMinAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerSumAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerSumAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/JavaAccumulatorFunctionExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/JavaAccumulatorFunctionExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/LongMaxAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/LongMaxAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/LongMinAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/LongMinAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/LongSumAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/LongSumAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/MaxAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/MaxAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/MinAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/MinAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/NumericMaxAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/NumericMaxAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/NumericMinAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/NumericMinAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/StandardDeviationAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/StandardDeviationAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/SumAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/SumAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/VarianceAccumulateFunction.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/VarianceAccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/base/extractors/ConstantValueReader.java
+++ b/drools-core/src/main/java/org/drools/core/base/extractors/ConstantValueReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/AbstractFactHandleFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/AbstractFactHandleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ActivationGroupImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/ActivationGroupImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ActivationGroupNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/ActivationGroupNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ActivationNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/ActivationNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ActivationsFilter.java
+++ b/drools-core/src/main/java/org/drools/core/common/ActivationsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ActivationsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/ActivationsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/AgendaFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/BaseNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/BaseNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/BetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/BetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ClassAwareObjectStore.java
+++ b/drools-core/src/main/java/org/drools/core/common/ClassAwareObjectStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
+++ b/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/DefaultBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/DefaultEventHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultEventHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/DefaultFactHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/DisconnectedFactHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/DisconnectedFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/DoubleBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/DoubleBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/DoubleNonIndexSkipBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/DoubleNonIndexSkipBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/EmptyBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/EmptyBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/EndOperationListener.java
+++ b/drools-core/src/main/java/org/drools/core/common/EndOperationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/EntryPointFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/EntryPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/EqualityKey.java
+++ b/drools-core/src/main/java/org/drools/core/common/EqualityKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/EventSupport.java
+++ b/drools-core/src/main/java/org/drools/core/common/EventSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/FactHandleClassStore.java
+++ b/drools-core/src/main/java/org/drools/core/common/FactHandleClassStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/IdentityObjectStore.java
+++ b/drools-core/src/main/java/org/drools/core/common/IdentityObjectStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/InternalActivationGroup.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalActivationGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/InternalAgenda.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalAgenda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/InternalAgendaGroup.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalAgendaGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/InternalFactHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/InternalKnowledgeRuntime.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalKnowledgeRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/InternalRuleFlowGroup.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalRuleFlowGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemoryActions.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemoryActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemoryEntryPoint.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemoryEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/MapObjectStore.java
+++ b/drools-core/src/main/java/org/drools/core/common/MapObjectStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/MapStorage.java
+++ b/drools-core/src/main/java/org/drools/core/common/MapStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/Memory.java
+++ b/drools-core/src/main/java/org/drools/core/common/Memory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/MemoryFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/MemoryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/MultipleBetaConstraint.java
+++ b/drools-core/src/main/java/org/drools/core/common/MultipleBetaConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/NodeMemories.java
+++ b/drools-core/src/main/java/org/drools/core/common/NodeMemories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ObjectFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/ObjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ObjectStore.java
+++ b/drools-core/src/main/java/org/drools/core/common/ObjectStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ObjectStoreWrapper.java
+++ b/drools-core/src/main/java/org/drools/core/common/ObjectStoreWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ObjectTypeConfigurationRegistry.java
+++ b/drools-core/src/main/java/org/drools/core/common/ObjectTypeConfigurationRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContext.java
+++ b/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContextFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContextFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/PriorityQueueAgendaGroupFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/PriorityQueueAgendaGroupFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/PropagationContext.java
+++ b/drools-core/src/main/java/org/drools/core/common/PropagationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/PropagationContextFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/PropagationContextFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/QuadroupleBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/QuadroupleBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/QuadroupleNonIndexSkipBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/QuadroupleNonIndexSkipBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/QueryElementFactHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/QueryElementFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/RuleFlowGroup.java
+++ b/drools-core/src/main/java/org/drools/core/common/RuleFlowGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/RuleFlowGroupListener.java
+++ b/drools-core/src/main/java/org/drools/core/common/RuleFlowGroupListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/SingleBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/SingleBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/SingleNonIndexSkipBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/SingleNonIndexSkipBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/Storage.java
+++ b/drools-core/src/main/java/org/drools/core/common/Storage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/SuperCacheFixer.java
+++ b/drools-core/src/main/java/org/drools/core/common/SuperCacheFixer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/TripleBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/TripleBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/TripleNonIndexSkipBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/TripleNonIndexSkipBetaConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/TruthMaintenanceSystem.java
+++ b/drools-core/src/main/java/org/drools/core/common/TruthMaintenanceSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/TruthMaintenanceSystemFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/TruthMaintenanceSystemFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/TupleSets.java
+++ b/drools-core/src/main/java/org/drools/core/common/TupleSets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/TupleSetsImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/TupleSetsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/TupleStartEqualsConstraint.java
+++ b/drools-core/src/main/java/org/drools/core/common/TupleStartEqualsConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/UpdateContext.java
+++ b/drools-core/src/main/java/org/drools/core/common/UpdateContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/common/WorkingMemoryAction.java
+++ b/drools-core/src/main/java/org/drools/core/common/WorkingMemoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/concurrent/AbstractGroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/AbstractGroupEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/concurrent/ExecutorProviderImpl.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/ExecutorProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/concurrent/GroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/GroupEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/concurrent/ParallelGroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/ParallelGroupEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/concurrent/SequentialGroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/SequentialGroupEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/conflict/MatchConflictResolver.java
+++ b/drools-core/src/main/java/org/drools/core/conflict/MatchConflictResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/conflict/RuleAgendaConflictResolver.java
+++ b/drools-core/src/main/java/org/drools/core/conflict/RuleAgendaConflictResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/AbstractEventSupport.java
+++ b/drools-core/src/main/java/org/drools/core/event/AbstractEventSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/ActivationCancelledEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/ActivationCancelledEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/ActivationCreatedEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/ActivationCreatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/ActivationEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/ActivationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/AfterActivationFiredEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/AfterActivationFiredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/AgendaEventSupport.java
+++ b/drools-core/src/main/java/org/drools/core/event/AgendaEventSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/AgendaGroupEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/AgendaGroupEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/AgendaGroupPoppedEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/AgendaGroupPoppedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/AgendaGroupPushedEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/AgendaGroupPushedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/BeforeActivationFiredEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/BeforeActivationFiredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/DebugAgendaEventListener.java
+++ b/drools-core/src/main/java/org/drools/core/event/DebugAgendaEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/DebugProcessEventListener.java
+++ b/drools-core/src/main/java/org/drools/core/event/DebugProcessEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/DebugRuleRuntimeEventListener.java
+++ b/drools-core/src/main/java/org/drools/core/event/DebugRuleRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/DefaultAgendaEventListener.java
+++ b/drools-core/src/main/java/org/drools/core/event/DefaultAgendaEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/DefaultProcessEventListener.java
+++ b/drools-core/src/main/java/org/drools/core/event/DefaultProcessEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/DefaultRuleRuntimeEventListener.java
+++ b/drools-core/src/main/java/org/drools/core/event/DefaultRuleRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/KnowledgeBaseEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/KnowledgeBaseEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/RuleEventListenerSupport.java
+++ b/drools-core/src/main/java/org/drools/core/event/RuleEventListenerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/RuleFlowGroupActivatedEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/RuleFlowGroupActivatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/RuleFlowGroupDeactivatedEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/RuleFlowGroupDeactivatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/RuleFlowGroupEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/RuleFlowGroupEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/RuleRuntimeEventSupport.java
+++ b/drools-core/src/main/java/org/drools/core/event/RuleRuntimeEventSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/WorkingMemoryEvent.java
+++ b/drools-core/src/main/java/org/drools/core/event/WorkingMemoryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterFunctionRemovedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterFunctionRemovedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterKiePackageAddedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterKiePackageAddedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterKiePackageRemovedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterKiePackageRemovedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterKnowledgeBaseLockedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterKnowledgeBaseLockedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterKnowledgeBaseUnlockedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterKnowledgeBaseUnlockedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterProcessAddedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterProcessAddedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterProcessRemovedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterProcessRemovedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterRuleAddedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterRuleAddedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterRuleRemovedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/AfterRuleRemovedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeFunctionRemovedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeFunctionRemovedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeKiePackageAddedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeKiePackageAddedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeKiePackageRemovedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeKiePackageRemovedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeKnowledgeBaseLockedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeKnowledgeBaseLockedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeKnowledgeBaseUnlockedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeKnowledgeBaseUnlockedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeProcessAddedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeProcessAddedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeProcessRemovedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeProcessRemovedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeRuleAddedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeRuleAddedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeRuleRemovedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/BeforeRuleRemovedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/KnowledgeBaseEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/knowlegebase/impl/KnowledgeBaseEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/package-info.java
+++ b/drools-core/src/main/java/org/drools/core/event/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/ActivationCancelledEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/ActivationCancelledEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/ActivationCreatedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/ActivationCreatedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/ActivationEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/ActivationEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/AfterActivationFiredEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/AfterActivationFiredEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/AgendaGroupEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/AgendaGroupEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/AgendaGroupPoppedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/AgendaGroupPoppedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/AgendaGroupPushedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/AgendaGroupPushedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/BeforeActivationFiredEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/BeforeActivationFiredEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/ObjectDeletedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/ObjectDeletedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/ObjectInsertedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/ObjectInsertedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/ObjectUpdatedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/ObjectUpdatedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/RuleFlowGroupActivatedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/RuleFlowGroupActivatedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/RuleFlowGroupDeactivatedEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/RuleFlowGroupDeactivatedEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/RuleFlowGroupEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/RuleFlowGroupEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/RuleRuntimeEventImpl.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/RuleRuntimeEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/SerializableActivation.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/SerializableActivation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/SerializableAgendaGroup.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/SerializableAgendaGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/event/rule/impl/SerializableRuleFlowGroup.java
+++ b/drools-core/src/main/java/org/drools/core/event/rule/impl/SerializableRuleFlowGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/AbstractRuntime.java
+++ b/drools-core/src/main/java/org/drools/core/impl/AbstractRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/EnvironmentFactory.java
+++ b/drools-core/src/main/java/org/drools/core/impl/EnvironmentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/EnvironmentImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/EnvironmentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/InternalKieContainer.java
+++ b/drools-core/src/main/java/org/drools/core/impl/InternalKieContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/InternalRuleBase.java
+++ b/drools-core/src/main/java/org/drools/core/impl/InternalRuleBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/KieBaseUpdate.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KieBaseUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/RuleBaseFactory.java
+++ b/drools-core/src/main/java/org/drools/core/impl/RuleBaseFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/impl/WorkingMemoryReteExpireAction.java
+++ b/drools-core/src/main/java/org/drools/core/impl/WorkingMemoryReteExpireAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
+++ b/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/management/GenericKieSessionMonitoringImpl.java
+++ b/drools-core/src/main/java/org/drools/core/management/GenericKieSessionMonitoringImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/management/KieBaseConfigurationMonitor.java
+++ b/drools-core/src/main/java/org/drools/core/management/KieBaseConfigurationMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/management/KnowledgeBaseMonitoring.java
+++ b/drools-core/src/main/java/org/drools/core/management/KnowledgeBaseMonitoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/management/ObjectTypeNodeMonitor.java
+++ b/drools-core/src/main/java/org/drools/core/management/ObjectTypeNodeMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/marshalling/ClassObjectMarshallingStrategyAcceptor.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/ClassObjectMarshallingStrategyAcceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/marshalling/MarshallerReaderContext.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/MarshallerReaderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/marshalling/MarshallerWriteContext.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/MarshallerWriteContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/marshalling/SerializablePlaceholderResolverStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/SerializablePlaceholderResolverStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/marshalling/TupleKey.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/TupleKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/package-info.java
+++ b/drools-core/src/main/java/org/drools/core/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/AbstractReactiveObject.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/AbstractReactiveObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/DetachedTuple.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/DetachedTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/ExecutableEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/ExecutableEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncReceiveNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncReceiveNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncSendNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncSendNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakEvalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakEvalNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNetworkNodeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNetworkNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNetworkNodeFactoryImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNetworkNodeFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryTerminalNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakReactiveFromNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakReactiveFromNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakSubnetworkNotExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakSubnetworkNotExistsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/ReactiveCollection.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/ReactiveCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/ReactiveList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/ReactiveList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/ReactiveObjectUtil.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/ReactiveObjectUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/ReactiveSet.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/ReactiveSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleAgendaItem.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleAgendaItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentPropagator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentPropagator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/StackEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/StackEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/SynchronizedBypassPropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SynchronizedBypassPropagationList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SynchronizedPropagationList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/ThreadUnsafePropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/ThreadUnsafePropagationList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/TupleEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/TupleEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/phreak/TupleEvaluationUtil.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/TupleEvaluationUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/AbstractProcessContext.java
+++ b/drools-core/src/main/java/org/drools/core/process/AbstractProcessContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/ProcessContext.java
+++ b/drools-core/src/main/java/org/drools/core/process/ProcessContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/WorkItem.java
+++ b/drools-core/src/main/java/org/drools/core/process/WorkItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/WorkItemHandler.java
+++ b/drools-core/src/main/java/org/drools/core/process/WorkItemHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/WorkItemListener.java
+++ b/drools-core/src/main/java/org/drools/core/process/WorkItemListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/WorkItemManager.java
+++ b/drools-core/src/main/java/org/drools/core/process/WorkItemManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/WorkItemManagerFactory.java
+++ b/drools-core/src/main/java/org/drools/core/process/WorkItemManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/impl/DefaultWorkItemManager.java
+++ b/drools-core/src/main/java/org/drools/core/process/impl/DefaultWorkItemManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/impl/DefaultWorkItemManagerFactory.java
+++ b/drools-core/src/main/java/org/drools/core/process/impl/DefaultWorkItemManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/process/impl/WorkItemImpl.java
+++ b/drools-core/src/main/java/org/drools/core/process/impl/WorkItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AbstractLeftTupleSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AbstractLeftTupleSinkAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AccumulateNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AgendaComponentFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AgendaComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AlphaNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AlphaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AsyncMessage.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AsyncMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AsyncMessagesCoordinator.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AsyncMessagesCoordinator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AsyncReceiveNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AsyncReceiveNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/AsyncSendNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AsyncSendNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ClassObjectTypeConf.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ClassObjectTypeConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/CompositeLeftTupleSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/CompositeLeftTupleSinkAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/CompositeObjectSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/CompositeObjectSinkAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/CompositePartitionAwareObjectSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/CompositePartitionAwareObjectSinkAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ConditionalBranchEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ConditionalBranchEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ConditionalBranchNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ConditionalBranchNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/CoreComponentFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/CoreComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/EmptyLeftTupleSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/EmptyLeftTupleSinkAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/EmptyObjectSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/EmptyObjectSinkAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/EvalConditionNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/EvalConditionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/EvalNodeLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/EvalNodeLeftTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ExistsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/FromNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/FromNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/JoinNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/JoinNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSink.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSinkNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSinkNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSinkNodeList.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSinkNodeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSinkPropagator.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSinkPropagator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSource.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ModifyPreviousTuples.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ModifyPreviousTuples.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/NodeSet.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/NodeSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/NotNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/NotNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/NotNodeLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/NotNodeLeftTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectSink.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectSinkNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectSinkNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectSinkPropagator.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectSinkPropagator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectSource.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeConf.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNodeId.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNodeId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/PathEndNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PathEndNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/PrototypeTypeConf.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PrototypeTypeConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/QueryElementNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/QueryElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/QueryTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/QueryTerminalNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReactiveFromNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReactiveFromNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReactiveFromNodeLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReactiveFromNodeLeftTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/Rete.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/Rete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReteDumper.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReteDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReteObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReteObjectTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReteooFactHandleFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReteooFactHandleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightTupleSink.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightTupleSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleRemovalContext.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleRemovalContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNodeLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNodeLeftTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuntimeComponentFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuntimeComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentNodeMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentNodeMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/SingleLeftTupleSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SingleLeftTupleSinkAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/SingleObjectSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SingleObjectSinkAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/Sink.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/Sink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/SubnetworkTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SubnetworkTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/TerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TerminalNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/TimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TimerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/Tuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/Tuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleImpl.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleIterator.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/WindowNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/WindowNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/WindowTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/WindowTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/WindowTupleList.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/WindowTupleList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/AccumulateBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/AccumulateBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/AsyncReceiveBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/AsyncReceiveBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/AsyncSendBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/AsyncSendBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/BetaNodeConstraintFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/BetaNodeConstraintFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/BetaNodeConstraintFactoryImpl.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/BetaNodeConstraintFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/BuildContext.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/BuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/BuildUtils.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/BuildUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/CollectBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/CollectBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ConditionalBranchBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ConditionalBranchBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/EntryPointBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/EntryPointBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/EvalBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/EvalBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ForallBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ForallBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/FromBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/FromBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/GroupElementBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/GroupElementBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/InstanceNotEqualsConstraint.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/InstanceNotEqualsConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/NamedConsequenceBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/NamedConsequenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/NodeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/NodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PhreakNodeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PhreakNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/QueryElementBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/QueryElementBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ReactiveFromBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ReactiveFromBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooComponentBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooComponentBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/TimerBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/TimerBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/WindowBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/WindowBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/WindowReferenceBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/WindowReferenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/BehaviorContext.java
+++ b/drools-core/src/main/java/org/drools/core/rule/BehaviorContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/BehaviorManager.java
+++ b/drools-core/src/main/java/org/drools/core/rule/BehaviorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/BehaviorRuntime.java
+++ b/drools-core/src/main/java/org/drools/core/rule/BehaviorRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/JavaDialectRuntimeData.java
+++ b/drools-core/src/main/java/org/drools/core/rule/JavaDialectRuntimeData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/SlidingLengthWindow.java
+++ b/drools-core/src/main/java/org/drools/core/rule/SlidingLengthWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/SlidingTimeWindow.java
+++ b/drools-core/src/main/java/org/drools/core/rule/SlidingTimeWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/accessor/FactHandleFactory.java
+++ b/drools-core/src/main/java/org/drools/core/rule/accessor/FactHandleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/consequence/ConsequenceExceptionHandler.java
+++ b/drools-core/src/main/java/org/drools/core/rule/consequence/ConsequenceExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/consequence/InternalMatch.java
+++ b/drools-core/src/main/java/org/drools/core/rule/consequence/InternalMatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/rule/consequence/KnowledgeHelper.java
+++ b/drools-core/src/main/java/org/drools/core/rule/consequence/KnowledgeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/runtime/process/InternalProcessRuntime.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/process/InternalProcessRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/runtime/process/ProcessRuntimeFactoryService.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/process/ProcessRuntimeFactoryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/runtime/rule/impl/DefaultConsequenceExceptionHandler.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/rule/impl/DefaultConsequenceExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/runtime/rule/impl/FlatQueryResultRow.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/rule/impl/FlatQueryResultRow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/runtime/rule/impl/LiveQueryImpl.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/rule/impl/LiveQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/runtime/rule/impl/OpenQueryViewChangedEventListenerAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/rule/impl/OpenQueryViewChangedEventListenerAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/runtime/rule/impl/RowAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/rule/impl/RowAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/EnqueuedSelfRemovalJobContext.java
+++ b/drools-core/src/main/java/org/drools/core/time/EnqueuedSelfRemovalJobContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/InternalSchedulerService.java
+++ b/drools-core/src/main/java/org/drools/core/time/InternalSchedulerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/Job.java
+++ b/drools-core/src/main/java/org/drools/core/time/Job.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/JobContext.java
+++ b/drools-core/src/main/java/org/drools/core/time/JobContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/Scheduler.java
+++ b/drools-core/src/main/java/org/drools/core/time/Scheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/SchedulerService.java
+++ b/drools-core/src/main/java/org/drools/core/time/SchedulerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/SelfRemovalJob.java
+++ b/drools-core/src/main/java/org/drools/core/time/SelfRemovalJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/SelfRemovalJobContext.java
+++ b/drools-core/src/main/java/org/drools/core/time/SelfRemovalJobContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/SessionPseudoClock.java
+++ b/drools-core/src/main/java/org/drools/core/time/SessionPseudoClock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/TemporalDependencyMatrix.java
+++ b/drools-core/src/main/java/org/drools/core/time/TemporalDependencyMatrix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/TimerExpression.java
+++ b/drools-core/src/main/java/org/drools/core/time/TimerExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/TimerExpressionUtil.java
+++ b/drools-core/src/main/java/org/drools/core/time/TimerExpressionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/TimerService.java
+++ b/drools-core/src/main/java/org/drools/core/time/TimerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/AbstractJobHandle.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/AbstractJobHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/BaseTimer.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/BaseTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/CommandServiceTimerJobFactoryManager.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/CommandServiceTimerJobFactoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/CompositeMaxDurationTimer.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/CompositeMaxDurationTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/CompositeMaxDurationTrigger.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/CompositeMaxDurationTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/CronExpression.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/CronExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/CronTimer.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/CronTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/CronTrigger.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/CronTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/DefaultJobHandle.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/DefaultJobHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/DefaultTimerJobFactoryManager.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/DefaultTimerJobFactoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/DefaultTimerJobInstance.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/DefaultTimerJobInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/DurationTimer.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/DurationTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/ExpressionIntervalTimer.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/ExpressionIntervalTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/IntervalTimer.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/IntervalTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/IntervalTrigger.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/IntervalTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/JDKTimerService.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/JDKTimerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/KieCronExpression.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/KieCronExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/PointInTimeTrigger.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/PointInTimeTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/PseudoClockScheduler.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/PseudoClockScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/ThreadSafeTrackableTimeJobFactoryManager.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/ThreadSafeTrackableTimeJobFactoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/TimerJobFactoryManager.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/TimerJobFactoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/TimerJobInstance.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/TimerJobInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/time/impl/TrackableTimeJobFactoryManager.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/TrackableTimeJobFactoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/AbstractHashTable.java
+++ b/drools-core/src/main/java/org/drools/core/util/AbstractHashTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/AbstractLinkedListNode.java
+++ b/drools-core/src/main/java/org/drools/core/util/AbstractLinkedListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/ArrayQueue.java
+++ b/drools-core/src/main/java/org/drools/core/util/ArrayQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/AtomicBitwiseLong.java
+++ b/drools-core/src/main/java/org/drools/core/util/AtomicBitwiseLong.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/Bag.java
+++ b/drools-core/src/main/java/org/drools/core/util/Bag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/BinaryHeapQueue.java
+++ b/drools-core/src/main/java/org/drools/core/util/BinaryHeapQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/CompositeIterator.java
+++ b/drools-core/src/main/java/org/drools/core/util/CompositeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/ConfFileUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/ConfFileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/DoubleLinkedEntry.java
+++ b/drools-core/src/main/java/org/drools/core/util/DoubleLinkedEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/FactEntry.java
+++ b/drools-core/src/main/java/org/drools/core/util/FactEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/FastIterator.java
+++ b/drools-core/src/main/java/org/drools/core/util/FastIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/HashTableIterator.java
+++ b/drools-core/src/main/java/org/drools/core/util/HashTableIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/Iterator.java
+++ b/drools-core/src/main/java/org/drools/core/util/Iterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/KeyStoreConstants.java
+++ b/drools-core/src/main/java/org/drools/core/util/KeyStoreConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/KeyStoreHelper.java
+++ b/drools-core/src/main/java/org/drools/core/util/KeyStoreHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/KieFunctions.java
+++ b/drools-core/src/main/java/org/drools/core/util/KieFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/LinkedList.java
+++ b/drools-core/src/main/java/org/drools/core/util/LinkedList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/LinkedListEntry.java
+++ b/drools-core/src/main/java/org/drools/core/util/LinkedListEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/MemoryUtil.java
+++ b/drools-core/src/main/java/org/drools/core/util/MemoryUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/MessageUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/MessageUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/Queue.java
+++ b/drools-core/src/main/java/org/drools/core/util/Queue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/QueueFactory.java
+++ b/drools-core/src/main/java/org/drools/core/util/QueueFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/ScalablePool.java
+++ b/drools-core/src/main/java/org/drools/core/util/ScalablePool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/SingleLinkedEntry.java
+++ b/drools-core/src/main/java/org/drools/core/util/SingleLinkedEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/TreeSetQueue.java
+++ b/drools-core/src/main/java/org/drools/core/util/TreeSetQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/TupleRBTree.java
+++ b/drools-core/src/main/java/org/drools/core/util/TupleRBTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/AbstractTupleIndexTree.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/AbstractTupleIndexTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/AlphaRangeIndex.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/AlphaRangeIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/IndexFactory.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/IndexFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/IndexMemory.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/IndexMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/IndexSpec.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/IndexSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/RangeIndex.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/RangeIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/TupleIndexHashTable.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/TupleIndexHashTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/TupleIndexRBTree.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/TupleIndexRBTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/TupleList.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/TupleList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/main/java/org/drools/core/util/index/TupleListWithContext.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/TupleListWithContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/base/ClassTypeResolverTest.java
+++ b/drools-core/src/test/java/org/drools/core/base/ClassTypeResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/base/ConcreteChild.java
+++ b/drools-core/src/test/java/org/drools/core/base/ConcreteChild.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/base/SimulateMacOSXClassLoader.java
+++ b/drools-core/src/test/java/org/drools/core/base/SimulateMacOSXClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/base/TestBean.java
+++ b/drools-core/src/test/java/org/drools/core/base/TestBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/base/ValueTypeTest.java
+++ b/drools-core/src/test/java/org/drools/core/base/ValueTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/base/accumulators/VarianceNaNTest.java
+++ b/drools-core/src/test/java/org/drools/core/base/accumulators/VarianceNaNTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/base/evaluators/TimeIntervalParserTest.java
+++ b/drools-core/src/test/java/org/drools/core/base/evaluators/TimeIntervalParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/common/ClassAwareObjectStoreTest.java
+++ b/drools-core/src/test/java/org/drools/core/common/ClassAwareObjectStoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/common/DroolsObjectIOTest.java
+++ b/drools-core/src/test/java/org/drools/core/common/DroolsObjectIOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/impl/KnowledgeBaseImplTest.java
+++ b/drools-core/src/test/java/org/drools/core/impl/KnowledgeBaseImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/integrationtests/SerializationHelper.java
+++ b/drools-core/src/test/java/org/drools/core/integrationtests/SerializationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/io/impl/ByteArrayResourceSerializationTest.java
+++ b/drools-core/src/test/java/org/drools/core/io/impl/ByteArrayResourceSerializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/io/impl/ByteArrayResourceToStringTest.java
+++ b/drools-core/src/test/java/org/drools/core/io/impl/ByteArrayResourceToStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/io/impl/ReaderResourceTest.java
+++ b/drools-core/src/test/java/org/drools/core/io/impl/ReaderResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/BaseNodeTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/BaseNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/BetaNodeTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/BetaNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/DefaultFactHandleFactoryTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/DefaultFactHandleFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/FactHandleTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/FactHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockAccumulator.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockAccumulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockEvalCondition.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockEvalCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockLeftTupleSink.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockLeftTupleSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSink.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSource.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockRightTupleSink.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockRightTupleSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockTupleSource.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockTupleSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/NodeTypeEnumTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/NodeTypeEnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/ObjectSourceTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/ObjectSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/ObjectTypeConfTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/ObjectTypeConfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/ReteComparator.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/ReteComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/ReteMemoryChecker.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/ReteMemoryChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/TupleIterationTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/TupleIterationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/TupleSourceTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/TupleSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/reteoo/builder/ReteooRuleBuilderTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/builder/ReteooRuleBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/Address.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/Cheese.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/CheeseEqual.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/CheeseEqual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/CheeseInterface.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/CheeseInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/FirstClass.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/FirstClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/MockFactHandle.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/MockFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/Person.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/SecondClass.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/SecondClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/StockTick.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/StockTick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/test/model/TestRuleRuntimeEventListener.java
+++ b/drools-core/src/test/java/org/drools/core/test/model/TestRuleRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/time/TemporalDistanceTest.java
+++ b/drools-core/src/test/java/org/drools/core/time/TemporalDistanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/time/impl/CompositeMaxDurationTimerTest.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/CompositeMaxDurationTimerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/time/impl/CronExpressionTest.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/CronExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/time/impl/CronJobTest.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/CronJobTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/time/impl/JDKTimerServiceTest.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/JDKTimerServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/time/impl/PseudoClockSchedulerTest.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/PseudoClockSchedulerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/time/impl/Quartz601Test.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/Quartz601Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/time/impl/SerializationTestSupport.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/SerializationTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/BinaryHeapPriorityQueueTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/BinaryHeapPriorityQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/BinaryHeapQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/ClassUtilsTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/ClassUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/DroolsAssert.java
+++ b/drools-core/src/test/java/org/drools/core/util/DroolsAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/DroolsStreamUtils.java
+++ b/drools-core/src/test/java/org/drools/core/util/DroolsStreamUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/DroolsTestUtil.java
+++ b/drools-core/src/test/java/org/drools/core/util/DroolsTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/FileManager.java
+++ b/drools-core/src/test/java/org/drools/core/util/FileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/HeapDump.java
+++ b/drools-core/src/test/java/org/drools/core/util/HeapDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/IndexedHashtableIteratorTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/IndexedHashtableIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/IoUtilsTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/IoUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/KeyStoreHelperTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/KeyStoreHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/KieFunctionsTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/KieFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/LeftTupleRBTreeTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/LeftTupleRBTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/LinkedListTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/LinkedListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/MethodUtilsTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/MethodUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/NaturalComparator.java
+++ b/drools-core/src/test/java/org/drools/core/util/NaturalComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/RightTupleListTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/RightTupleListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/ScalablePoolTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/ScalablePoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/AbstractClass.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/AbstractClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/BaseBean.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/BaseBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/BeanInherit.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/BeanInherit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/InterfaceChild.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/InterfaceChild.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/InterfaceChildImpl.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/InterfaceChildImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/InterfaceParent.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/InterfaceParent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/InterfaceParent2.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/InterfaceParent2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/MethodCompareA.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/MethodCompareA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/MethodCompareB.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/MethodCompareB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/TestAbstract.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/TestAbstract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/TestAbstractImpl.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/TestAbstractImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/TestBean.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/TestBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/TestInterface.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/TestInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/TestInterfaceImpl.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/TestInterfaceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/asm/TestObject.java
+++ b/drools-core/src/test/java/org/drools/core/util/asm/TestObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/index/IndexUtilTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/index/IndexUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/util/index/RangeIndexTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/index/RangeIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/core/xml/GenericsTest.java
+++ b/drools-core/src/test/java/org/drools/core/xml/GenericsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-core/src/test/java/org/drools/mvel/dataproviders/TestVariable.java
+++ b/drools-core/src/test/java/org/drools/mvel/dataproviders/TestVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/ExternalSpreadsheetCompiler.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/ExternalSpreadsheetCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/InputType.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/InputType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/SpreadsheetCompiler.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/SpreadsheetCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/package-info.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/ActionType.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/ActionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/DecisionTableParser.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/DecisionTableParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/DefaultRuleSheetListener.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/DefaultRuleSheetListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/LhsBuilder.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/LhsBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/RhsBuilder.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/RhsBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/RuleMatrixSheetListener.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/RuleMatrixSheetListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/RuleSheetListener.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/RuleSheetListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/RuleSheetParserUtil.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/RuleSheetParserUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/SourceBuilder.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/SourceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/csv/CsvLineParser.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/csv/CsvLineParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/csv/CsvParser.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/csv/CsvParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/ExcelParser.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/ExcelParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/NullSheetListener.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/NullSheetListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/PropertiesSheetListener.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/PropertiesSheetListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/com/sample/FactData.java
+++ b/drools-decisiontables/src/test/java/com/sample/FactData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/acme/insurance/Driver.java
+++ b/drools-decisiontables/src/test/java/org/acme/insurance/Driver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/acme/insurance/Policy.java
+++ b/drools-decisiontables/src/test/java/org/acme/insurance/Policy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/acme/insurance/launcher/PricingRuleLauncher.java
+++ b/drools-decisiontables/src/test/java/org/acme/insurance/launcher/PricingRuleLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/CalendarTimerResourcesTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/CalendarTimerResourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/Cheese.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/ColumnReplaceTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/ColumnReplaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/DecimalSeparatorTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/DecimalSeparatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/DumpGeneratedDrlTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/DumpGeneratedDrlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/EmptyHeaderTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/EmptyHeaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/ExternalSpreadsheetCompilerTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/ExternalSpreadsheetCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/FixedPatternTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/FixedPatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/IgnoreNumericFormatTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/IgnoreNumericFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/LineBreakXLSTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/LineBreakXLSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/LinkedWorkbookTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/LinkedWorkbookTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/MakeSureMultiLinesWorkTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/MakeSureMultiLinesWorkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/Person.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/PrioritySetWithFormulaTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/PrioritySetWithFormulaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/SpreadsheetCompilerUnitTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/SpreadsheetCompilerUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/SpreadsheetIntegrationExampleTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/SpreadsheetIntegrationExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/UnicodeInCSVTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/UnicodeInCSVTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/UnicodeInXLSTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/UnicodeInXLSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/ValueHolder.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/ValueHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/XlsFormulaTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/XlsFormulaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/integrationtests/IncrementalCompilationTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/integrationtests/IncrementalCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/integrationtests/KModuleWithDecisionTablesTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/integrationtests/KModuleWithDecisionTablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/ActionTypeTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/ActionTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/ColumnFactoryTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/ColumnFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/LhsBuilderTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/LhsBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/PropertiesSheetListenerTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/PropertiesSheetListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RhsBuilderTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RhsBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleSheetParserUtilTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleSheetParserUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleWorksheetParse2Test.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleWorksheetParse2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleWorksheetParseFromFileTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleWorksheetParseFromFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleWorksheetParseLargeTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleWorksheetParseLargeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RulesheetUtil.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RulesheetUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/csv/CsvLineParserTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/csv/CsvLineParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/csv/CsvParserTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/csv/CsvParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/xls/ExcelParserTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/xls/ExcelParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/project/MultiKieBaseTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/project/MultiKieBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/project/MultiSheetsTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/project/MultiSheetsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/project/Person.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/project/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/project/Result.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/project/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/kie/kogito/quickstart/Person.java
+++ b/drools-decisiontables/src/test/java/org/kie/kogito/quickstart/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-decisiontables/src/test/java/org/kie/kogito/quickstart/Result.java
+++ b/drools-decisiontables/src/test/java/org/kie/kogito/quickstart/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AbstractClassTypeDeclarationDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AbstractClassTypeDeclarationDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AccessorDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AccessorDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AccumulateDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AccumulateDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AccumulateImportDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AccumulateImportDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ActionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ActionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AndDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AndDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AnnotatedBaseDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AnnotatedBaseDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AnnotationDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AnnotationDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AtomicExprDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AtomicExprDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AttributeDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/AttributeDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/BaseDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/BaseDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/BehaviorDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/BehaviorDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/BindingDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/BindingDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/CollectDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/CollectDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConditionalBranchDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConditionalBranchDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConditionalElementDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConditionalElementDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConnectiveDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConnectiveDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConnectiveType.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConnectiveType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConstraintConnectiveDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ConstraintConnectiveDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/DeclarativeInvokerDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/DeclarativeInvokerDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/DescrVisitor.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/DescrVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EntryPointDeclarationDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EntryPointDeclarationDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EntryPointDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EntryPointDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EnumDeclarationDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EnumDeclarationDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EnumLiteralDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EnumLiteralDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EvalDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EvalDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EvaluatorBasedRestrictionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/EvaluatorBasedRestrictionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ExistsDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ExistsDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ExprConstraintDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ExprConstraintDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ExpressionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ExpressionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FactTemplateDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FactTemplateDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FieldConstraintDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FieldConstraintDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FieldTemplateDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FieldTemplateDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ForFunctionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ForFunctionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ForallDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ForallDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FromDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FromDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FunctionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FunctionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FunctionImportDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/FunctionImportDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/GlobalDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/GlobalDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/GroupByDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/GroupByDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ImportDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ImportDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/LiteralDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/LiteralDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/LiteralRestrictionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/LiteralRestrictionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/MVELExprDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/MVELExprDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/MultiPatternDestinationDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/MultiPatternDestinationDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/NamedConsequenceDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/NamedConsequenceDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/Namespaceable.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/Namespaceable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/NotDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/NotDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/OperatorDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/OperatorDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/OrDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/OrDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PackageDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PackageDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PackageDescrDumper.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PackageDescrDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PatternDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PatternDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PatternDestinationDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PatternDestinationDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PatternSourceDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PatternSourceDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PredicateDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/PredicateDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ProcessDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ProcessDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/QualifiedIdentifierRestrictionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/QualifiedIdentifierRestrictionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/QualifiedName.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/QualifiedName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/QueryDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/QueryDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/RelationalExprDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/RelationalExprDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/Restriction.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/Restriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/RestrictionConnectiveDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/RestrictionConnectiveDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/RestrictionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/RestrictionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ReturnValueDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ReturnValueDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ReturnValueRestrictionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/ReturnValueRestrictionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/RuleDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/RuleDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/TypeDeclarationDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/TypeDeclarationDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/TypeFieldDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/TypeFieldDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/UnitDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/UnitDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/VariableRestrictionDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/VariableRestrictionDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/WindowDeclarationDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/WindowDeclarationDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/WindowReferenceDescr.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/descr/WindowReferenceDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AbstractClassTypeDeclarationBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AbstractClassTypeDeclarationBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AccumulateDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AccumulateDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AccumulateImportDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AccumulateImportDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AnnotatedDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AnnotatedDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AnnotationDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AnnotationDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AttributeDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AttributeDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AttributeSupportBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/AttributeSupportBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/BehaviorDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/BehaviorDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/CEDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/CEDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/CollectDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/CollectDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/ConditionalBranchDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/ConditionalBranchDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/DeclareDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/DeclareDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/DescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/DescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/DescrFactory.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/DescrFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/EntryPointDeclarationDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/EntryPointDeclarationDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/EnumDeclarationDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/EnumDeclarationDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/EnumLiteralDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/EnumLiteralDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/EvalDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/EvalDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/FieldDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/FieldDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/ForallDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/ForallDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/FunctionDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/FunctionDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/GlobalDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/GlobalDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/GroupByDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/GroupByDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/ImportDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/ImportDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/NamedConsequenceDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/NamedConsequenceDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/PackageDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/PackageDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/ParameterSupportBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/ParameterSupportBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/PatternContainerDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/PatternContainerDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/PatternDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/PatternDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/QueryDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/QueryDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/RuleDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/RuleDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/SourceDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/SourceDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/TypeDeclarationDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/TypeDeclarationDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/UnitDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/UnitDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/WindowDeclarationDescrBuilder.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/WindowDeclarationDescrBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/AccumulateDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/AccumulateDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/AccumulateImportDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/AccumulateImportDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/AnnotationDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/AnnotationDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/AttributeDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/AttributeDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/BaseDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/BaseDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/BehaviorDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/BehaviorDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/CEDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/CEDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/CollectDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/CollectDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/ConditionalBranchDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/ConditionalBranchDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/DeclareDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/DeclareDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/EntryPointDeclarationDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/EntryPointDeclarationDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/EnumDeclarationDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/EnumDeclarationDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/EnumLiteralDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/EnumLiteralDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/EvalDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/EvalDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/FieldDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/FieldDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/ForallDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/ForallDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/FunctionDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/FunctionDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/GlobalDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/GlobalDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/GroupByDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/GroupByDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/ImportDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/ImportDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/NamedConsequenceDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/NamedConsequenceDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/PackageDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/PackageDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/PatternDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/PatternDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/QueryDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/QueryDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/RuleDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/RuleDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/SourceDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/SourceDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/TypeDeclarationDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/TypeDeclarationDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/UnitDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/UnitDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/WindowDeclarationDescrBuilderImpl.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/dsl/impl/WindowDeclarationDescrBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/util/AstUtil.java
+++ b/drools-drl/drools-drl-ast/src/main/java/org/drools/drl/ast/util/AstUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/DecisionTableFactory.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/DecisionTableFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/DecisionTableProvider.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/DecisionTableProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/GuidedRuleTemplateFactory.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/GuidedRuleTemplateFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/GuidedRuleTemplateProvider.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/GuidedRuleTemplateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/ResourceConversionResult.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/ResourceConversionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/YamlFactory.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/YamlFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/YamlProvider.java
+++ b/drools-drl/drools-drl-extensions/src/main/java/org/drools/drl/extensions/YamlProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRL10ParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRL10ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserIdentifierTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLParserIdentifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrCommonPropertyTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrCommonPropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrDumperTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DescrDumperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/ParserTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/BaseKnowledgeBuilderResultImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/BaseKnowledgeBuilderResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DRLFactory.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DRLFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/Drl6ExprParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/Drl6ExprParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlExprParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlExprParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlExprParserFactory.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlExprParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DrlParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DroolsError.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DroolsError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DroolsParserException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/DroolsParserException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/MessageImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/MessageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/ParserError.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/ParserError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/Antlr4ParserStringUtils.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/Antlr4ParserStringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/BaseDescrFactory.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/BaseDescrFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRL10ParserHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRL10ParserHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRL10ParserWrapper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRL10ParserWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLErrorListener.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLErrorListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLExpressions.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLExpressions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLParserError.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLParserError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLParserException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLParserException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DRLVisitorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DescrHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DescrHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/Drl10ExprParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/Drl10ExprParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DroolsParserExceptionFactory.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DroolsParserExceptionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/impl/Operator.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/impl/Operator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/AbstractDRLLexer.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/AbstractDRLLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/AbstractDRLParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/AbstractDRLParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL5Expressions.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL5Expressions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL5Lexer.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL5Lexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL5Parser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL5Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6Lexer.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6Lexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6Parser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6StrictParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6StrictParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRLExpressions.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRLExpressions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRLLexer.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRLLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRLParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRLParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsEditorType.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsEditorType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsMismatchedSetException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsMismatchedSetException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsMismatchedTokenException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsMismatchedTokenException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsMissingTokenException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsMissingTokenException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsParaphraseTypes.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsParaphraseTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsParserExceptionFactory.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsParserExceptionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSentence.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSentence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSentenceType.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSentenceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSoftKeywords.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSoftKeywords.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsToken.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsTree.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsUnexpectedAnnotationException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsUnexpectedAnnotationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/Expander.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/Expander.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ExpanderException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ExpanderException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ExpanderResolver.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ExpanderResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/GeneralParseException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/GeneralParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/Location.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/Location.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ParseException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ParserHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ParserHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/XpathAnalysis.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/XpathAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/AbstractDSLMappingEntry.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/AbstractDSLMappingEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/AntlrDSLMappingEntry.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/AntlrDSLMappingEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMapLexer.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMapLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMapParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMapParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMapWalker.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMapWalker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMapping.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMappingEntry.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMappingEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMappingFile.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMappingFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMappingParseException.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLMappingParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLTokenizedMappingFile.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DSLTokenizedMappingFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DefaultDSLMapping.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DefaultDSLMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DefaultExpander.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DefaultExpander.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DefaultExpanderResolver.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/DefaultExpanderResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/MappingError.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/dsl/MappingError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/util/ParserStringUtils.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/util/ParserStringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drl/drools-drl-parser/src/test/java/org/drools/drl/parser/util/ParserStringUtilsTest.java
+++ b/drools-drl/drools-drl-parser/src/test/java/org/drools/drl/parser/util/ParserStringUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli-tests/src/main/java/org/drools/drlonyaml/cli/tests/Utils.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli-tests/src/main/java/org/drools/drlonyaml/cli/tests/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli-tests/src/test/java/org/drools/drlonyaml/cli/tests/ConversionsUsingCliTest.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli-tests/src/test/java/org/drools/drlonyaml/cli/tests/ConversionsUsingCliTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/App.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/App.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Batch2Drl.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Batch2Drl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Batch2Yaml.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Batch2Yaml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Drl2Yaml.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Drl2Yaml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Yaml2Drl.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/Yaml2Drl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/utils/DrlOnYamlCliVersionProvider.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/utils/DrlOnYamlCliVersionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/utils/FileWriteStrategy.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/utils/FileWriteStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/utils/Utils.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/src/main/java/org/drools/drlonyaml/cli/utils/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/Message.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/ProgrammaticProjectTest.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/src/test/java/org/drools/drlonyaml/integration/tests/ProgrammaticProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/AbstractThen.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/AbstractThen.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/AbstractThenDeserializer.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/AbstractThenDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/All.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/All.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Base.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Base.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/BaseDeserializer.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/BaseDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/DrlPackage.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/DrlPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Exists.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Exists.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Function.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Function.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Global.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Global.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Import.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Import.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Not.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Not.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Pattern.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Rule.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/StringThen.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/StringThen.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Utils.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/main/java/org/drools/drlonyaml/model/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/java/org/drools/drlonyaml/model/SmokeTest.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/src/test/java/org/drools/drlonyaml/model/SmokeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-schemagen/src/main/java/org/drools/drlonyaml/schemagen/AtomicTypeJsonValueDefinitionProvider.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-schemagen/src/main/java/org/drools/drlonyaml/schemagen/AtomicTypeJsonValueDefinitionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-schemagen/src/main/java/org/drools/drlonyaml/schemagen/Generator.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-schemagen/src/main/java/org/drools/drlonyaml/schemagen/Generator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/java/org/drools/drlonyaml/todrl/YAMLtoDrlDumper.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/java/org/drools/drlonyaml/todrl/YAMLtoDrlDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/java/org/drools/drlonyaml/todrl/YamlProviderImpl.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/main/java/org/drools/drlonyaml/todrl/YamlProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/test/java/org/drools/drlonyaml/todrl/YAMLtoDRLTest.java
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/src/test/java/org/drools/drlonyaml/todrl/YAMLtoDRLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ecj/src/main/java/org/drools/ecj/EclipseCompilationProblem.java
+++ b/drools-ecj/src/main/java/org/drools/ecj/EclipseCompilationProblem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ecj/src/main/java/org/drools/ecj/EclipseJavaCompiler.java
+++ b/drools-ecj/src/main/java/org/drools/ecj/EclipseJavaCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ecj/src/main/java/org/drools/ecj/EclipseJavaCompilerSettings.java
+++ b/drools-ecj/src/main/java/org/drools/ecj/EclipseJavaCompilerSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ecj/src/test/java/org/drools/ecj/JavaCompilerI18NTest.java
+++ b/drools-ecj/src/test/java/org/drools/ecj/JavaCompilerI18NTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/default-kiesession-from-file/src/main/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromFileExample.java
+++ b/drools-examples-api/default-kiesession-from-file/src/main/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromFileExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/default-kiesession-from-file/src/test/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromByteArrayExampleTest.java
+++ b/drools-examples-api/default-kiesession-from-file/src/test/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromByteArrayExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/default-kiesession-from-file/src/test/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromFileExampleTest.java
+++ b/drools-examples-api/default-kiesession-from-file/src/test/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromFileExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/default-kiesession/src/main/java/org/drools/example/api/defaultkiesession/DefaultKieSessionExample.java
+++ b/drools-examples-api/default-kiesession/src/main/java/org/drools/example/api/defaultkiesession/DefaultKieSessionExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/default-kiesession/src/main/java/org/drools/example/api/defaultkiesession/Message.java
+++ b/drools-examples-api/default-kiesession/src/main/java/org/drools/example/api/defaultkiesession/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/default-kiesession/src/test/java/org/drools/example/api/defaultkiesession/DefaultKieSessionExampleTest.java
+++ b/drools-examples-api/default-kiesession/src/test/java/org/drools/example/api/defaultkiesession/DefaultKieSessionExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/default-kiesession/src/test/java/org/drools/example/api/defaultkiesession/DefaultKieSessionFromFSExampleTest.java
+++ b/drools-examples-api/default-kiesession/src/test/java/org/drools/example/api/defaultkiesession/DefaultKieSessionFromFSExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kie-module-from-multiple-files/src/main/java/org/drools/example/api/kiemodulefrommultiplefiles/KieModuleFromMultipleFilesExample.java
+++ b/drools-examples-api/kie-module-from-multiple-files/src/main/java/org/drools/example/api/kiemodulefrommultiplefiles/KieModuleFromMultipleFilesExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kie-module-from-multiple-files/src/test/java/org/drools/example/api/kiemodulefrommultiplefiles/KieModuleFromMultipleFilesExampleTest.java
+++ b/drools-examples-api/kie-module-from-multiple-files/src/test/java/org/drools/example/api/kiemodulefrommultiplefiles/KieModuleFromMultipleFilesExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kiebase-inclusion/src/main/java/org/drools/example/api/kiebaseinclusion/KieBaseInclusionExample.java
+++ b/drools-examples-api/kiebase-inclusion/src/main/java/org/drools/example/api/kiebaseinclusion/KieBaseInclusionExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kiebase-inclusion/src/test/java/org/drools/example/api/kiebaseinclusion/KieBaseInclusionExampleTest.java
+++ b/drools-examples-api/kiebase-inclusion/src/test/java/org/drools/example/api/kiebaseinclusion/KieBaseInclusionExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kiecontainer-from-kierepo/src/main/java/org/drools/example/api/kiecontainerfromkierepo/KieContainerFromKieRepoExample.java
+++ b/drools-examples-api/kiecontainer-from-kierepo/src/main/java/org/drools/example/api/kiecontainerfromkierepo/KieContainerFromKieRepoExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kiecontainer-from-kierepo/src/test/java/org/drools/example/api/kiecontainerfromkierepo/KieContainerFromKieRepoExampleTest.java
+++ b/drools-examples-api/kiecontainer-from-kierepo/src/test/java/org/drools/example/api/kiecontainerfromkierepo/KieContainerFromKieRepoExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kiefilesystem-example/src/main/java/org/drools/example/api/kiefilesystem/KieFileSystemExample.java
+++ b/drools-examples-api/kiefilesystem-example/src/main/java/org/drools/example/api/kiefilesystem/KieFileSystemExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kiefilesystem-example/src/main/java/org/drools/example/api/kiefilesystem/Message.java
+++ b/drools-examples-api/kiefilesystem-example/src/main/java/org/drools/example/api/kiefilesystem/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kiefilesystem-example/src/test/java/org/drools/example/api/kiefilesystem/KieFileSystemExampleTest.java
+++ b/drools-examples-api/kiefilesystem-example/src/test/java/org/drools/example/api/kiefilesystem/KieFileSystemExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kiemodulemodel-example/src/main/java/org/drools/example/api/kiemodulemodel/KieModuleModelExample.java
+++ b/drools-examples-api/kiemodulemodel-example/src/main/java/org/drools/example/api/kiemodulemodel/KieModuleModelExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/kiemodulemodel-example/src/test/java/org/drools/example/api/kiemodulemodel/KieModuleModelExampleTest.java
+++ b/drools-examples-api/kiemodulemodel-example/src/test/java/org/drools/example/api/kiemodulemodel/KieModuleModelExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/multiple-kbases/src/test/java/org/drools/example/api/multiplekbases/MultipleKbasesExampleTest.java
+++ b/drools-examples-api/multiple-kbases/src/test/java/org/drools/example/api/multiplekbases/MultipleKbasesExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/named-kiesession-from-file/src/main/java/org/drools/example/api/namedkiesessionfromfile/NamedKieSessionFromFileExample.java
+++ b/drools-examples-api/named-kiesession-from-file/src/main/java/org/drools/example/api/namedkiesessionfromfile/NamedKieSessionFromFileExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/named-kiesession-from-file/src/test/java/org/drools/example/api/namedkiesessionfromfile/NamedKieSessionFromFileExampleTest.java
+++ b/drools-examples-api/named-kiesession-from-file/src/test/java/org/drools/example/api/namedkiesessionfromfile/NamedKieSessionFromFileExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/named-kiesession/src/main/java/org/drools/example/api/namedkiesession/Message.java
+++ b/drools-examples-api/named-kiesession/src/main/java/org/drools/example/api/namedkiesession/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/named-kiesession/src/main/java/org/drools/example/api/namedkiesession/NamedKieSessionExample.java
+++ b/drools-examples-api/named-kiesession/src/main/java/org/drools/example/api/namedkiesession/NamedKieSessionExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/named-kiesession/src/test/java/org/drools/example/api/namedkiesession/NamedKieSessionExampleTest.java
+++ b/drools-examples-api/named-kiesession/src/test/java/org/drools/example/api/namedkiesession/NamedKieSessionExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/reactive-kiesession/src/main/java/org/drools/example/api/reactivekiesession/ReactiveKieSessionExample.java
+++ b/drools-examples-api/reactive-kiesession/src/main/java/org/drools/example/api/reactivekiesession/ReactiveKieSessionExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples-api/reactive-kiesession/src/test/java/org/drools/example/api/reactivekiesession/ReactiveKieSessionExampleTest.java
+++ b/drools-examples-api/reactive-kiesession/src/test/java/org/drools/example/api/reactivekiesession/ReactiveKieSessionExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/DroolsBenchmarkExamplesApp.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/DroolsBenchmarkExamplesApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltz/Edge.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltz/Edge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltz/Junction.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltz/Junction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltz/Line.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltz/Line.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltz/Stage.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltz/Stage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltz/WaltzBenchmark.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltz/WaltzBenchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltz/WaltzUtil.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltz/WaltzUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Edge.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Edge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltzdb/EdgeLabel.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltzdb/EdgeLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Illegal.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Illegal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Junction.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Junction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Label.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Label.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Line.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Line.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Stage.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltzdb/Stage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/benchmark/waltzdb/WaltzDbBenchmark.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltzdb/WaltzDbBenchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/DroolsExamplesApp.java
+++ b/drools-examples/src/main/java/org/drools/examples/DroolsExamplesApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/backwardchaining/HouseOfDoomMain.java
+++ b/drools-examples/src/main/java/org/drools/examples/backwardchaining/HouseOfDoomMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/backwardchaining/Location.java
+++ b/drools-examples/src/main/java/org/drools/examples/backwardchaining/Location.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/Account.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/Account.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/AllocatedCashflow.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/AllocatedCashflow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/BankingExample1.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/BankingExample1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/BankingExample2.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/BankingExample2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/BankingExample3.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/BankingExample3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/BankingExample4.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/BankingExample4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/BankingExample5.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/BankingExample5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/BankingExample6.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/BankingExample6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/BankingExamplesApp.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/BankingExamplesApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/Cashflow.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/Cashflow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/RuleRunner.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/RuleRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/SimpleDate.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/SimpleDate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/banking/TypedCashflow.java
+++ b/drools-examples/src/main/java/org/drools/examples/banking/TypedCashflow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/birdsfly/Bird.java
+++ b/drools-examples/src/main/java/org/drools/examples/birdsfly/Bird.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/birdsfly/BirdsFlyExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/birdsfly/BirdsFlyExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/birdsfly/Broken.java
+++ b/drools-examples/src/main/java/org/drools/examples/birdsfly/Broken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/birdsfly/Fly.java
+++ b/drools-examples/src/main/java/org/drools/examples/birdsfly/Fly.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/birdsfly/Rocket.java
+++ b/drools-examples/src/main/java/org/drools/examples/birdsfly/Rocket.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/AdultBusPass.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/AdultBusPass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/BadBehaviour.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/BadBehaviour.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/BusPass.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/BusPass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/BussPassBadExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/BussPassBadExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/BussPassGoodExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/BussPassGoodExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/BussPassJTMSExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/BussPassJTMSExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/ChildBusPass.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/ChildBusPass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/IsAdult.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/IsAdult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/IsChild.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/IsChild.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/buspass/Person.java
+++ b/drools-examples/src/main/java/org/drools/examples/buspass/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/cashflow/Account.java
+++ b/drools-examples/src/main/java/org/drools/examples/cashflow/Account.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/cashflow/AccountPeriod.java
+++ b/drools-examples/src/main/java/org/drools/examples/cashflow/AccountPeriod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/cashflow/CashFlow.java
+++ b/drools-examples/src/main/java/org/drools/examples/cashflow/CashFlow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/cashflow/CashFlowMain.java
+++ b/drools-examples/src/main/java/org/drools/examples/cashflow/CashFlowMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/cashflow/CashFlowType.java
+++ b/drools-examples/src/main/java/org/drools/examples/cashflow/CashFlowType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/circularTms/CircularTmsExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/circularTms/CircularTmsExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/decisiontable/Driver.java
+++ b/drools-examples/src/main/java/org/drools/examples/decisiontable/Driver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/decisiontable/Policy.java
+++ b/drools-examples/src/main/java/org/drools/examples/decisiontable/Policy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/decisiontable/PricingRuleDTExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/decisiontable/PricingRuleDTExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/diagnostics/Answer.java
+++ b/drools-examples/src/main/java/org/drools/examples/diagnostics/Answer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/diagnostics/DiagnosticsExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/diagnostics/DiagnosticsExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/diagnostics/Question.java
+++ b/drools-examples/src/main/java/org/drools/examples/diagnostics/Question.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/diagnostics/Solution.java
+++ b/drools-examples/src/main/java/org/drools/examples/diagnostics/Solution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/diagnostics/WontStart.java
+++ b/drools-examples/src/main/java/org/drools/examples/diagnostics/WontStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/fibonacci/FibonacciExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/fibonacci/FibonacciExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/fire/Alarm.java
+++ b/drools-examples/src/main/java/org/drools/examples/fire/Alarm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/fire/Fire.java
+++ b/drools-examples/src/main/java/org/drools/examples/fire/Fire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/fire/FireExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/fire/FireExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/fire/FireLogicalExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/fire/FireLogicalExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/fire/Room.java
+++ b/drools-examples/src/main/java/org/drools/examples/fire/Room.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/fire/Sprinkler.java
+++ b/drools-examples/src/main/java/org/drools/examples/fire/Sprinkler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/golfing/GolfingExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/golfing/GolfingExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/helloworld/HelloWorldExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/helloworld/HelloWorldExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/honestpolitician/HonestPoliticianExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/honestpolitician/HonestPoliticianExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/honestpolitician/Hope.java
+++ b/drools-examples/src/main/java/org/drools/examples/honestpolitician/Hope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/honestpolitician/Politician.java
+++ b/drools-examples/src/main/java/org/drools/examples/honestpolitician/Politician.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/performance/PerformanceExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/performance/PerformanceExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/petstore/PetStoreExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/petstore/PetStoreExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/shopping/ShoppingExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/shopping/ShoppingExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/state/State.java
+++ b/drools-examples/src/main/java/org/drools/examples/state/State.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/state/StateExampleUsingAgendaGroup.java
+++ b/drools-examples/src/main/java/org/drools/examples/state/StateExampleUsingAgendaGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/state/StateExampleUsingSalience.java
+++ b/drools-examples/src/main/java/org/drools/examples/state/StateExampleUsingSalience.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/Cell.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/Cell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/CellCol.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/CellCol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/CellFile.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/CellFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/CellGroup.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/CellGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/CellRow.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/CellRow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/CellSqr.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/CellSqr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/Counter.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/Counter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/SetOfNine.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/SetOfNine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/Setting.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/Setting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/Stepping.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/Stepping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/Sudoku.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/Sudoku.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/SudokuExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/SudokuExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/swing/AbstractSudokuGridModel.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/swing/AbstractSudokuGridModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridEvent.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridListener.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridModel.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridSamples.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridSamples.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridView.java
+++ b/drools-examples/src/main/java/org/drools/examples/sudoku/swing/SudokuGridView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/traits/Scholar.java
+++ b/drools-examples/src/main/java/org/drools/examples/traits/Scholar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/traits/ScholarImpl.java
+++ b/drools-examples/src/main/java/org/drools/examples/traits/ScholarImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/traits/TraitExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/traits/TraitExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/troubleticket/Customer.java
+++ b/drools-examples/src/main/java/org/drools/examples/troubleticket/Customer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/troubleticket/Ticket.java
+++ b/drools-examples/src/main/java/org/drools/examples/troubleticket/Ticket.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/troubleticket/TroubleTicketExample.java
+++ b/drools-examples/src/main/java/org/drools/examples/troubleticket/TroubleTicketExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/troubleticket/TroubleTicketExampleWithDSL.java
+++ b/drools-examples/src/main/java/org/drools/examples/troubleticket/TroubleTicketExampleWithDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/examples/troubleticket/TroubleTicketExampleWithDT.java
+++ b/drools-examples/src/main/java/org/drools/examples/troubleticket/TroubleTicketExampleWithDT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/GameConfiguration.java
+++ b/drools-examples/src/main/java/org/drools/games/GameConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/GameFrame.java
+++ b/drools-examples/src/main/java/org/drools/games/GameFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/GamePanel.java
+++ b/drools-examples/src/main/java/org/drools/games/GamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/GameUI.java
+++ b/drools-examples/src/main/java/org/drools/games/GameUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/KeyPressed.java
+++ b/drools-examples/src/main/java/org/drools/games/KeyPressed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/Run.java
+++ b/drools-examples/src/main/java/org/drools/games/Run.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/Action.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/Action.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/AdventureFrame.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/AdventureFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/Counter.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/Counter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/GameEngine.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/GameEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/Request.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/Request.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/Response.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/Response.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/TextAdventure.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/TextAdventure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/UserSession.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/UserSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/Character.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/Character.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/Command.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/Door.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/Door.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/DropCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/DropCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/DropEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/DropEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/EnterEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/EnterEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/ExitEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/ExitEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/GameEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/GameEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/GiveCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/GiveCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/GiveEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/GiveEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/Holding.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/Holding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/Item.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/Key.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/Key.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/Location.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/Location.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/LockStatus.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/LockStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/LookCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/LookCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/MoveCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/MoveCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/PickupCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/PickupCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/PickupEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/PickupEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/Room.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/Room.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/SearchCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/SearchCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/Thing.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/Thing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/adventures/model/UseCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/adventures/model/UseCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Bullet.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Bullet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/FPSTimer.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/FPSTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Invader.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Invader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Invaders1Main.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Invaders1Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Invaders2Main.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Invaders2Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Invaders3Main.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Invaders3Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Invaders4Main.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Invaders4Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Invaders5Main.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Invaders5Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Invaders6Main.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Invaders6Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/InvadersConfiguration.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/InvadersConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Ship.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Ship.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/invaders/Unit.java
+++ b/drools-examples/src/main/java/org/drools/games/invaders/Unit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/numberguess/Game.java
+++ b/drools-examples/src/main/java/org/drools/games/numberguess/Game.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/numberguess/GameRules.java
+++ b/drools-examples/src/main/java/org/drools/games/numberguess/GameRules.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/numberguess/Guess.java
+++ b/drools-examples/src/main/java/org/drools/games/numberguess/Guess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/numberguess/NumberGuessMain.java
+++ b/drools-examples/src/main/java/org/drools/games/numberguess/NumberGuessMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/numberguess/RandomNumber.java
+++ b/drools-examples/src/main/java/org/drools/games/numberguess/RandomNumber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/Ball.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/Ball.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/Bat.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/Bat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/Collision.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/Collision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/CollisionType.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/CollisionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/Player.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/Player.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/PlayerId.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/PlayerId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/PointWin.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/PointWin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/PongConfiguration.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/PongConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/PongGame.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/PongGame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/PongMain.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/PongMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/pong/PongUI.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/PongUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Arrow.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Arrow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Cell.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Cell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/ClimbCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/ClimbCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Command.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Direction.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Direction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/EndEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/EndEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/EndGameEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/EndGameEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/EndNewTurnEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/EndNewTurnEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/FeelBreeze.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/FeelBreeze.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/FeelBump.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/FeelBump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Gold.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Gold.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/GoldWin.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/GoldWin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/GrabCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/GrabCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/HearScream.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/HearScream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Hero.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Hero.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Init.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Init.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Move.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Move.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/MoveCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/MoveCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/MoveEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/MoveEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Pit.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Pit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/PitDeath.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/PitDeath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Play.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Play.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Reset.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Reset.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Score.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Score.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/SeeGlitter.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/SeeGlitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Sensor.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Sensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/SensorArray.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/SensorArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/ShootCommand.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/ShootCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/SmellStench.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/SmellStench.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Start.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Start.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/StartEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/StartEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/StartGameEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/StartGameEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/StartNewTurnEvent.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/StartNewTurnEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Thing.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Thing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/Wumpus.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/Wumpus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/WumpusDeath.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/WumpusDeath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/WumpusWorldConfiguration.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/WumpusWorldConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/WumpusWorldMain.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/WumpusWorldMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/view/GameUI.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/view/GameUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-examples/src/main/java/org/drools/games/wumpus/view/GameView.java
+++ b/drools-examples/src/main/java/org/drools/games/wumpus/view/GameView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-fastutil/src/main/java/org/drools/fastutil/FastUtilHashTupleMemory.java
+++ b/drools-fastutil/src/main/java/org/drools/fastutil/FastUtilHashTupleMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-fastutil/src/main/java/org/drools/fastutil/FastUtilIndexMemory.java
+++ b/drools-fastutil/src/main/java/org/drools/fastutil/FastUtilIndexMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-fastutil/src/main/java/org/drools/fastutil/FastUtilMergableHashSet.java
+++ b/drools-fastutil/src/main/java/org/drools/fastutil/FastUtilMergableHashSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-fastutil/src/main/java/org/drools/fastutil/FastUtilTreeMemory.java
+++ b/drools-fastutil/src/main/java/org/drools/fastutil/FastUtilTreeMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-fastutil/src/test/java/org/drools/fastutil/FastUtilTreeMemoryTest.java
+++ b/drools-fastutil/src/test/java/org/drools/fastutil/FastUtilTreeMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/AnalyzedRule.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/AnalyzedRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/Graph.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/Graph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/GraphAnalysis.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/GraphAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/GraphCollapsionHelper.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/GraphCollapsionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/ImpactAnalysisHelper.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/ImpactAnalysisHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/Link.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/Link.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/LinkFilter.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/LinkFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/ModelToGraphConverter.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/ModelToGraphConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/Node.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/ReactivityType.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/ReactivityType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/TextReporter.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/src/main/java/org/drools/impact/analysis/graph/TextReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/src/main/java/org/drools/impact/analysis/graph/graphviz/GraphImageGenerator.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/src/main/java/org/drools/impact/analysis/graph/graphviz/GraphImageGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/src/test/java/org/drools/impact/analysis/graph/graphviz/GraphvizOutputTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/src/test/java/org/drools/impact/analysis/graph/graphviz/GraphvizOutputTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-json/src/main/java/org/drools/impact/analysis/graph/json/GraphJsonGenerator.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-json/src/main/java/org/drools/impact/analysis/graph/json/GraphJsonGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-json/src/test/java/org/drools/impact/analysis/graph/json/JsonOutputTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-json/src/test/java/org/drools/impact/analysis/graph/json/JsonOutputTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/ExampleUsageTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/ExampleUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/domain/Order.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/domain/Order.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/domain/Product.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/example/domain/Product.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/AbstractGraphTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/AbstractGraphTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/BasicGraphTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/BasicGraphTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/DeleteSpecificFactActionTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/DeleteSpecificFactActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/DrlSyntaxTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/DrlSyntaxTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/GraphCollapsionTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/GraphCollapsionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/ImpactAnalysisTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/ImpactAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/LinkFilterTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/LinkFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/PropertyTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/PropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/RhsTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/RhsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/RuleExecutionHelper.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/RuleExecutionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/SpecialUsageTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/SpecialUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/TypeTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/TypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/Address.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/ControlFact.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/ControlFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/FunctionUtils.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/FunctionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/Order.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/Order.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/Person.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/ProductItem.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/ProductItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/PropHolder.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/domain/PropHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/kogito/KogitoDrlSyntaxTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/kogito/KogitoDrlSyntaxTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/kogito/LoanUnit.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/kogito/LoanUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/kogito/domain/Applicant.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/kogito/domain/Applicant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/kogito/domain/LoanApplication.java
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/java/org/drools/impact/analysis/integrationtests/kogito/domain/LoanApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/AnalysisModel.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/AnalysisModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/Package.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/Package.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/Rule.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/left/Constraint.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/left/Constraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/left/LeftHandSide.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/left/LeftHandSide.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/left/MapConstraint.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/left/MapConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/left/Pattern.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/left/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/ConsequenceAction.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/ConsequenceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/DeleteSpecificFactAction.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/DeleteSpecificFactAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/InsertAction.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/InsertAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/InsertedProperty.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/InsertedProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/ModifiedMapProperty.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/ModifiedMapProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/ModifiedProperty.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/ModifiedProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/ModifyAction.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/ModifyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/RightHandSide.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/RightHandSide.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/SpecificProperty.java
+++ b/drools-impact-analysis/drools-impact-analysis-model/src/main/java/org/drools/impact/analysis/model/right/SpecificProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/ModelBuilder.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/ModelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/ImpactAnalysisRuleContext.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/ImpactAnalysisRuleContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/LhsParser.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/LhsParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/PackageParser.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/PackageParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/ParserUtil.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/ParserUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/RhsParser.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/RhsParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisKieModule.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisKieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisKieProject.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisKieProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisProject.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactModelBuilderImpl.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactModelBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/test/java/org/drools/impact/analysis/parser/ParserTest.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/test/java/org/drools/impact/analysis/parser/ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/test/java/org/drools/impact/analysis/parser/domain/Address.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/test/java/org/drools/impact/analysis/parser/domain/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/test/java/org/drools/impact/analysis/parser/domain/Person.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/test/java/org/drools/impact/analysis/parser/domain/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/BaseResource.java
+++ b/drools-io/src/main/java/org/drools/io/BaseResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/ByteArrayResource.java
+++ b/drools-io/src/main/java/org/drools/io/ByteArrayResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/ClassPathResource.java
+++ b/drools-io/src/main/java/org/drools/io/ClassPathResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/DescrResource.java
+++ b/drools-io/src/main/java/org/drools/io/DescrResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/FileSystemResource.java
+++ b/drools-io/src/main/java/org/drools/io/FileSystemResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/InputStreamResource.java
+++ b/drools-io/src/main/java/org/drools/io/InputStreamResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/InternalResource.java
+++ b/drools-io/src/main/java/org/drools/io/InternalResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/KnowledgeResource.java
+++ b/drools-io/src/main/java/org/drools/io/KnowledgeResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/ReaderInputStream.java
+++ b/drools-io/src/main/java/org/drools/io/ReaderInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/ReaderResource.java
+++ b/drools-io/src/main/java/org/drools/io/ReaderResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/ResourceConfigurationImpl.java
+++ b/drools-io/src/main/java/org/drools/io/ResourceConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-io/src/main/java/org/drools/io/ResourceFactoryServiceImpl.java
+++ b/drools-io/src/main/java/org/drools/io/ResourceFactoryServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgendaFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgendaFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/PartitionedDefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/PartitionedDefaultAgenda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/ActivationLogEvent.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/ActivationLogEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/ActivationLogEventFilter.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/ActivationLogEventFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/ILogEventFilter.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/ILogEventFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/KnowledgeRuntimeLoggerProviderImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/KnowledgeRuntimeLoggerProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/LogEvent.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/LogEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/ObjectLogEvent.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/ObjectLogEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleBaseLogEvent.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleBaseLogEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleFlowGroupLogEvent.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleFlowGroupLogEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleFlowLogEvent.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleFlowLogEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleFlowNodeLogEvent.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleFlowNodeLogEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleFlowVariableLogEvent.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/RuleFlowVariableLogEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/ThreadedWorkingMemoryFileLogger.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/ThreadedWorkingMemoryFileLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryConsoleLogger.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryConsoleLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryFileLogger.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryFileLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryLog.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryLogEventFilter.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryLogEventFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryLogger.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/WorkingMemoryLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/audit/package-info.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/audit/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/consequence/DefaultKnowledgeHelper.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/consequence/DefaultKnowledgeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/consequence/StatefulKnowledgeSessionForRHS.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/consequence/StatefulKnowledgeSessionForRHS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/AbstractNetworkNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/AbstractNetworkNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/AccumulateNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/AccumulateNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/AlphaNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/AlphaNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/BetaNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/BetaNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/DefaultNetworkNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/DefaultNetworkNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/DefaultNodeInfo.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/DefaultNodeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/EvalConditionNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/EvalConditionNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/FromNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/FromNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/LeftInputAdapterNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/LeftInputAdapterNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/LeftMemorySizeComparator.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/LeftMemorySizeComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/NetworkNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/NetworkNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/NodeInfo.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/NodeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/ObjectTypeNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/ObjectTypeNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/QueryTerminalNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/QueryTerminalNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/RightInputAdapterNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/RightInputAdapterNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/RightMemorySizeComparator.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/RightMemorySizeComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/RuleTerminalNodeVisitor.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/RuleTerminalNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/SessionInspector.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/SessionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/debug/StatefulKnowledgeSessionInfo.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/debug/StatefulKnowledgeSessionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/DisconnectedWorkingMemoryEntryPoint.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/DisconnectedWorkingMemoryEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointsManager.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/factory/KnowledgeHelperFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/factory/KnowledgeHelperFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/factory/PhreakWorkingMemoryFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/factory/PhreakWorkingMemoryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/factory/RuntimeComponentFactoryImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/factory/RuntimeComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/factory/WorkingMemoryFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/factory/WorkingMemoryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/management/KieSessionMonitoringImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/management/KieSessionMonitoringImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/management/StatelessKieSessionMonitoringImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/management/StatelessKieSessionMonitoringImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/InternalKnowledgeBase.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/InternalKnowledgeBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/KieBaseEventSupport.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/KieBaseEventSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/KnowledgeBaseFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/KnowledgeBaseFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/AbstractKieSessionsPool.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/AbstractKieSessionsPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/KieSessionsPoolImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/KieSessionsPoolImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/ProcessRuntimeFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/ProcessRuntimeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulSessionPool.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulSessionPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatelessKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatelessKnowledgeSessionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/core/positional/BetaConstraintsPositionalIndexingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/core/positional/BetaConstraintsPositionalIndexingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/core/positional/Functions.java
+++ b/drools-kiesession/src/test/java/org/drools/core/positional/Functions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/core/positional/IntFunctions.java
+++ b/drools-kiesession/src/test/java/org/drools/core/positional/IntFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/core/positional/PositionalConsequence.java
+++ b/drools-kiesession/src/test/java/org/drools/core/positional/PositionalConsequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/core/positional/PositionalConstraint.java
+++ b/drools-kiesession/src/test/java/org/drools/core/positional/PositionalConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/core/positional/Predicates.java
+++ b/drools-kiesession/src/test/java/org/drools/core/positional/Predicates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/core/positional/VoidFunctions.java
+++ b/drools-kiesession/src/test/java/org/drools/core/positional/VoidFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/AddRemoveTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/AddRemoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/CrossProductTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/CrossProductTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/InternalRuleBaseConfigurationTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/InternalRuleBaseConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/MockInternalMatch.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/MockInternalMatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/PropertyChangeListenerTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/PropertyChangeListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/QueryElementNodeTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/QueryElementNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/ReteTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/ReteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/ReteooRuleBaseMultiThreadedTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/ReteooRuleBaseMultiThreadedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/ReteooWorkingMemoryTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/ReteooWorkingMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/RuleRuntimeEventSupportTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/RuleRuntimeEventSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingWithSegmentMemoryTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingWithSegmentMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/CommonTestMethodBase.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/CommonTestMethodBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Address.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Alarm.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Alarm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Cell.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Cell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Cheese.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/CheeseEqual.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/CheeseEqual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Cheesery.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Cheesery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/EmergencyTeam.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/EmergencyTeam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/FactA.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/FactA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/FactB.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/FactB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/FactC.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/FactC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Message.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Person.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/PersonInterface.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/PersonInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Pet.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Pet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Primitives.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Primitives.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Sensor.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/Sensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/StaticMethods.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/StaticMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/StaticMethods2.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/StaticMethods2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/StockTick.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/StockTick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/StockTickInterface.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/StockTickInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/TestEnum.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/TestEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/TestUtil.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/command/MoreBatchExecutionTest.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/command/MoreBatchExecutionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/command/SimpleBatchExecutionTest.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/compiler/command/SimpleBatchExecutionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/integrationtests/IteratorToList.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/integrationtests/IteratorToList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-legacy-test-util/src/test/java/org/drools/mvel/integrationtests/SerializationHelper.java
+++ b/drools-legacy-test-util/src/test/java/org/drools/mvel/integrationtests/SerializationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/common/DefaultBetaConstraintsMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/common/DefaultBetaConstraintsMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/common/DoubleBetaConstraintsMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/common/DoubleBetaConstraintsMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/common/QuadroupleBetaConstraintsMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/common/QuadroupleBetaConstraintsMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/common/SingleBetaConstraintsMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/common/SingleBetaConstraintsMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/common/TripleBetaConstraintsMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/common/TripleBetaConstraintsMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/MetricPhreakNetworkNodeFactoryImpl.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/MetricPhreakNetworkNodeFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAccumulateNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAccumulateNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAsyncReceiveNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAsyncReceiveNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAsyncSendNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAsyncSendNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakBranchNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakBranchNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakEvalNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakEvalNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakExistsNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakExistsNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakFromNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakFromNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakGroupByNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakGroupByNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakJoinNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakJoinNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakNotNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakNotNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakQueryNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakQueryNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakQueryTerminalNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakQueryTerminalNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakReactiveFromNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakReactiveFromNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakTimerNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakTimerNodeMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/reteoo/builder/MetricBetaNodeConstraintFactoryImpl.java
+++ b/drools-metric/src/main/java/org/drools/metric/reteoo/builder/MetricBetaNodeConstraintFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/rule/EvalConditionMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/rule/EvalConditionMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/rule/MetricEvalConditionFactoryImpl.java
+++ b/drools-metric/src/main/java/org/drools/metric/rule/MetricEvalConditionFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/util/MetricLogUtils.java
+++ b/drools-metric/src/main/java/org/drools/metric/util/MetricLogUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/util/MicrometerUtils.java
+++ b/drools-metric/src/main/java/org/drools/metric/util/MicrometerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/main/java/org/drools/metric/util/NodeStats.java
+++ b/drools-metric/src/main/java/org/drools/metric/util/NodeStats.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/test/java/org/drools/metric/AbstractMetricTest.java
+++ b/drools-metric/src/test/java/org/drools/metric/AbstractMetricTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/test/java/org/drools/metric/CloneTest.java
+++ b/drools-metric/src/test/java/org/drools/metric/CloneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/test/java/org/drools/metric/ConstraintsTest.java
+++ b/drools-metric/src/test/java/org/drools/metric/ConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-metric/src/test/java/org/drools/metric/MetricLogUtilsTest.java
+++ b/drools-metric/src/test/java/org/drools/metric/MetricLogUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/AccumulatePattern.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/AccumulatePattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/AlphaIndex.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/AlphaIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/AnnotationValue.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/AnnotationValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Argument.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Argument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndex.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndex2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndex2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndex3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndex3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndex4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndex4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndexN.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/BetaIndexN.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Binding.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Binding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/BitMask.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/BitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Channel.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Channel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Condition.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Condition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/ConditionalConsequence.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/ConditionalConsequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Consequence.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Consequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Constraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Constraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/ConstraintOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/ConstraintOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DataSourceDefinition.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DataSourceDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Declaration.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Declaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DeclarationSource.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DeclarationSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DomainClassMetadata.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DomainClassMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Drools.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Drools.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DroolsEntryPoint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DroolsEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DynamicValueSupplier.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DynamicValueSupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/EntryPoint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/EntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From0.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From0.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From10.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From10.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From11.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From11.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From5.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From6.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From7.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From7.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From8.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/From9.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/From9.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Global.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Global.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/GroupByPattern.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/GroupByPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Handle.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Handle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Index.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Index.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/InvokerMultiValuePattern.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/InvokerMultiValuePattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/InvokerPattern.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/InvokerPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/InvokerSingleValuePattern.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/InvokerSingleValuePattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Model.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/NamedModelItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/NamedModelItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Pattern.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query0Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query0Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query10Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query10Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query1Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query1Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query2Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query2Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query3Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query3Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query4Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query4Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query5Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query5Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query6Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query6Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query7Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query7Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query8Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query8Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query9Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query9Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/QueryDef.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/QueryDef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Rule.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/RuleItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/RuleItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/RuleItemBuilder.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/RuleItemBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/RulesSupplier.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/RulesSupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/SingleConstraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/SingleConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Tuple.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Tuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/TupleHandle.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/TupleHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/TypeMetaData.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/TypeMetaData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/TypeReference.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/TypeReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/UnitData.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/UnitData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Value.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Value.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Variable.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Variable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/View.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/View.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Window.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Window.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/WindowDefinition.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/WindowDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/WindowReference.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/WindowReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/AllSetBitMask.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/AllSetBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/AllSetButLastBitMask.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/AllSetButLastBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/AllSetMask.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/AllSetMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/BitMaskUtil.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/BitMaskUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/EmptyBitMask.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/EmptyBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/EmptyButLastBitMask.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/EmptyButLastBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/EmptyMask.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/EmptyMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/LongBitMask.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/LongBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/SingleLongBitMask.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/bitmask/SingleLongBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConditionalConsequenceBuilder.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConditionalConsequenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConditionalConsequenceImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConditionalConsequenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConditionalNamedConsequenceImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConditionalNamedConsequenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConsequenceBuilder.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConsequenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConsequenceImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConsequenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/NamedConsequenceImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/NamedConsequenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AbstractConstraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AbstractConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AbstractSingleConstraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AbstractSingleConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AndConstraints.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AndConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/FixedTemporalConstraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/FixedTemporalConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/MultipleConstraints.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/MultipleConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/OrConstraints.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/OrConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/ReactivitySpecs.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/ReactivitySpecs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint10.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint10.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint11.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint11.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint12.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint12.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint13.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint13.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint14.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint14.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint15.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint15.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint16.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint16.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint17.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint17.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint18.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint18.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint5.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint6.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint7.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint7.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint8.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint9.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint9.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/TemporalConstraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/TemporalConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/VariableTemporalConstraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/VariableTemporalConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block0.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block0.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block10.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block10.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block11.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block11.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block12.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block12.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block13.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block13.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block14.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block14.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block15.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block15.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block16.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block16.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block17.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block17.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block18.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block18.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block19.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block19.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block20.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block20.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block21.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block21.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block22.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block22.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block23.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block23.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block24.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block24.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block25.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block25.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block26.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block26.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block27.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block27.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block28.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block28.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block29.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block29.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block30.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block30.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block31.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block31.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block5.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block6.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block7.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block7.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block8.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block9.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Block9.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/BlockN.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/BlockN.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function0.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function0.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function10.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function10.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function11.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function11.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function5.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function6.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function7.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function7.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function8.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function9.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function9.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/FunctionN.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/FunctionN.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/FunctionUtils.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/FunctionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/HashedExpression.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/HashedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/LambdaPrinter.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/LambdaPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Operator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Operator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate10.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate10.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate11.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate11.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate12.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate12.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate13.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate13.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate14.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate14.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate15.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate15.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate16.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate16.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate17.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate17.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate18.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate18.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate5.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate6.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate7.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate7.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate8.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate9.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate9.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateN.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateN.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/ScriptBlock.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/ScriptBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/accumulate/AccumulateFunction.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/accumulate/AccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/accumulate/GroupKey.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/accumulate/GroupKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/AbstractTemporalPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/AbstractTemporalPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/AfterPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/AfterPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/BeforePredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/BeforePredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/CoincidesPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/CoincidesPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/DuringPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/DuringPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/FinishedbyPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/FinishedbyPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/FinishesPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/FinishesPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/IncludesPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/IncludesPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/Interval.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/Interval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/MeetsPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/MeetsPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/MetbyPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/MetbyPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/OverlappedbyPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/OverlappedbyPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/OverlapsPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/OverlapsPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/StartedbyPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/StartedbyPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/StartsPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/StartsPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/TemporalPredicate.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/TemporalPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/TimeUtil.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/temporal/TimeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/AbstractWindow.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/AbstractWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/AnnotationValueImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/AnnotationValueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/DataSourceDefinitionImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/DataSourceDefinitionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/DeclarationImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/DeclarationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/EntryPointImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/EntryPointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Exchange.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Exchange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From0Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From0Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From10Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From10Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From11Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From11Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From1Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From1Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From2Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From2Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From3Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From3Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From4Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From4Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From5Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From5Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From6Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From6Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From7Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From7Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From8Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From8Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From9Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/From9Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/GlobalImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/GlobalImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ModelComponent.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ModelComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ModelImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/NamesGenerator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/NamesGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query0DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query0DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query10DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query10DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query1DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query1DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query2DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query2DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query6DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query6DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query7DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query7DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query8DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query8DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query9DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query9DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/QueryDefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/QueryDefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/QueryImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/QueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/RuleBuilder.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/RuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/RuleImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/RuleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/TupleHandleImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/TupleHandleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/TypeMetaDataImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/TypeMetaDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/UnitDataImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/UnitDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ValueImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ValueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/VariableImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/VariableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ViewBuilder.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ViewBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ViewPatternBuilder.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/ViewPatternBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/WindowImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/WindowImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/WindowReferenceImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/WindowReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/AbstractBetaIndex.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/AbstractBetaIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/AbstractIndex.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/AbstractIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/AlphaIndexImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/AlphaIndexImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/BetaIndex2Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/BetaIndex2Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/BetaIndex3Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/BetaIndex3Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/BetaIndex4Impl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/BetaIndex4Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/BetaIndexImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/index/BetaIndexImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/ContainsOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/ContainsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/ExcludesOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/ExcludesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/InOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/InOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/MatchesOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/MatchesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/MemberOfOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/MemberOfOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/SoundsLikeOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/SoundsLikeOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringEndsWithOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringEndsWithOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringLengthWithOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringLengthWithOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringStartsWithOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringStartsWithOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/AbstractSinglePattern.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/AbstractSinglePattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/AccumulatePatternImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/AccumulatePatternImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/CompositePatterns.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/CompositePatterns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/EvalImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/EvalImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/ExistentialPatternImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/ExistentialPatternImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/GroupByPatternImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/GroupByPatternImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/PatternBuilder.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/PatternBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/PatternImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/PatternImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/QueryCallPattern.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/patterns/QueryCallPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/util/OperatorUtils.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/util/OperatorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/AbstractExprViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/AbstractExprViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/AccumulateExprViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/AccumulateExprViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/BindViewItem1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/BindViewItem1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/BindViewItem2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/BindViewItem2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/BindViewItem3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/BindViewItem3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/BindViewItem4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/BindViewItem4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/CombinedExprViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/CombinedExprViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ExistentialExprViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ExistentialExprViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr10ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr10ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr11ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr11ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr12ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr12ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr13ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr13ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr14ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr14ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr15ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr15ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr16ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr16ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr17ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr17ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr18ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr18ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr1ViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr1ViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr1ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr1ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr2ViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr2ViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr2ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr2ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr3ViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr3ViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr3ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr3ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr4ViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr4ViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr4ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr4ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr5ViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr5ViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr5ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr5ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr6ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr6ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr7ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr7ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr8ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr8ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr9ViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/Expr9ViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ExprNViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ExprNViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ExprViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ExprViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/FixedTemporalExprViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/FixedTemporalExprViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/FixedValueItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/FixedValueItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/GroupByExprViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/GroupByExprViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/InputViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/InputViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/InputViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/InputViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/QueryCallViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/QueryCallViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/QueryCallViewItemImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/QueryCallViewItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/SelfPatternBiding.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/SelfPatternBiding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/TemporalExprViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/TemporalExprViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/VariableTemporalExprViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/VariableTemporalExprViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ViewItem.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ViewItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ViewItemBuilder.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/view/ViewItemBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/test/java/org/drools/model/operators/MatchesOperatorTest.java
+++ b/drools-model/drools-canonical-model/src/test/java/org/drools/model/operators/MatchesOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-canonical-model/src/test/java/org/drools/model/util/OperatorUtilsTest.java
+++ b/drools-model/drools-canonical-model/src/test/java/org/drools/model/util/OperatorUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/AppPaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/DroolsModelApplicationPropertyProvider.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/DroolsModelApplicationPropertyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/DroolsModelBuildContext.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/DroolsModelBuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileType.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileWriter.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/AbstractDroolsModelBuildContext.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/AbstractDroolsModelBuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/JavaDroolsModelBuildContext.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/JavaDroolsModelBuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/QuarkusDroolsModelBuildContext.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/QuarkusDroolsModelBuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/SpringBootDroolsModelBuildContext.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/SpringBootDroolsModelBuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/AppPathsTest.java
+++ b/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/AppPathsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/GeneratedFileWriterTest.java
+++ b/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/GeneratedFileWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/ExecutableModelProject.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/ExecutableModelProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/AccumulateClassWriter.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/AccumulateClassWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/CanonicalModelBuildContext.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/CanonicalModelBuildContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/CanonicalModelKieProject.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/CanonicalModelKieProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/CompositePackageManager.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/CompositePackageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/DeclaredTypeWriter.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/DeclaredTypeWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/GeneratedClassWithPackage.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/GeneratedClassWithPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/JavaParserCompiler.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/JavaParserCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/ModelBuilderImpl.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/ModelBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/ModelSourceClass.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/ModelSourceClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/ModelWriter.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/ModelWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModelManager.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModelManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModelWriter.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModelWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageSourceManager.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageSourceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageSources.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/QueryModel.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/QueryModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/RuleDescrImpl.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/RuleDescrImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/RuleUnitWriter.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/RuleUnitWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/RuleWriter.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/RuleWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/drlx/DrlxAssembler.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/drlx/DrlxAssembler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/drlx/DrlxCompiler.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/drlx/DrlxCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/drlx/DrlxVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/drlx/DrlxVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/CompilationProblemErrorResult.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/CompilationProblemErrorResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/ConsequenceRewriteException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/ConsequenceRewriteException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/DuplicatedDeclarationError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/DuplicatedDeclarationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/GetterOverloadWarning.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/GetterOverloadWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/IncompatibleGetterOverloadError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/IncompatibleGetterOverloadError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/InvalidExpressionErrorResult.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/InvalidExpressionErrorResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/MvelCompilationError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/MvelCompilationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/ParseExpressionErrorResult.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/ParseExpressionErrorResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnknownDeclarationError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnknownDeclarationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnknownDeclarationException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnknownDeclarationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnknownRuleUnitException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnknownRuleUnitException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnsupportedFeatureError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/UnsupportedFeatureError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/VariableUsedInBindingError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/errors/VariableUsedInBindingError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/AggregateKey.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/AggregateKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/BoxedParameters.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/BoxedParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/Consequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/ConstraintUtil.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/ConstraintUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DRLIdGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DRLIdGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DeclarationSpec.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DeclarationSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DslMethodNames.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/DslMethodNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/FunctionGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/FunctionGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/ModelGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/ModelGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/OOPathExprGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/OOPathExprGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/PrototypeDeclarationSpec.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/PrototypeDeclarationSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/QueryGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/QueryGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/QueryParameter.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/QueryParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/TypedDeclarationSpec.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/TypedDeclarationSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/TypedExpression.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/TypedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/UnificationTypedExpression.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/UnificationTypedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/WindowReferenceGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/WindowReferenceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/consequence/BlockGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/consequence/BlockGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/consequence/ConsequenceDSLGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/consequence/ConsequenceDSLGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/consequence/ConsequenceGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/consequence/ConsequenceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/AccessibleMethod.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/AccessibleMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrAnnotationDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrAnnotationDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrFieldDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrFieldDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrTypeDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrTypeDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/EnumGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/EnumGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/POJOGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/POJOGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/UnknownKeysInAnnotation.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/UnknownKeysInAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/UnkownAnnotationClassException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/UnkownAnnotationClassException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/AnnotationDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/AnnotationDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/FieldDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/FieldDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/MethodDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/MethodDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/MethodParameter.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/MethodParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/MethodWithStringBody.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/MethodWithStringBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/SimpleAnnotationDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/SimpleAnnotationDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/TypeDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/TypeDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/TypeResolver.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/api/TypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedClassDeclaration.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedClassDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedConstructor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedEqualsMethod.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedEqualsMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedHashcode.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedHashcode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedToString.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/generator/GeneratedToString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/AbstractDrlxParseSuccess.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/AbstractDrlxParseSuccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/CoercedExpression.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/CoercedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintExpression.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/DrlxParseFail.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/DrlxParseFail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/DrlxParseResult.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/DrlxParseResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/DrlxParseSuccess.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/DrlxParseSuccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/MultipleDrlxParseSuccess.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/MultipleDrlxParseSuccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/NumberAndStringArithmeticOperationCoercion.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/NumberAndStringArithmeticOperationCoercion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ParseResultVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ParseResultVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ParseResultVoidVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/ParseResultVoidVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/SingleDrlxParseSuccess.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/SingleDrlxParseSuccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/SpecialComparisonCase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/drlxparse/SpecialComparisonCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/AbstractExpressionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/EvalExpressionBuilder.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/EvalExpressionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/PatternExpressionBuilder.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expression/PatternExpressionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/CannotTypeExpressionException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/CannotTypeExpressionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyperContext.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/ExpressionTyperContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/FlattenScope.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/FlattenScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/TypedExpressionResult.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/expressiontyper/TypedExpressionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/CustomOperatorSpec.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/CustomOperatorSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/CustomOperatorWrapper.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/CustomOperatorWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/NativeOperatorSpec.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/NativeOperatorSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/OperatorSpec.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/OperatorSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/TemporalOperatorSpec.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/operatorspec/TemporalOperatorSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/FlowDSLQueryGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/FlowDSLQueryGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/Generator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/Generator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/PatternDSLQueryGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/PatternDSLQueryGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/QueryDefGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/QueryDefGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/QueryDefImplGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/QueryDefImplGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/query/QueryGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/AndVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/AndVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/ConditionalElementVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/ConditionalElementVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/DSLNode.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/DSLNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/EvalVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/EvalVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromCollectVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromCollectVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/FromVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/ModelGeneratorVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/ModelGeneratorVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/NamedConsequenceVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/NamedConsequenceVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/OrVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/OrVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateInline.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateInline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateInlineVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateInlineVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/AccumulateVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/GroupByVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/GroupByVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/InvalidInlineTemplateException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/InvalidInlineTemplateException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/LegacyAccumulate.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/LegacyAccumulate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/MissingSemicolonInlineAccumulateException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/MissingSemicolonInlineAccumulateException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/PatternToReplace.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/PatternToReplace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/UnsupportedInlineAccumulate.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/accumulate/UnsupportedInlineAccumulate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/ClassPatternDSL.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/ClassPatternDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/ConstraintOOPath.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/ConstraintOOPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternAccumulateConstraint.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternAccumulateConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternConstraintParseResult.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternConstraintParseResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternDSL.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternDSLSimpleConstraint.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternDSLSimpleConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternVisitor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PatternVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PrototypePatternDSL.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/PrototypePatternDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/Query.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/QueryCall.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/QueryCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/DeclaredTypeCompilationPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/DeclaredTypeCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/DeclaredTypeDeregistrationPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/DeclaredTypeDeregistrationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/DeclaredTypeRegistrationPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/DeclaredTypeRegistrationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/GeneratedPojoCompilationPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/GeneratedPojoCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelGeneratorPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelGeneratorPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelMainCompilationPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelMainCompilationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelRuleValidator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/ModelRuleValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/PojoStoragePhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/PojoStoragePhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/PopulateIncludedRuleNameMapPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/PopulateIncludedRuleNameMapPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/SourceCodeGenerationPhase.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/processors/SourceCodeGenerationPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/LambdaUtil.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/LambdaUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/ParserLogUtils.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/ParserLogUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/PatternUtil.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/PatternUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/CreatedClass.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/CreatedClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/DoNotConvertLambdaException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/DoNotConvertLambdaException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/DroolsNeededInConsequenceException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/DroolsNeededInConsequenceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/ExecModelLambdaPostProcessor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/ExecModelLambdaPostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/LambdaTypeNeededException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/LambdaTypeNeededException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambda.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaConsequence.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaConsequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaExtractor.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaPredicate.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/NonExternalisedLambdaFoundException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/NonExternalisedLambdaFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/NotLambdaException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/NotLambdaException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/ReplaceTypeInLambda.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/util/lambdareplace/ReplaceTypeInLambda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/CodegenPackageSources.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/CodegenPackageSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/DroolsModelBuilder.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/DroolsModelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/KieModuleModelWrapper.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/KieModuleModelWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/KieSessionModelBuilder.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/KieSessionModelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/MissingDecisionTableDependencyError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/MissingDecisionTableDependencyError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/ProjectRuntimeGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/ProjectRuntimeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/RuleCodegen.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/RuleCodegen.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/RuleCodegenError.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/RuleCodegenError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/template/InvalidTemplateException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/template/InvalidTemplateException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/template/TemplateInstantiationException.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/template/TemplateInstantiationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/template/TemplatedGenerator.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/project/template/TemplatedGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/tool/ExplicitCanonicalModelCompiler.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/tool/ExplicitCanonicalModelCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/AccumulateInlineTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/AccumulateInlineTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/BlockTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/BlockTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/ConsequenceBuilderTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/ConsequenceBuilderTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/RuleUnitInstanceTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/RuleUnitInstanceTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/config/RuleConfigJavaTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/config/RuleConfigJavaTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/config/RuleConfigQuarkusTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/config/RuleConfigQuarkusTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/config/RuleConfigSpringTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/config/RuleConfigSpringTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/rules/ProjectRuntimeJavaTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/rules/ProjectRuntimeJavaTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/rules/ProjectRuntimeQuarkusTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/rules/ProjectRuntimeQuarkusTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/rules/ProjectRuntimeSpringTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/rules/ProjectRuntimeSpringTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RuleUnitJavaTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RuleUnitJavaTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RuleUnitQuarkusTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RuleUnitQuarkusTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RuleUnitSpringTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RuleUnitSpringTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/compiler/rule/builder/util/ConstraintTestUtil.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/compiler/rule/builder/util/ConstraintTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BaseModelTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BaseModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BetaConditionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BetaConditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BigPojoExecModelGenerationTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BigPojoExecModelGenerationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BindingTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BindingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BuildFromDescrTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BuildFromDescrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BuildFromKJarTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/BuildFromKJarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CepTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ChannelTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ChannelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CompilationFailuresTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CompilationFailuresTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CompilerTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ComplexRulesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ComplexRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ConditionalExprTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ConditionalExprTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ConstraintNormalizationTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ConstraintNormalizationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ConstraintTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ConstraintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CustomConstraintOperatorTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CustomConstraintOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DataType.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DataType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypeDifferentKJarIncludesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypeDifferentKJarIncludesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DowncastTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DowncastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DroolsContextTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DroolsContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/EnumTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/EnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/EvalTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/EvalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ExisistentialTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ExisistentialTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ExternalisedLambdaTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ExternalisedLambdaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/FromTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/FromTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/FunctionsTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/FunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GeneratedClassNamesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GeneratedClassNamesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GenericsTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GenericsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GetterOverloadingTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GetterOverloadingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GlobalTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GlobalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GroupByTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GroupByTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/HalfBinaryTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/HalfBinaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/HierarchyRulesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/HierarchyRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/InTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/InTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/IncrementalCompilationTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/IncrementalCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/IndexTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/IndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/InternalMatchGroupTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/InternalMatchGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KJARUtils.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KJARUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KieBaseBuilderTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KieBaseBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KieBuilderTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KieBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KjarBuildTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/KjarBuildTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ListenersTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ListenersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ManyArgumentTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ManyArgumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MapInitializationDrools3800Test.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MapInitializationDrools3800Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MaterializedLambdaTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MaterializedLambdaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MixedArgumentTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MixedArgumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ModelBuilderImplTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ModelBuilderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ModelSourceClassTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ModelSourceClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MultiKieBaseTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MultiKieBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MvelDialectMapTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MvelDialectMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MvelDialectTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MvelDialectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MvelOperatorsTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/MvelOperatorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NamedConsequencesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NamedConsequencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NativeCompilerTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NativeCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NodeSharingTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NodeSharingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NullSafeDereferencingTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NullSafeDereferencingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NumberAndStringArithmeticOperationCoercionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/NumberAndStringArithmeticOperationCoercionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/OOPathTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/OOPathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/OnlyExecModelTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/OnlyExecModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/OnlyPatternTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/OnlyPatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/OrTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/OrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PackagesIsolationTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PackagesIsolationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PrimitiveConversionErrorsTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PrimitiveConversionErrorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PropertyReactivityMatrixTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PropertyReactivityMatrixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PropertyReactivityTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PropertyReactivityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PrototypeTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PrototypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PrototypesAllowedTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/PrototypesAllowedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/QueryTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/QueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ReteDumper.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ReteDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/RuleAttributesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/RuleAttributesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/SegmentPrototypeExpressionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/SegmentPrototypeExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TextBlockTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TextBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ToStringTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/ToStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TypeCoercionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TypeCoercionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TypeDeclarationTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TypeDeclarationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TypeObjectCoercionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/TypeObjectCoercionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/UseClassFieldsInRulesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/UseClassFieldsInRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/alphaNetworkCompiler/ObjectTypeNodeCompilerTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/alphaNetworkCompiler/ObjectTypeNodeCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/assembler/AssemblerTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/assembler/AssemblerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/assembler/TestAssembler.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/assembler/TestAssembler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/benchmark/BenchmarkMain.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/benchmark/BenchmarkMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/benchmark/BenchmarkUtil.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/benchmark/BenchmarkUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/benchmark/BuildFromKJarBenchmark.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/benchmark/BuildFromKJarBenchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/benchmark/KJarWithKnowledgeFiles.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/benchmark/KJarWithKnowledgeFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigdecimaltest/BDFact.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigdecimaltest/BDFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigdecimaltest/BigDecimalTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigdecimaltest/BigDecimalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigdecimaltest/Customer.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigdecimaltest/Customer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigdecimaltest/Policy.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigdecimaltest/Policy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigintegertest/BIFact.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigintegertest/BIFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigintegertest/BigIntegerTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigintegertest/BigIntegerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigintegertest/Customer.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigintegertest/Customer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigintegertest/Policy.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/bigintegertest/Policy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/constraints/ConstraintEvaluationExceptionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/constraints/ConstraintEvaluationExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Address.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Adult.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Adult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/CalcFact.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/CalcFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Cheese.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Child.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Child.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactComplex.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactComplex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithEnum1.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithEnum1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithEnum2.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithEnum2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithEnum3.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithEnum3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithFirings1.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithFirings1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithId1.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithId1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithId2.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithId2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithId3.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithId3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithObject.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ChildFactWithObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Counter.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Counter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Customer.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Customer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/DateTimeHolder.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/DateTimeHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Employee.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Employee.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/EnumFact1.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/EnumFact1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/EnumFact2.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/EnumFact2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/InputDataTypes.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/InputDataTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/InterfaceAsEnum.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/InterfaceAsEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/InternationalAddress.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/InternationalAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Man.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Man.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ManyPropFact.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ManyPropFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/MysteriousMan.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/MysteriousMan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Overloaded.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Overloaded.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Parent.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Parent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Person.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Pet.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Pet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/PetPerson.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/PetPerson.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Relationship.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Relationship.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Result.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/RootFact.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/RootFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/SimpleDateHolder.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/SimpleDateHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/StockFact.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/StockFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/StockTick.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/StockTick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/StockTickEx.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/StockTickEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/SubFact.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/SubFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/TargetPolicy.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/TargetPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Toy.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Toy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ToysStore.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ToysStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ValueHolder.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/ValueHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/VariousCasePropFact.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/VariousCasePropFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Woman.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/domain/Woman.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/drlx/DrlxCompilerTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/drlx/DrlxCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/drlx/Example.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/drlx/Example.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/exchange/SendReceiveTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/exchange/SendReceiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/CompilerTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/CompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/FireAndAlarmTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/FireAndAlarmTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/FireAndAlarmUsingDroolsTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/FireAndAlarmUsingDroolsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/model/Alarm.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/model/Alarm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/model/Fire.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/model/Fire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/model/Room.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/model/Room.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/model/Sprinkler.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/fireandalarm/model/Sprinkler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/ConsequenceTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/ConsequenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/ConstraintTestUtil.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/ConstraintTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
 e * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtilTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/DrlxParseUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/ExpressionTyperTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/ExpressionTyperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/FlattenScopeTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/FlattenScopeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/GeneratedClassDeclarationTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/GeneratedClassDeclarationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/StringUtilTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/StringUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/drlxparse/CoercedExpressionTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/drlxparse/CoercedExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParserTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/generator/drlxparse/ConstraintParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICA.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICAbstractA.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICAbstractA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICAbstractB.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICAbstractB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICAbstractC.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICAbstractC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICB.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICC.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/ICC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/InlineCastTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/inlinecast/InlineCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/oopathdtables/Address.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/oopathdtables/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/oopathdtables/InternationalAddress.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/oopathdtables/InternationalAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/oopathdtables/Person.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/oopathdtables/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/BaseOperatorsTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/BaseOperatorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/DateOperatorTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/DateOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/EqualityComparisonTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/EqualityComparisonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/EqualityComparisonWith2PropertiesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/EqualityComparisonWith2PropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/ValueHolder.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/ValueHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/ValueHolderWith2Properties.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/operators/ValueHolderWith2Properties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/LambdaUtilTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/LambdaUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/TrackingAgendaEventListener.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/TrackingAgendaEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaConsequenceTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaConsequenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaExtractorTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaPredicateTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaPredicateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaTestUtils.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/util/lambdareplace/MaterializedLambdaTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/variables/Result.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/variables/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/variables/SimpleObject.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/variables/SimpleObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/variables/VariablesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/variables/VariablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/RuleCodegenTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/RuleCodegenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/data/Address.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/data/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/data/Person.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/data/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/data/Result.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/data/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/data/Results.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/data/Results.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/ruleunits/RuleUnitWriterTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/ruleunits/RuleUnitWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/wiring/api/classloader/ProjectClassLoaderTestUtil.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/wiring/api/classloader/ProjectClassLoaderTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/resources/model/Child.java
+++ b/drools-model/drools-model-codegen/src/test/resources/model/Child.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/resources/model/Person.java
+++ b/drools-model/drools-model-codegen/src/test/resources/model/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/resources/org/drools/model/codegen/execmodel/util/lambdareplace/FlowConsequenceTestHarness.java
+++ b/drools-model/drools-model-codegen/src/test/resources/org/drools/model/codegen/execmodel/util/lambdareplace/FlowConsequenceTestHarness.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/resources/org/drools/model/codegen/execmodel/util/lambdareplace/PatternTestHarness.java
+++ b/drools-model/drools-model-codegen/src/test/resources/org/drools/model/codegen/execmodel/util/lambdareplace/PatternTestHarness.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/resources/unit1/AdultUnit.java
+++ b/drools-model/drools-model-codegen/src/test/resources/unit1/AdultUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/resources/unit2/AdultUnit.java
+++ b/drools-model/drools-model-codegen/src/test/resources/unit2/AdultUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/resources/unit3/AdultUnit.java
+++ b/drools-model/drools-model-codegen/src/test/resources/unit3/AdultUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-codegen/src/test/resources/unit4/AdultUnit.java
+++ b/drools-model/drools-model-codegen/src/test/resources/unit4/AdultUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalInternalKieModule.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalInternalKieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieBaseUpdater.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieBaseUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModuleModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModuleModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModuleProvider.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModuleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKiePackages.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKiePackages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KieBaseBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KieBaseBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KiePackagesBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KiePackagesBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/PrototypeService.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/PrototypeService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/RuleContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/attributes/DynamicAttributeEvaluator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/attributes/DynamicAttributeEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/attributes/LambdaEnabled.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/attributes/LambdaEnabled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/attributes/LambdaSalience.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/attributes/LambdaSalience.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/ChannelImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/ChannelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/DroolsEntryPointImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/DroolsEntryPointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/DroolsImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/DroolsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/FactHandleLookup.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/FactHandleLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/AbstractConstraint.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/AbstractConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/BindingEvaluator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/BindingEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/BindingInnerObjectEvaluator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/BindingInnerObjectEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/CombinedConstraint.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/CombinedConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/ConstraintEvaluationException.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/ConstraintEvaluationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/ConstraintEvaluator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/ConstraintEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/GenericCollectAccumulator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/GenericCollectAccumulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaAccumulator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaAccumulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaDataProvider.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaEvalExpression.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaEvalExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaFieldReader.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaGroupByAccumulate.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaGroupByAccumulate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaReadAccessor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaReadAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/SupplierDataProvider.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/SupplierDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/TemporalConstraintEvaluator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/TemporalConstraintEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/UnificationConstraint.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/UnificationConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/dsl/pattern/D.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/dsl/pattern/D.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/ClassUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/ClassUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/EvaluationUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/EvaluationUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/StringUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/StringUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/TimerUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/TimerUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/TypeDeclarationUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/TypeDeclarationUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/KieBaseBuilderTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/KieBaseBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright
  * ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the
  * License at

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PatternDSLTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PatternDSLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Address.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Adult.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Adult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Child.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Child.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Man.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Man.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Pair.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Pair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Person.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Relationship.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Relationship.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Result.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/StockFact.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/StockFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/StockTick.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/StockTick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Toy.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Toy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Woman.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Woman.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/PrototypeDSL.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/PrototypeDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/PrototypeExpression.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/PrototypeExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/PrototypeVariable.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/PrototypeVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/HashMapEventImpl.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/HashMapEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/HashMapFactImpl.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/HashMapFactImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeBuilderImpl.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeEventImpl.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeFactImpl.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeFactImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeImpl.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeServiceImpl.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeVariableImpl.java
+++ b/drools-model/drools-model-prototype/src/main/java/org/drools/model/prototype/impl/PrototypeVariableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-model-prototype/src/test/java/org/drools/model/prototype/PrototypeFieldExtractorTest.java
+++ b/drools-model/drools-model-prototype/src/test/java/org/drools/model/prototype/PrototypeFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvel2/CompiledJavaEvaluator.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvel2/CompiledJavaEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledBlockResult.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledBlockResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledExpressionResult.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledExpressionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledResult.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ConstraintCompiler.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ConstraintCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MethodCallExprVisitor.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MethodCallExprVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompiler.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompilerException.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompilerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/PreprocessCompiler.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/PreprocessCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/PreprocessPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/PreprocessPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ReProcessRHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ReProcessRHSPhase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/StatementVisitor.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/StatementVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/AssignExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/AssignExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalArithmeticExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalArithmeticExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalConvertedExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalConvertedExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalRelationalExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalRelationalExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigIntegerArithmeticExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigIntegerArithmeticExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigIntegerConvertedExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigIntegerConvertedExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigIntegerRelationalExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigIntegerRelationalExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BinaryExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BinaryExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BlockStmtT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BlockStmtT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BooleanLiteralExpressionT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BooleanLiteralExpressionT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/CastExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/CastExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/CharacterLiteralExpressionT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/CharacterLiteralExpressionT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/DoStmtT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/DoStmtT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/DoubleLiteralExpressionT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/DoubleLiteralExpressionT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ExpressionStmtT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ExpressionStmtT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/FieldAccessTExpr.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/FieldAccessTExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/FieldToAccessorTExpr.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/FieldToAccessorTExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ForEachDowncastStmtT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ForEachDowncastStmtT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ForEachStmtT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ForEachStmtT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ForStmtT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ForStmtT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/IfStmtT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/IfStmtT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/IntegerLiteralExpressionT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/IntegerLiteralExpressionT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ListAccessExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ListAccessExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ListExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ListExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/LongLiteralExpressionT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/LongLiteralExpressionT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MapExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MapExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MapGetExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MapGetExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MapPutExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MapPutExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MethodCallExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MethodCallExprT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ObjectCreationExpressionT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ObjectCreationExpressionT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/RootTypeThisExpr.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/RootTypeThisExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/SimpleNameTExpr.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/SimpleNameTExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/StringLiteralExpressionT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/StringLiteralExpressionT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/SwitchEntryT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/SwitchEntryT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/SwitchStmtT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/SwitchStmtT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/TypedExpression.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/TypedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/UnalteredTypedExpression.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/UnalteredTypedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/VariableDeclaratorTExpr.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/VariableDeclaratorTExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/WhileStmtT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/WhileStmtT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/Declaration.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/Declaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/DeclaredFunction.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/DeclaredFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/MvelCompilerContext.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/MvelCompilerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/StaticMethod.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/StaticMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/BigNumberArgumentCoercion.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/BigNumberArgumentCoercion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/CoercionUtils.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/CoercionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/MethodResolutionUtils.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/MethodResolutionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/OptionalUtils.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/OptionalUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/TypeUtils.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/TypeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/VisitorContext.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/VisitorContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/main/resources/org/drools/mvel/EvaluatorTemplate.java
+++ b/drools-model/drools-mvel-compiler/src/main/resources/org/drools/mvel/EvaluatorTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/Address.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/Gender.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/Gender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/Person.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/ArithmeticTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/ArithmeticTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Bar.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Bar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Base.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Base.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/CompiledExpression.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/CompiledExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/DerivedClass.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/DerivedClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Evaluator.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Evaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/EvaluatorGenerator.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/EvaluatorGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Foo.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Foo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/MVEL.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/MVEL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/MyEnum.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/MyEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/SampleBean.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/SampleBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/TestInterface.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/TestInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Thing.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvel/Thing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/CompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/CompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ConstraintCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ConstraintCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/PreprocessCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/PreprocessCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/util/MethodResolutionUtilsTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/util/MethodResolutionUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/DrlxParser.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/DrlxParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/JavaToken.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/JavaToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ParseStart.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ParseStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/Providers.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/Providers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigDecimalLiteralExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigDecimalLiteralExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigIntegerLiteralExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigIntegerLiteralExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/DrlNameExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/DrlNameExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/DrlxExpression.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/DrlxExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/FullyQualifiedInlineCastExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/FullyQualifiedInlineCastExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/HalfBinaryExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/HalfBinaryExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/HalfPointFreeExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/HalfPointFreeExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/InlineCastExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/InlineCastExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/ListCreationLiteralExpression.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/ListCreationLiteralExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/ListCreationLiteralExpressionElement.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/ListCreationLiteralExpressionElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/MapCreationLiteralExpression.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/MapCreationLiteralExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/MapCreationLiteralExpressionKeyValuePair.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/MapCreationLiteralExpressionKeyValuePair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/ModifyStatement.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/ModifyStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/NullSafeFieldAccessExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/NullSafeFieldAccessExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/NullSafeMethodCallExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/NullSafeMethodCallExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/OOPathChunk.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/OOPathChunk.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/OOPathExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/OOPathExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/PointFreeExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/PointFreeExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleBody.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleConsequence.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleConsequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleDeclaration.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleItem.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleJoinedPatterns.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleJoinedPatterns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RulePattern.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RulePattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalChunkExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalChunkExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalLiteralArguments.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalLiteralArguments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalLiteralChunkExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalLiteralChunkExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalLiteralExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalLiteralExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalLiteralInfiniteChunkExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/TemporalLiteralInfiniteChunkExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/WithStatement.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/WithStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlCloneVisitor.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlCloneVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlGenericVisitor.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlGenericVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlVoidVisitor.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/visitor/DrlVoidVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/printer/ConstraintPrintVisitor.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/printer/ConstraintPrintVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/printer/PrintUtil.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/printer/PrintUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/utils/AstUtils.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/utils/AstUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/GeneratedMvelParserBase.java
+++ b/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/GeneratedMvelParserBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/GeneratedMvelParserTokenManagerBase.java
+++ b/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/GeneratedMvelParserTokenManagerBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/ModifierHolder.java
+++ b/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/ModifierHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/RangedList.java
+++ b/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/RangedList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/TokenBase.java
+++ b/drools-model/drools-mvel-parser/src/main/javacc-support/org/drools/mvel/parser/TokenBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DrlxParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DrlxParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/ASMConditionEvaluatorJitter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/ASMConditionEvaluatorJitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/ConditionAnalyzer.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/ConditionAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/ConditionEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/ConditionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/ConstraintEvaluationException.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/ConstraintEvaluationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/DrlDumper.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/DrlDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/EvaluatorConstraint.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/EvaluatorConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/EvaluatorHelper.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/EvaluatorHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConditionEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConditionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraintBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraintBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELCoreComponentFactory.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELCoreComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELCoreComponentsBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELCoreComponentsBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELDialectRuntimeData.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELDialectRuntimeData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELGroupByAccumulate.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELGroupByAccumulate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELKnowledgePackageImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELKnowledgePackageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELSafeHelper.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELSafeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/SessionReporter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/SessionReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/UnsafeMVELEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/UnsafeMVELEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseBooleanClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseBooleanClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseBooleanClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseBooleanClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseByteClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseByteClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseByteClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseByteClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseCharClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseCharClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseCharClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseCharClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseDateClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseDateClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseDoubleClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseDoubleClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseDoubleClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseDoubleClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseFloatClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseFloatClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseFloatClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseFloatClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseIntClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseIntClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseIntClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseIntClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseLocalDateClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseLocalDateClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseLocalDateTimeClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseLocalDateTimeClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseLongClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseLongClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseLongClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseLongClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseNumberClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseNumberClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseObjectClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseObjectClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseShortClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseShortClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseShortClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseShortClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseZonedDateTimeClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/BaseZonedDateTimeClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/ClassFieldAccessor.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/ClassFieldAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/ClassFieldAccessorStore.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/ClassFieldAccessorStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/ClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/ClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/accessors/ClassFieldWriter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/accessors/ClassFieldWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ASMConsequenceBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ASMConsequenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ASMConsequenceStubBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ASMConsequenceStubBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ASMEvalStubBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ASMEvalStubBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/AbstractASMConsequenceBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/AbstractASMConsequenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/AbstractASMEvalBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/AbstractASMEvalBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/AsmUtil.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/AsmUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ClassFieldAccessorFactory.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ClassFieldAccessorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ClassFieldInspectorImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ClassFieldInspectorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ClassGenerator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ClassGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ClassLevel.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ClassLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ConsequenceGenerator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ConsequenceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ConsequenceStub.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ConsequenceStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/DefaultBeanClassBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/DefaultBeanClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/DefaultClassBuilderFactory.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/DefaultClassBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/DefaultEnumClassBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/DefaultEnumClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/DumpMethodVisitor.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/DumpMethodVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/EvalGenerator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/EvalGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/EvalStub.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/EvalStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/GeneratorHelper.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/GeneratorHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/InvokerContext.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/InvokerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/InvokerDataProvider.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/InvokerDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/InvokerGenerator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/InvokerGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/InvokerStub.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/InvokerStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/KnowledgeHelperFixer.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/KnowledgeHelperFixer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/LambdaIntrospector.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/LambdaIntrospector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/MethodComparator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/MethodComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ReturnValueGenerator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ReturnValueGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ReturnValueStub.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ReturnValueStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELAccumulateBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELAccumulateBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELAnalysisResult.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELAnalysisResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELBeanCreator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELBeanCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELConsequenceBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELConsequenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELDialect.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELDialect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELDialectConfiguration.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELDialectConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELEnabledBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELEnabledBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELEvalBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELEvalBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELExprAnalyzer.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELExprAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELFromBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELFromBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELGroupByBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELGroupByBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELObjectExpressionBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELObjectExpressionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/builder/MVELSalienceBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/builder/MVELSalienceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/dataproviders/ArrayIterator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/dataproviders/ArrayIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/dataproviders/MVELDataProvider.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/dataproviders/MVELDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/dataproviders/ReactiveMVELDataProvider.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/dataproviders/ReactiveMVELDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/AfterEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/AfterEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/BaseEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/BaseEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/BeforeEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/BeforeEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/CoincidesEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/CoincidesEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/DuringEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/DuringEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/EvaluatorCache.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/EvaluatorCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/FinishedByEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/FinishedByEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/FinishesEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/FinishesEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/IncludesEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/IncludesEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/MatchesEvaluatorsDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/MatchesEvaluatorsDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/MeetsEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/MeetsEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/MetByEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/MetByEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/MvelEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/MvelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/OverlappedByEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/OverlappedByEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/OverlapsEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/OverlapsEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/PointInTimeEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/PointInTimeEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/SetEvaluatorsDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/SetEvaluatorsDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/SoundslikeEvaluatorsDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/SoundslikeEvaluatorsDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/StartedByEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/StartedByEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/StartsEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/StartsEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/StrEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/StrEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/VariableRestriction.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/VariableRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/ActivationPropertyHandler.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/ActivationPropertyHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELAccumulator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELAccumulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELAccumulatorFunctionExecutor.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELAccumulatorFunctionExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELCalendarCoercion.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELCalendarCoercion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELCompilationUnit.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELCompilationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELCompileable.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELCompileable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELConsequence.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELConsequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELDateCoercion.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELDateCoercion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELDebugHandler.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELDebugHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELEnabledExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELEnabledExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELEvalExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELEvalExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELObjectExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELObjectExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELReturnValueExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELReturnValueExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELSalienceExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELSalienceExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MvelEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MvelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/extractors/MVELClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/extractors/MVELClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/extractors/MVELDateClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/extractors/MVELDateClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/extractors/MVELNumberClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/extractors/MVELNumberClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/extractors/MVELObjectClassFieldReader.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/extractors/MVELObjectClassFieldReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/field/BooleanFieldImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/field/BooleanFieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/field/ClassFieldImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/field/ClassFieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/field/DoubleFieldImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/field/DoubleFieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/field/FieldDataFactory.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/field/FieldDataFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/field/FieldFactory.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/field/FieldFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/field/IntegerFieldImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/field/IntegerFieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/field/LongFieldImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/field/LongFieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaAccumulateBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaAccumulateBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaAnalysisResult.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaAnalysisResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaDialect.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaDialect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaDialectError.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaDialectError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaDialectSession.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaDialectSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaExprAnalyzer.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaExprAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaForMvelDialectConfiguration.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaForMvelDialectConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaFunctionBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaFunctionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaGroupByBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaGroupByBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/JavaRuleBuilderHelper.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/JavaRuleBuilderHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/java/PackageStore.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/java/PackageStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/util/MVELEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/util/MVELEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/main/java/org/drools/mvel/util/RawMVELEvaluator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/util/RawMVELEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/BuildUtilsTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/BuildUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/CommonTestMethodBase.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/CommonTestMethodBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/MVELCalendarCoercionTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/MVELCalendarCoercionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/MVELConstraintTestUtil.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/MVELConstraintTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/MVELDateCoercionTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/MVELDateCoercionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/asm/ClassFieldInspectorTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/asm/ClassFieldInspectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/asm/KnowledgeHelperFixerTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/asm/KnowledgeHelperFixerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/asm/LambdaIntrospectorTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/asm/LambdaIntrospectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/asm/MethodComparerTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/asm/MethodComparerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/Address.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/Cheese.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/Option.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/Option.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/Person.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/PersonInterface.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/PersonInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/Pet.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/Pet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/asm/ClassGeneratorTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/asm/ClassGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/asm/InvokerGeneratorTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/asm/InvokerGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaAccumulateBuilderTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaAccumulateBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaConsequenceBuilderPRAlwaysTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaConsequenceBuilderPRAlwaysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaConsequenceBuilderTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaConsequenceBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaExprAnalyzerTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaExprAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaForMvelDialectConfigurationTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaForMvelDialectConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/InstrumentedDeclarationScopeResolver.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/InstrumentedDeclarationScopeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELAccumulateBuilderTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELAccumulateBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELConsequenceBuilderTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELConsequenceBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELDebugTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELDebugTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELEvalBuilderTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELEvalBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELExprAnalyzerTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELExprAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELSalienceBuilderTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELSalienceBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/evaluators/TemporalEvaluatorFactoryTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/evaluators/TemporalEvaluatorFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/field/FieldFactoryTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/field/FieldFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/field/FieldValueTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/field/FieldValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/integrationtests/IteratorToList.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/integrationtests/IteratorToList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/integrationtests/LogicTransformerTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/integrationtests/LogicTransformerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-mvel/src/test/java/org/drools/mvel/integrationtests/SerializationHelper.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/integrationtests/SerializationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/OrderedTransactionSynchronization.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/OrderedTransactionSynchronization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/PersistenceContext.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/PersistenceContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/PersistenceContextManager.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/PersistenceContextManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/PersistentSession.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/PersistentSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/PersistentWorkItem.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/PersistentWorkItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/SessionNotFoundException.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/SessionNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionAware.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionManager.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionManagerFactory.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionManagerHelper.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionManagerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionSynchronization.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionSynchronization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionSynchronizationContainer.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionSynchronizationContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionSynchronizationRegistryHelper.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/TransactionSynchronizationRegistryHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/Transformable.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/api/Transformable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManagerFactory.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionSynchronizationAdapter.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionSynchronizationAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/TransactionLockInterceptor.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/TransactionLockInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/processinstance/InternalWorkItemManager.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/processinstance/InternalWorkItemManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/PersistableRunner.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/PersistableRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/SessionMarshallingHelper.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/SessionMarshallingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/TriggerUpdateTransactionSynchronization.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/TriggerUpdateTransactionSynchronization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/info/SessionInfo.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/info/SessionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/info/WorkItemInfo.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/info/WorkItemInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/AbstractPersistenceContextManager.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/AbstractPersistenceContextManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JDKCallableJobCommand.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JDKCallableJobCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaJDKTimerService.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaJDKTimerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContext.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaTimeJobFactoryManager.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaTimeJobFactoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaTimerJobInstance.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaTimerJobInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/KnowledgeStoreServiceImpl.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/KnowledgeStoreServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/OptimisticLockRetryInterceptor.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/OptimisticLockRetryInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/EntityPersister.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/EntityPersister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/JPAPlaceholderResolverStrategy.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/JPAPlaceholderResolverStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/MappedVariable.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/MappedVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/VariableEntity.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/VariableEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/processinstance/JPAWorkItemManager.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/processinstance/JPAWorkItemManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/processinstance/JPAWorkItemManagerFactory.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/processinstance/JPAWorkItemManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/EnvironmentBuilder.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/EnvironmentBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/KnowledgeSessionStorage.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/KnowledgeSessionStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/KnowledgeSessionStorageEnvironmentBuilder.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/KnowledgeSessionStorageEnvironmentBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/ManualTransactionManager.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/ManualTransactionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/MapBasedPersistenceContext.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/MapBasedPersistenceContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/MapPersistenceContextManager.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/MapPersistenceContextManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/NonTransactionalPersistentSession.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/map/NonTransactionalPersistentSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/TransactionManagerFactoryTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/TransactionManagerFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/command/MoreBatchExecutionPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/command/MoreBatchExecutionPersistenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/command/SimpleBatchExecutionPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/command/SimpleBatchExecutionPersistenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerFactoryTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/TransactionTestObject.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/TransactionTestObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/kie/persistence/session/JpaPersistentStatefulSessionTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/kie/persistence/session/JpaPersistentStatefulSessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/kie/persistence/session/PersistentSessionForallTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/kie/persistence/session/PersistentSessionForallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/Buddy.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/Buddy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/JpaBasedPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/JpaBasedPersistenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapBasedPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapBasedPersistenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapPersistenceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapPersistenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/monitoring/MonitoringWithJPAKnowledgeServiceTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/monitoring/MonitoringWithJPAKnowledgeServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/AgendaRuleFlowGroupsTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/AgendaRuleFlowGroupsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaOptLockPersistentStatefulSessionTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaOptLockPersistentStatefulSessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaPersistentStatefulSessionTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaPersistentStatefulSessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/timer/integrationtests/TimerAndCalendarTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/timer/integrationtests/TimerAndCalendarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/util/DroolsPersistenceUtil.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/util/DroolsPersistenceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-deployment/src/main/java/org/drools/quarkus/deployment/DroolsAssetsProcessor.java
+++ b/drools-quarkus-extension/drools-quarkus-deployment/src/main/java/org/drools/quarkus/deployment/DroolsAssetsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/deployment/BuildItemsTest.java
+++ b/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/deployment/BuildItemsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/deployment/NoDrlTest.java
+++ b/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/deployment/NoDrlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/ASubclassOfMeasurement.java
+++ b/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/ASubclassOfMeasurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/Measurement.java
+++ b/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/MyImplementation.java
+++ b/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/MyImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/MyInterface.java
+++ b/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/MyInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/MyUnusedClass.java
+++ b/drools-quarkus-extension/drools-quarkus-deployment/src/test/java/org/drools/quarkus/examples/otn/model/MyUnusedClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/FirstUnit.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/FirstUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleInput.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleOutput1.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleOutput1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleOutput2.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/RuleOutput2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/SecondUnit.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/main/java/org/drools/quarkus/ruleunit/examples/multiunit/SecondUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/test/java/org/drools/quarkus/ruleunit/examples/multiunit/RuntimeTest.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/src/test/java/org/drools/quarkus/ruleunit/examples/multiunit/RuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/Adaptor.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/Adaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/Alert.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/Alert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/AlertingUnit.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/AlertingUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/Event.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/Event.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/EventDeserializer.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/java/org/drools/quarkus/ruleunit/examples/reactive/EventDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/test/java/org/drools/quarkus/ruleunit/examples/reactive/KafkaTestResourceLifecycleManager.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/test/java/org/drools/quarkus/ruleunit/examples/reactive/KafkaTestResourceLifecycleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/test/java/org/drools/quarkus/ruleunit/examples/reactive/RuntimeTest.java
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/test/java/org/drools/quarkus/ruleunit/examples/reactive/RuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/src/main/java/org/drools/quarkus/test/hotreload/FindAdultEndpoint.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/src/main/java/org/drools/quarkus/test/hotreload/FindAdultEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/src/main/java/org/drools/quarkus/test/hotreload/Person.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/src/main/java/org/drools/quarkus/test/hotreload/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/src/test/java/org/drools/quarkus/test/hotreload/HotReloadIT.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/src/test/java/org/drools/quarkus/test/hotreload/HotReloadIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/main/java/org/drools/quarkus/test/kmodule/ProbeCounter.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/main/java/org/drools/quarkus/test/kmodule/ProbeCounter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/main/java/org/drools/quarkus/test/kmodule/ProbeEvent.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/main/java/org/drools/quarkus/test/kmodule/ProbeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/main/java/org/drools/quarkus/test/kmodule/StockTick.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/main/java/org/drools/quarkus/test/kmodule/StockTick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/main/java/org/drools/quarkus/test/kmodule/TestableResource.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/main/java/org/drools/quarkus/test/kmodule/TestableResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/test/java/org/drools/quarkus/test/TestableIT.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/src/test/java/org/drools/quarkus/test/TestableIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-dep/src/main/java/org/drools/quarkus/test/multimodule/dep/Person.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-dep/src/main/java/org/drools/quarkus/test/multimodule/dep/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-main/src/test/java/org/drools/quarkus/test/multimodule/main/RuntimeTest.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-main/src/test/java/org/drools/quarkus/test/multimodule/main/RuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test/src/main/java/org/drools/quarkus/test/Person.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test/src/main/java/org/drools/quarkus/test/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test/src/main/java/org/drools/quarkus/test/Result.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test/src/main/java/org/drools/quarkus/test/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-integration-test/src/test/java/org/drools/quarkus/test/RuntimeTest.java
+++ b/drools-quarkus-extension/drools-quarkus-integration-test/src/test/java/org/drools/quarkus/test/RuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/HomeAlertsBean.java
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/HomeAlertsBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/HomeRuleUnitData.java
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/HomeRuleUnitData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/model/Alert.java
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/model/Alert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/model/CCTV.java
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/model/CCTV.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/model/Light.java
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/model/Light.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/model/Smartphone.java
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/src/main/java/org/drools/quarkus/quickstart/test/model/Smartphone.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/src/test/java/org/drools/quarkus/quickstart/test/BeanTest.java
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/src/test/java/org/drools/quarkus/quickstart/test/BeanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/src/test/java/org/drools/quarkus/quickstart/test/RuntimeIT.java
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/src/test/java/org/drools/quarkus/quickstart/test/RuntimeIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/main/java/org/drools/quarkus/ruleunit/test/HelloWorldUnit.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/main/java/org/drools/quarkus/ruleunit/test/HelloWorldUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/main/java/org/drools/quarkus/ruleunit/test/SimpleDTUnit.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/main/java/org/drools/quarkus/ruleunit/test/SimpleDTUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/main/java/org/drools/quarkus/ruleunit/test/TestableResource.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/main/java/org/drools/quarkus/ruleunit/test/TestableResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/RuntimeDslRuleUnitTest.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/RuntimeDslRuleUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/RuntimeTest.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/RuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/TestableIT.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/src/test/java/org/drools/quarkus/ruleunit/test/TestableIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunits-deployment/src/main/java/org/drools/quarkus/deployment/ruleunit/DroolsAssetsProcessor.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits-deployment/src/main/java/org/drools/quarkus/deployment/ruleunit/DroolsAssetsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/FirstUnit.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/FirstUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/RuleInput.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/RuleInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/RuleOutput1.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/RuleOutput1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/RuleOutput2.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/RuleOutput2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/SecondUnit.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits/src/main/codestarts/quarkus/drools-quarkus-ruleunits-codestart/java/src/main/java/org/acme/SecondUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/AbstractCompilationProvider.java
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/AbstractCompilationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/AbstractDroolsAssetsProcessor.java
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/AbstractDroolsAssetsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/DroolsCompilationProvider.java
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/DroolsCompilationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/DroolsQuarkusResourceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/GlobalsBuildItem.java
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/GlobalsBuildItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/KmoduleKieBaseModelsBuiltItem.java
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/KmoduleKieBaseModelsBuiltItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/PatternsTypesBuildItem.java
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/PatternsTypesBuildItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/QuarkusAppPaths.java
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/QuarkusAppPaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/ResourceCollector.java
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/src/main/java/org/drools/quarkus/util/deployment/ResourceCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus/src/main/codestarts/quarkus/drools-quarkus-codestart/java/src/main/java/org/acme/Applicant.java
+++ b/drools-quarkus-extension/drools-quarkus/src/main/codestarts/quarkus/drools-quarkus-codestart/java/src/main/java/org/acme/Applicant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus/src/main/codestarts/quarkus/drools-quarkus-codestart/java/src/main/java/org/acme/LoanAppDTO.java
+++ b/drools-quarkus-extension/drools-quarkus/src/main/codestarts/quarkus/drools-quarkus-codestart/java/src/main/java/org/acme/LoanAppDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus/src/main/codestarts/quarkus/drools-quarkus-codestart/java/src/main/java/org/acme/LoanApplication.java
+++ b/drools-quarkus-extension/drools-quarkus/src/main/codestarts/quarkus/drools-quarkus-codestart/java/src/main/java/org/acme/LoanApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-quarkus-extension/drools-quarkus/src/main/codestarts/quarkus/drools-quarkus-codestart/java/src/main/java/org/acme/LoanApplicationEndPoint.java
+++ b/drools-quarkus-extension/drools-quarkus/src/main/codestarts/quarkus/drools-quarkus-codestart/java/src/main/java/org/acme/LoanApplicationEndPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BaseStoredEvent.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BaseStoredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BaseStoredObject.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BaseStoredObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BatchingStorageDecorator.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/BatchingStorageDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/FullReliableObjectStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReferenceWireable.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReferenceWireable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliabilityConfigurationException.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliabilityConfigurationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliabilityRuntimeException.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliabilityRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgendaFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgendaFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableGlobalResolver.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableGlobalResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableGlobalResolverFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableGlobalResolverFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableKieSession.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableKieSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPointFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePhreakWorkingMemoryFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePhreakWorkingMemoryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePropagationList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePseudoClockScheduler.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliablePseudoClockScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableRuntimeComponentFactoryImpl.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableRuntimeComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableSessionInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableStatefulKnowledgeSessionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SerializableStoredEvent.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SerializableStoredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SerializableStoredObject.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SerializableStoredObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SerializableStoredRefEvent.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SerializableStoredRefEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SerializableStoredRefObject.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SerializableStoredRefObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleReliableObjectStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleReliableObjectStoreFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleReliableObjectStoreFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableObjectStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableObjectStoreFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableObjectStoreFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableRefObjectStore.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/SimpleSerializationReliableRefObjectStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StorageManager.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StorageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StorageManagerFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StorageManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StoredEvent.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StoredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StoredObject.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/StoredObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/TestableStorageManager.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/TestableStorageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/util/ReliabilityUtils.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/util/ReliabilityUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-h2mvstore/src/main/java/org/drools/reliability/h2mvstore/H2MVStoreStorage.java
+++ b/drools-reliability/drools-reliability-h2mvstore/src/main/java/org/drools/reliability/h2mvstore/H2MVStoreStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-h2mvstore/src/main/java/org/drools/reliability/h2mvstore/H2MVStoreStorageManager.java
+++ b/drools-reliability/drools-reliability-h2mvstore/src/main/java/org/drools/reliability/h2mvstore/H2MVStoreStorageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-h2mvstore/src/main/java/org/drools/reliability/h2mvstore/H2MVStoreStorageManagerFactory.java
+++ b/drools-reliability/drools-reliability-h2mvstore/src/main/java/org/drools/reliability/h2mvstore/H2MVStoreStorageManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/EmbeddedStorageManager.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/EmbeddedStorageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanReliableGlobalResolverFactory.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanReliableGlobalResolverFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanStorage.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanStorageManager.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanStorageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanStorageManagerFactory.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/InfinispanStorageManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/RemoteStorageManager.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/RemoteStorageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/SimpleInfinispanReliableObjectStoreFactory.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/SimpleInfinispanReliableObjectStoreFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamGlobal.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamGlobal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamReliableGlobalResolver.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamReliableGlobalResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamStoredEvent.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamStoredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamStoredObject.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamStoredObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamUtils.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/ProtoStreamUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/SimpleProtoStreamReliableObjectStore.java
+++ b/drools-reliability/drools-reliability-infinispan/src/main/java/org/drools/reliability/infinispan/proto/SimpleProtoStreamReliableObjectStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/BeforeAllMethodExtension.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/BeforeAllMethodExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/CachePersistenceTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/CachePersistenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/EmbeddedStorageManagerTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/EmbeddedStorageManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/FactoryServiceTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/FactoryServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ObjectReferenceEventTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ObjectReferenceEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityAccumulateTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityAccumulateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepOnceAfterTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepOnceAfterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepOnceWithinTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepOnceWithinTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepTimeWindowTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepTimeWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepTimedOutTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityCepTimedOutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityFireAndAlarmTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityFireAndAlarmTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityFullStrategyTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityFullStrategyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityTestBasics.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityTestBasics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityUpdateInDrlTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/ReliabilityUpdateInDrlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/h2mvstore/H2MVStoreStorageManagerExample.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/h2mvstore/H2MVStoreStorageManagerExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/h2mvstore/H2MVStoreStorageManagerExampleAfterFailOver.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/h2mvstore/H2MVStoreStorageManagerExampleAfterFailOver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/infinispan/RemoteCacheManagerExample.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/infinispan/RemoteCacheManagerExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/infinispan/RemoteCacheManagerExampleAfterFailOver.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/example/infinispan/RemoteCacheManagerExampleAfterFailOver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/BooleanAdaptor.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/BooleanAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/EntryImpl.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/EntryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/HashMapAdaptor.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/HashMapAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/HashMapEventImplAdaptor.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/HashMapEventImplAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/IntegerAdaptor.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/IntegerAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/PersonAdaptor.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/PersonAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/StockTickAdaptor.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/StockTickAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/StringAdaptor.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/StringAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/TestProtoStreamSchema.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/proto/TestProtoStreamSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/smoke/BaseSmokeTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/smoke/BaseSmokeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/smoke/proto/ProtoSmokeTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/smoke/proto/ProtoSmokeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/smoke/remote/RemoteSmokeTest.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/smoke/remote/RemoteSmokeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/util/PrototypeUtils.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/util/PrototypeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/util/TestConfigurationUtils.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/util/TestConfigurationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/util/TimeAmount.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/drools/reliability/test/util/TimeAmount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/ControlEvent.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/ControlEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/Person.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/StockFact.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/StockFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/StockTick.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/StockTick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Alarm.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Alarm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Fire.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Fire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Room.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Room.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Sprinkler.java
+++ b/drools-reliability/drools-reliability-tests/src/test/java/org/test/domain/fireandalarm/Sprinkler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-retediagram/src/main/java/org/drools/retediagram/ReteDiagram.java
+++ b/drools-retediagram/src/main/java/org/drools/retediagram/ReteDiagram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-retediagram/src/test/java/org/drools/retediagram/RuleTest.java
+++ b/drools-retediagram/src/test/java/org/drools/retediagram/RuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-retediagram/src/test/java/org/drools/retediagram/model/Cheese.java
+++ b/drools-retediagram/src/test/java/org/drools/retediagram/model/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-retediagram/src/test/java/org/drools/retediagram/model/Measurement.java
+++ b/drools-retediagram/src/test/java/org/drools/retediagram/model/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-retediagram/src/test/java/org/drools/retediagram/model/Person.java
+++ b/drools-retediagram/src/test/java/org/drools/retediagram/model/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataHandle.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataObserver.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataProcessor.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataSource.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStore.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStream.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/DataStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnit.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitData.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitInstance.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitProvider.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnitProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnits.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/RuleUnits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/SingletonStore.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/SingletonStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/annotation/When.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/annotation/When.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/Clock.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/Clock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/ClockType.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/ClockType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/DefaultEntryPoint.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/DefaultEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/EntryPoint.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/EntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/EventProcessing.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/EventProcessing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/EventProcessingType.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/EventProcessingType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/RuleConfig.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/RuleConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/RuleUnitConfig.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/RuleUnitConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/SessionsPool.java
+++ b/drools-ruleunits/drools-ruleunits-api/src/main/java/org/drools/ruleunits/api/conf/SessionsPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/Accumulators.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/Accumulators.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleFactory.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleUnitDefinition.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleUnitDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleUnitProviderForDSL.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleUnitProviderForDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RulesFactory.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RulesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/SyntheticRuleUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/SyntheticRuleUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/SyntheticRuleUnitBuilder.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/SyntheticRuleUnitBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/UnitGlobalsResolver.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/UnitGlobalsResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/AccumulatePattern1.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/AccumulatePattern1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/AccumulatePattern2.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/AccumulatePattern2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/Accumulator1.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/Accumulator1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/GroupByPattern1.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/GroupByPattern1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/GroupByPattern2.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/accumulate/GroupByPattern2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/AbstractConstraint.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/AbstractConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/AlphaConstraintWithRightExtractor.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/AlphaConstraintWithRightExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/AlphaConstraintWithRightValue.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/AlphaConstraintWithRightValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/Beta1Constraint.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/Beta1Constraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/Beta2Constraint.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/Beta2Constraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/Beta3Constraint.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/Beta3Constraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/Constraint.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/constraints/Constraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/CombinedPatternDef.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/CombinedPatternDef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/ExistentialPatternDef.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/ExistentialPatternDef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/InternalPatternDef.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/InternalPatternDef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern1Def.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern1Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern1DefImpl.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern1DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern2Def.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern2Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern2DefImpl.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern2DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern3Def.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern3Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern3DefImpl.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern3DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern4Def.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern4Def.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern4DefImpl.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/Pattern4DefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/PatternDef.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/PatternDef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/SinglePatternDef.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/patterns/SinglePatternDef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/util/ClassIntrospectionCache.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/util/ClassIntrospectionCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/util/DataSourceDefinition.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/util/DataSourceDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/util/RuleDefinition.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/util/RuleDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/AccumulateUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/AccumulateUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/DynamicHelloWorldUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/DynamicHelloWorldUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/ExistentialUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/ExistentialUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/GroupByUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/GroupByUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/HelloWorldUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/HelloWorldUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/InferenceUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/InferenceUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/LogicalAddUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/LogicalAddUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/MultiJoinUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/MultiJoinUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/NamedHelloWorldUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/NamedHelloWorldUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/ProgrammaticSyntheticRuleUnitsTest.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/ProgrammaticSyntheticRuleUnitsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/RuleNameUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/RuleNameUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/RuleUnitRebuildTest.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/RuleUnitRebuildTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/RuleUnitsTest.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/RuleUnitsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SelfJoinUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SelfJoinUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SelfJoinWithInferenceAndNotUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SelfJoinWithInferenceAndNotUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SumAccumulateUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SumAccumulateUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SyntheticRuleUnitsTest.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/SyntheticRuleUnitsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/UnitOne.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/UnitOne.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/UnitTwo.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/UnitTwo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/domain/Cheese.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/domain/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/domain/Person.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/domain/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/AbstractRuleUnitDescription.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/AbstractRuleUnitDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/AbstractRuleUnitInstance.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/AbstractRuleUnitInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/AssignableChecker.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/AssignableChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/EntryPointDataProcessor.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/EntryPointDataProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/GeneratedRuleUnitDescription.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/GeneratedRuleUnitDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/InternalRuleUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/InternalRuleUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/InternalStoreCallback.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/InternalStoreCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/NamedRuleUnitData.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/NamedRuleUnitData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ReflectiveRuleUnitDescription.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ReflectiveRuleUnitDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ReteEvaluatorBasedRuleUnitInstance.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/ReteEvaluatorBasedRuleUnitInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/RuleUnitGenerationException.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/RuleUnitGenerationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/RuleUnitProviderImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/RuleUnitProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/SessionData.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/SessionData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/SessionUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/SessionUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/SimpleRuleUnitVariable.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/SimpleRuleUnitVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/UndefinedGeneratedRuleUnitVariableException.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/UndefinedGeneratedRuleUnitVariableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/UndefinedRuleUnitVariableException.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/UndefinedRuleUnitVariableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/conf/RuleConfigImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/conf/RuleConfigImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/AbstractDataSource.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/AbstractDataSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/BufferedDataStream.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/BufferedDataStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/ConsequenceDataStore.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/ConsequenceDataStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/ConsequenceDataStoreImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/ConsequenceDataStoreImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/DataSourceFactoryImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/DataSourceFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/DirectDataStream.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/DirectDataStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/EventListDataStream.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/EventListDataStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/FieldDataStore.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/FieldDataStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/ListDataStore.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/datasources/ListDataStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/facthandles/RuleUnitDefaultFactHandle.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/facthandles/RuleUnitDefaultFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/facthandles/RuleUnitEventFactHandle.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/facthandles/RuleUnitEventFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/facthandles/RuleUnitFactHandleFactory.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/facthandles/RuleUnitFactHandleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/facthandles/RuleUnitInternalFactHandle.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/facthandles/RuleUnitInternalFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/AbstractRuleUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/AbstractRuleUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/AbstractRuleUnits.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/AbstractRuleUnits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/DataHandleImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/DataHandleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/RuleUnitComponentFactoryImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/RuleUnitComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/RuleUnitRuntimeComponentFactory.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/factory/RuleUnitRuntimeComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/AgendaGroupUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/AgendaGroupUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/BufferedDataStreamTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/BufferedDataStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/CepTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/CepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/HelloWorldUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/HelloWorldUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnitInstance.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnitInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnitTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/InterpretedRuleUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/LocationUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/LocationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/LogicalAddByElementTestUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/LogicalAddByElementTestUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/LogicalAddTestUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/LogicalAddTestUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/MultipleDataSourceUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/MultipleDataSourceUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/NotTestUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/NotTestUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/OOPathTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/OOPathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/OOPathTestUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/OOPathTestUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/QueryTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/QueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleConfigTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleConfigTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleNameUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleNameUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleUnitDescriptionTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleUnitDescriptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleUnitProviderImplTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/RuleUnitProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/SingletonDataStoreTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/SingletonDataStoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/StockTickUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/StockTickUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/TestRuleUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/TestRuleUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/TimerUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/TimerUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/UpdateNoDSTestUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/UpdateNoDSTestUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/UpdateTestUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/UpdateTestUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/WronglyTypedUnit.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/WronglyTypedUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/Location.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/Location.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/Measurement.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/Person.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/Sensor.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/Sensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/SimpleFact.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/SimpleFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/StockTick.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/domain/StockTick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/listener/TestAgendaEventListener.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/listener/TestAgendaEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/listener/TestRuleEventListener.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/listener/TestRuleEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/listener/TestRuleRuntimeEventListener.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/listener/TestRuleRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/AbstractScesimData.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/AbstractScesimData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/AbstractScesimModel.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/AbstractScesimModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/AuditLog.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/AuditLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/AuditLogLine.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/AuditLogLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Background.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Background.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/BackgroundData.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/BackgroundData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/BackgroundDataWithIndex.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/BackgroundDataWithIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ExpressionElement.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ExpressionElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ExpressionIdentifier.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ExpressionIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactIdentifier.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMapping.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingType.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingValue.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingValueStatus.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingValueStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingValueType.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingValueType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Scenario.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Scenario.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioSimulationModel.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioSimulationModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioWithIndex.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioWithIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScesimDataWithIndex.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScesimDataWithIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScesimModelDescriptor.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScesimModelDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Settings.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Settings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Simulation.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Simulation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/SimulationRunMetadata.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/SimulationRunMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/imports/HasImports.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/imports/HasImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/imports/Import.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/imports/Import.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/imports/Imports.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/imports/Imports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/utils/ConstantsHolder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/utils/ConstantsHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/utils/ScenarioSimulationSharedUtils.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/utils/ScenarioSimulationSharedUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/ExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/ExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/ExpressionEvaluatorFactory.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/ExpressionEvaluatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/ExpressionEvaluatorResult.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/ExpressionEvaluatorResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/MVELExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/MVELExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/AddCoverageListenerCommand.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/AddCoverageListenerCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ConditionFilter.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ConditionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/CoverageAgendaListener.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/CoverageAgendaListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/FactCheckerHandle.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/FactCheckerHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ValidateFactCommand.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ValidateFactCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/interfaces/ThrowingConsumer.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/interfaces/ThrowingConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/interfaces/ThrowingFunction.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/interfaces/ThrowingFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/interfaces/package-info.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/interfaces/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/IndexedScenarioAssertionError.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/IndexedScenarioAssertionError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/IndexedScenarioException.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/IndexedScenarioException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioException.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/SimulationRunMetadataBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/SimulationRunMetadataBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/InstanceGiven.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/InstanceGiven.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioExpect.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioExpect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioResult.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioResultMetadata.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioResultMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioRunnerDTO.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioRunnerDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioRunnerData.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioRunnerData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DOMParserUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DOMParserUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ImpossibleToFindDMNException.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ImpossibleToFindDMNException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/InMemoryMigrationStrategy.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/InMemoryMigrationStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/JsonUtils.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/JsonUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/MigrationStrategy.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/MigrationStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanWrapper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationServerMessages.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationServerMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/CompilationCacheProviderImpl.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/CompilationCacheProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/MarshallerProviderImpl.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/MarshallerProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/PersisterHelper.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/PersisterHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufInputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufInputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufMarshallerReaderContext.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufMarshallerReaderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufMarshallerWriteContext.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufMarshallerWriteContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufMessages.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufOutputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufOutputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufProcessMarshallerWriteContext.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufProcessMarshallerWriteContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufWorkingMemoryAction.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufWorkingMemoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ReadSessionResult.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ReadSessionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/TimersInputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/TimersInputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/TimersOutputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/TimersOutputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/WorkingMemoryReteAssertAction.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/WorkingMemoryReteAssertAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufBehaviorExpireWMAction.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufBehaviorExpireWMAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufBeliefSystemLogicalCallback.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufBeliefSystemLogicalCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufDeactivateCallback.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufDeactivateCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufWorkingMemoryReteAssertAction.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufWorkingMemoryReteAssertAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufWorkingMemoryReteExpireAction.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/actions/ProtobufWorkingMemoryReteExpireAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/ActivationIterator.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/ActivationIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/LeftTupleIterator.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/LeftTupleIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/PhreakActivationIterator.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/PhreakActivationIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/TerminalNodeIterator.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/TerminalNodeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/kie/KieModuleCache.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/kie/KieModuleCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/kie/KieModuleCacheHelper.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/kie/KieModuleCacheHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/kie/MarshallingKieMetaInfoBuilder.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/kie/MarshallingKieMetaInfoBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ActivationKey.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ActivationKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/IdentityPlaceholderResolverStrategy.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/IdentityPlaceholderResolverStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/InternalMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/InternalMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/JavaSerializableResolverStrategy.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/JavaSerializableResolverStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/KieSessionInitializer.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/KieSessionInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/MarshallingConfigurationImpl.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/MarshallingConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/MarshallingHelper.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/MarshallingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ObjectMarshallingStrategyStoreImpl.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ObjectMarshallingStrategyStoreImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/PersisterEnums.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/PersisterEnums.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ProcessMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ProcessMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ProcessMarshallerFactory.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ProcessMarshallerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ProcessMarshallerFactoryService.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/ProcessMarshallerFactoryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/RightTupleKey.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/RightTupleKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/RuleBaseNodes.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/marshalling/RuleBaseNodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/BehaviorJobContextTimerInputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/BehaviorJobContextTimerInputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/BehaviorJobContextTimerOutputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/BehaviorJobContextTimerOutputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/ExpireJobContextTimerInputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/ExpireJobContextTimerInputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/ExpireJobContextTimerOutputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/ExpireJobContextTimerOutputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/TimerNodeTimerInputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/TimerNodeTimerInputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/TimerNodeTimerOutputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/timers/TimerNodeTimerOutputMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/EventAccessorRestoreTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/EventAccessorRestoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/FactHandleMarshallingTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/FactHandleMarshallingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/MarshalledInternalMatchSortTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/MarshalledInternalMatchSortTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/MarshallerTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/MarshallerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/MarshallingTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/MarshallingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/OldOutputMarshallerMethods.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/OldOutputMarshallerMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/ProtobufOutputMarshallerTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/ProtobufOutputMarshallerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/QueryTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/QueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/SerializationHelper.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/SerializationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/TruthMaintenanceTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/TruthMaintenanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/UnmarshallingTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/UnmarshallingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/DataProvider.java
+++ b/drools-templates/src/main/java/org/drools/template/DataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/DataProviderCompiler.java
+++ b/drools-templates/src/main/java/org/drools/template/DataProviderCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/ObjectDataCompiler.java
+++ b/drools-templates/src/main/java/org/drools/template/ObjectDataCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/jdbc/ResultSetGenerator.java
+++ b/drools-templates/src/main/java/org/drools/template/jdbc/ResultSetGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/AttributedDRLElement.java
+++ b/drools-templates/src/main/java/org/drools/template/model/AttributedDRLElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/Condition.java
+++ b/drools-templates/src/main/java/org/drools/template/model/Condition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/Consequence.java
+++ b/drools-templates/src/main/java/org/drools/template/model/Consequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/DRLElement.java
+++ b/drools-templates/src/main/java/org/drools/template/model/DRLElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/DRLJavaEmitter.java
+++ b/drools-templates/src/main/java/org/drools/template/model/DRLJavaEmitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/DRLOutput.java
+++ b/drools-templates/src/main/java/org/drools/template/model/DRLOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/DeclaredType.java
+++ b/drools-templates/src/main/java/org/drools/template/model/DeclaredType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/Functions.java
+++ b/drools-templates/src/main/java/org/drools/template/model/Functions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/Global.java
+++ b/drools-templates/src/main/java/org/drools/template/model/Global.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/Import.java
+++ b/drools-templates/src/main/java/org/drools/template/model/Import.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/Package.java
+++ b/drools-templates/src/main/java/org/drools/template/model/Package.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/Queries.java
+++ b/drools-templates/src/main/java/org/drools/template/model/Queries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/Rule.java
+++ b/drools-templates/src/main/java/org/drools/template/model/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/model/SnippetBuilder.java
+++ b/drools-templates/src/main/java/org/drools/template/model/SnippetBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/objects/ArrayDataProvider.java
+++ b/drools-templates/src/main/java/org/drools/template/objects/ArrayDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/objects/ObjectDataProvider.java
+++ b/drools-templates/src/main/java/org/drools/template/objects/ObjectDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/AbstractCell.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/AbstractCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/AbstractColumn.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/AbstractColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/ArrayCell.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/ArrayCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/ArrayColumn.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/ArrayColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/BooleanCell.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/BooleanCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/BooleanColumn.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/BooleanColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/Cell.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/Cell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/Column.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/Column.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/ColumnFactory.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/ColumnFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/DataListener.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DataListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/DecisionTableParseException.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DecisionTableParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/DefaultGenerator.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DefaultGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateColumn.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/DoubleCell.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DoubleCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/DoubleColumn.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DoubleColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/Generator.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/Generator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/LongCell.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/LongCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/LongColumn.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/LongColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/Row.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/Row.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/RuleTemplate.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/RuleTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/StringCell.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/StringCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/StringColumn.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/StringColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/TemplateColumn.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/TemplateColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/TemplateContainer.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/TemplateContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/main/java/org/drools/template/parser/TemplateDataListener.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/TemplateDataListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/DataProviderCompilerTest.java
+++ b/drools-templates/src/test/java/org/drools/template/DataProviderCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/jdbc/Cheese.java
+++ b/drools-templates/src/test/java/org/drools/template/jdbc/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/jdbc/Person.java
+++ b/drools-templates/src/test/java/org/drools/template/jdbc/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/jdbc/ResultSetGeneratorTest.java
+++ b/drools-templates/src/test/java/org/drools/template/jdbc/ResultSetGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/model/FunctionsRenderTest.java
+++ b/drools-templates/src/test/java/org/drools/template/model/FunctionsRenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/model/PackageRenderTest.java
+++ b/drools-templates/src/test/java/org/drools/template/model/PackageRenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/model/QueriesRenderTest.java
+++ b/drools-templates/src/test/java/org/drools/template/model/QueriesRenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/model/RuleRenderTest.java
+++ b/drools-templates/src/test/java/org/drools/template/model/RuleRenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/model/SnippetBuilderTest.java
+++ b/drools-templates/src/test/java/org/drools/template/model/SnippetBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/parser/ColumnFactoryTest.java
+++ b/drools-templates/src/test/java/org/drools/template/parser/ColumnFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/parser/DefaultGeneratorTest.java
+++ b/drools-templates/src/test/java/org/drools/template/parser/DefaultGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/parser/DefaultTemplateContainerTest.java
+++ b/drools-templates/src/test/java/org/drools/template/parser/DefaultTemplateContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/parser/ExternalSheetListenerTest.java
+++ b/drools-templates/src/test/java/org/drools/template/parser/ExternalSheetListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-templates/src/test/java/org/drools/template/parser/RuleTemplateTest.java
+++ b/drools-templates/src/test/java/org/drools/template/parser/RuleTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/only-jar-pojo-not-kjar-no-kmodule/src/main/java/org/drools/compiler/integrationtests/only_jar_pojo_not_kjar_no_kmodule/MyPojo.java
+++ b/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/only-jar-pojo-not-kjar-no-kmodule/src/main/java/org/drools/compiler/integrationtests/only_jar_pojo_not_kjar_no_kmodule/MyPojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/drools-test-coverage-jars/setter-overload/src/main/java/org/drools/compiler/integrationtests/setter/overload/SetterOverload.java
+++ b/drools-test-coverage/drools-test-coverage-jars/setter-overload/src/main/java/org/drools/compiler/integrationtests/setter/overload/SetterOverload.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/drools-test-coverage-jars/surf/src/main/java/org/example/surf/Board.java
+++ b/drools-test-coverage/drools-test-coverage-jars/surf/src/main/java/org/example/surf/Board.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/drools-test-coverage-jars/surf/src/main/java/org/example/surf/Person.java
+++ b/drools-test-coverage/drools-test-coverage-jars/surf/src/main/java/org/example/surf/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/drools-test-coverage-jars/testEnum/src/main/java/org/drools/Primitives.java
+++ b/drools-test-coverage/drools-test-coverage-jars/testEnum/src/main/java/org/drools/Primitives.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/drools-test-coverage-jars/testEnum/src/main/java/org/drools/TestEnum.java
+++ b/drools-test-coverage/drools-test-coverage-jars/testEnum/src/main/java/org/drools/TestEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Customer.java
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Customer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Drink.java
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Drink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Order.java
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Order.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-with-domain/tests/src/test/java/org/drools/testcoverage/kieci/withdomain/KJarLoadingTest.java
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/tests/src/test/java/org/drools/testcoverage/kieci/withdomain/KJarLoadingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-with-domain/tests/src/test/java/org/drools/testcoverage/kieci/withdomain/util/KJarLoadUtils.java
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/tests/src/test/java/org/drools/testcoverage/kieci/withdomain/util/KJarLoadUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Customer.java
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Customer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Drink.java
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Drink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Order.java
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/src/main/java/org/drools/testcoverage/domain/Order.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-without-domain/tests/src/test/java/org/drools/testcoverage/kieci/withoutdomain/KJarLoadingTest.java
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/tests/src/test/java/org/drools/testcoverage/kieci/withoutdomain/KJarLoadingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/standalone/kie-ci-without-domain/tests/src/test/java/org/drools/testcoverage/kieci/withoutdomain/util/KJarLoadUtils.java
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/tests/src/test/java/org/drools/testcoverage/kieci/withoutdomain/util/KJarLoadUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AbstractBackwardChainingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AbstractBackwardChainingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AbstractCellTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AbstractCellTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AbstractCepEspTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AbstractCepEspTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateCepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateMvelDialectTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateMvelDialectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ActivateAndDeleteOnListenerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ActivateAndDeleteOnListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaNetworkModifyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaNetworkModifyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaNodeRangeIndexingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaNodeRangeIndexingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaNodeSharingWithDiffPackageNameTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaNodeSharingWithDiffPackageNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
 3 * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsCepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsOnPatternTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsOnPatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AnnotationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ArrayTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BetaTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BetaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BigRuleSetCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BigRuleSetCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CalendarTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CalendarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CellTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CellTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepEspNegativeCloudTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepEspNegativeCloudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepQueryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ClassLoaderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CommandsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CommandsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CompositeAgendaTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CompositeAgendaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConditionLimitTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConditionLimitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceOffsetTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceOffsetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceTypeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/FromSharingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/FromSharingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ImmutableFactsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ImmutableFactsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/JoinNodeRangeIndexingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/JoinNodeRangeIndexingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/KieBaseIncludeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/KieBaseIncludeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/MultiSheetsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/MultiSheetsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/NegativePatternsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/NegativePatternsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PassivePatternTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PassivePatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyChangeSupportTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyChangeSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyReactivityTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/PropertyReactivityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/QueryConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/QueryConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/StreamsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/StreamsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkCEPTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkCEPTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarExceptionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarFireUntilHaltTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarFireUntilHaltTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarWithPseudoTimeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarWithPseudoTimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarWithRealTimeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarWithRealTimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/UnexpectedLoopTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/UnexpectedLoopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/AccumulateFunctionConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/AccumulateFunctionConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/Album.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/Album.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/BaseConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/BaseConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/Bus.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/Bus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceWithAndOrConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConsequenceWithAndOrConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrJittingConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/ConstraintWithAndOrJittingConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/EvalConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/EvalConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/FromAccumulateConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/FromAccumulateConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/GlobalConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/GlobalConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/Karaoke.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/Karaoke.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELDateClassFieldReaderConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELDateClassFieldReaderConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELNumberClassFieldReaderConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELNumberClassFieldReaderConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELObjectClassFieldReaderConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/MVELObjectClassFieldReaderConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/StaticUtils.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/concurrency/StaticUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/domainfirst/Pojo.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/domainfirst/Pojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/domainsecond/Pojo.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/domainsecond/Pojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/AbstractDeclareTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/AbstractDeclareTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/BindTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/BindTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/CommentTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/CommentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/ConsequenceTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/ConsequenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DRLCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DRLCepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DRLTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DRLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DeclareTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DeclareTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DrlSpecificFeaturesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/DrlSpecificFeaturesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/ExceptionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/ExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/GlobalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/GlobalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/ImportsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/ImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/LiteralTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/LiteralTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/NestingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/NestingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/PatternTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/PatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/RHSTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/RHSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/RuleFlowGroupTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/RuleFlowGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/StaticMethods.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/StaticMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/StaticMethods2.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/StaticMethods2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/VariableTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/drl/VariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/AccumulateCepEqualityModeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/AccumulateCepEqualityModeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/BackwardChainingEqualityModeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/BackwardChainingEqualityModeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/CellEqualityModeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/CellEqualityModeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/CepEspEqualityModeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/CepEspEqualityModeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/DeclareEqualityModeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/DeclareEqualityModeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/EqualityModeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/EqualityModeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/FactWithEquals.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/equalitymode/FactWithEquals.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveGenerated2RulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveGenerated2RulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEval2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEval2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEvalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesEvalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesIntegerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesIntegerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesMapContainsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesMapContainsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringIntegerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringIntegerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAddDeleteFactsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAddDeleteFactsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAdvOperatorsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAdvOperatorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestCases.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestCases.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/CasesFromGeneratedRulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/CasesFromGeneratedRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/ClassLoaderLeakTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/ClassLoaderLeakTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/ConstraintsPair.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/ConstraintsPair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationCepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationNonExecModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationNonExecModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/MultipleIncrementalCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/MultipleIncrementalCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/RemoveRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/RemoveRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/StringPermutation.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/StringPermutation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/CalcFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/CalcFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/Item.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/RecordFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/RecordFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/AndTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/AndTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ContainsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ContainsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EnabledTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EnabledTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EqualsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EqualsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EvalRewriteTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EvalRewriteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EvalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/EvalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ExistsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ExistsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ForAllTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ForAllTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FormulaTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FormulaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/InTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/InTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/InstanceOfTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/InstanceOfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MatchesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MatchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MathTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MemberOfTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/MemberOfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/OrTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/OrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/SoundsLikeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/SoundsLikeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCanonicalModelCompilerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCanonicalModelCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/phases/ExplicitCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/AbstractTupleIndexHashTableIteratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/AbstractTupleIndexHashTableIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/AlphaNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/AlphaNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/BaseBetaConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/BaseBetaConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/CommonTestMethodBase.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/CommonTestMethodBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/CompositeObjectSinkAdapterTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/CompositeObjectSinkAdapterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/ConstraintTestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/ConstraintTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/DefaultBetaConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/DefaultBetaConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/DoubleBetaConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/DoubleBetaConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/FieldConstraintTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/FieldConstraintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/GenericTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/GenericTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/InternalRuleBaseEventSupportTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/InternalRuleBaseEventSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/KnowledgeBaseEventSupportTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/KnowledgeBaseEventSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/LambdaConstraintTestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/LambdaConstraintTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/LeftTupleIndexHashTableIteratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/LeftTupleIndexHashTableIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/MVELConstraintTestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/MVELConstraintTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/MockBetaNode.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/MockBetaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/QuadroupleBetaConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/QuadroupleBetaConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/RightTupleIndexHashTableIteratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/RightTupleIndexHashTableIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/SingleBetaConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/SingleBetaConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/TripleBetaConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/TripleBetaConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/asm/BaseClassFieldAccessorFactoryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/asm/BaseClassFieldAccessorFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Address.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Approach.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Approach.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Asset.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Asset.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/AssetCard.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/AssetCard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Attribute.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Bar.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Bar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Car.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Car.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Cat.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Cat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Cell.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Cell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Cheese.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/CheeseEqual.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/CheeseEqual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Cheesery.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Cheesery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Child.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Child.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/ChildHolder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/ChildHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Close.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Close.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/DomainObject.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/DomainObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/FactA.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/FactA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/FactB.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/FactB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/FactC.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/FactC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Foo.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Foo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/GrandParent.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/GrandParent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/I18nPerson.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/I18nPerson.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/IndexedNumber.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/IndexedNumber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/InlineCastTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/InlineCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/InsertedObject.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/InsertedObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Interval.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Interval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/LegacyBean.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/LegacyBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/LongAddress.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/LongAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MemoryLeakTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Message.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MockPersistentSet.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MockPersistentSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MockPersistentSetException.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MockPersistentSetException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Move.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Move.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MyUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/MyUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Neighbor.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Neighbor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/NestedAccessorsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/NestedAccessorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/NodeHashingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/NodeHashingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/ObjectWithSet.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/ObjectWithSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Option.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Option.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Order.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Order.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/OrderItem.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/OrderItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/OuterClass.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/OuterClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Parent.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Parent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Person.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/PersonFinal.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/PersonFinal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/PersonHolder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/PersonHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/PersonInterface.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/PersonInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Pet.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Pet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/PolymorphicFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/PolymorphicFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Precondition.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Precondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Primitives.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Primitives.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/RoutingMessage.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/RoutingMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/ScenarioType.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/ScenarioType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/SpecialString.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/SpecialString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/State.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/State.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/StaticMethods.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/StaticMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/StaticMethods2.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/StaticMethods2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/StockTick.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/StockTick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/StockTickInterface.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/StockTickInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Target.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Target.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/TestEnum.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/TestEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/TestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Triangle.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Triangle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Win.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Win.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Worker.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/Worker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/api/KnowledgeBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/api/KnowledgeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/beliefsystem/abductive/AbductionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/beliefsystem/abductive/AbductionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/beliefsystem/defeasible/DefeasibilityTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/beliefsystem/defeasible/DefeasibilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/beliefsystem/jtms/JTMSTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/beliefsystem/jtms/JTMSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/KieBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/KieBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/KnowledgeBuilderConfigurationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/KnowledgeBuilderConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KieFileSystemScannerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KieFileSystemScannerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderConfigurationImplTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderConfigurationImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderImplTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/DisposeCommandPublicAPITest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/DisposeCommandPublicAPITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/MoreBatchExecutionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/MoreBatchExecutionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/PropagationListTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/PropagationListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/RegisterWorkItemHandlerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/RegisterWorkItemHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/SimpleBatchExecutionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/command/SimpleBatchExecutionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/common/InternalMatchIteratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/common/InternalMatchIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/common/TerminalNodeIteratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/common/TerminalNodeIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/commons/jci/compilers/NativeJavaCompilerSettingsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/commons/jci/compilers/NativeJavaCompilerSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/CImpl.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/CImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/CompilerPerfProfileTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/CompilerPerfProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/DImpl.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/DImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/DescrResourceSetTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/DescrResourceSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/DrlParserTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/DrlParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/IA.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/IA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/IB.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/IB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/PackageBuilderConfigurationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/PackageBuilderConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/PackageDescrResourceVisitor.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/PackageDescrResourceVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/PatternBuilderForQueryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/PatternBuilderForQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/RuleErrorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/RuleErrorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/TypeDeclarationMergingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/TypeDeclarationMergingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/TypeDeclarationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/TypeDeclarationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/TypeDeclarationUnsupportedModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/TypeDeclarationUnsupportedModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/io/memory/MemoryFileSystemTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/io/memory/MemoryFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/conf/KnowledgeBaseConfigurationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/conf/KnowledgeBaseConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/conf/KnowledgeSessionConfigurationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/conf/KnowledgeSessionConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/definitions/KnowledgePackageMetaDataTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/definitions/KnowledgePackageMetaDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/DslExpansionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/DslExpansionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireChannelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireChannelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireListenerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/ClasspathKieProjectTransformUrlToFileSystemPathTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/ClasspathKieProjectTransformUrlToFileSystemPathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieBuilderSetImplTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieBuilderSetImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieFileSystemImplTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieFileSystemImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieModuleRepoTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieModuleRepoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/MemoryKieModuleResourceProviderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/MemoryKieModuleResourceProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/util/ChangeSetBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/util/ChangeSetBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/ReleaseIdTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/ReleaseIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/memory/MemoryFileTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/memory/MemoryFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/memory/MemoryFolderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/memory/MemoryFolderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/memory/MemoryURLConnection.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/memory/MemoryURLConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/memory/MemorytURLStreamHandler.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kproject/memory/MemorytURLStreamHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DRLContextTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DRLContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DRLExprParserTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DRLExprParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DescrDumperTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DescrDumperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DroolsSoftKeywordsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/DroolsSoftKeywordsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/ErrorsParserTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/ErrorsParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/MockExpander.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/MockExpander.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/MockExpanderResolver.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/MockExpanderResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/RuleParserTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/RuleParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/TestDRL.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/TestDRL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/Tree2TestDRL.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/Tree2TestDRL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/api/DescrBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/api/DescrBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/descr/AndDescrTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/descr/AndDescrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/descr/ConnectiveDescrTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/descr/ConnectiveDescrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/descr/PackageDescrTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/descr/PackageDescrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/ANTLRDSLTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/ANTLRDSLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/DSLMappingEntryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/DSLMappingEntryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/DSLMappingFileTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/DSLMappingFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/DSLTokenizedMappingFileTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/DSLTokenizedMappingFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/DefaultExpanderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/dsl/DefaultExpanderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathAccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathAccumulateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathBenchmarkTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathBenchmarkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathBindTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathBindTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathCastTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathMultilevelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathMultilevelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathQueriesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathQueriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathReactiveTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathReactiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/RecursiveQueryBenchmark.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/RecursiveQueryBenchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/graph/Edge.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/graph/Edge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/graph/OOPathOnGraphTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/graph/OOPathOnGraphTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/graph/Vertex.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/graph/Vertex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Adult.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Adult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Appliance.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Appliance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/BabyBoy.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/BabyBoy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/BabyGirl.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/BabyGirl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/BodyMeasurement.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/BodyMeasurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Child.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Child.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Company.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Company.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Disease.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Disease.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Employee.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Employee.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Group.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Group.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Man.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Man.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Person.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Room.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Room.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/School.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/School.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Sensor.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Sensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/SensorEvent.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/SensorEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/TMDirectory.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/TMDirectory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/TMFile.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/TMFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/TMFileSet.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/TMFileSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/TMFileWithParentObj.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/TMFileWithParentObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Thing.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Thing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Toy.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Toy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Woman.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/model/Woman.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/phreak/A.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/phreak/A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/MockLeftTupleSink.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/MockLeftTupleSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/MockRightTupleSink.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/MockRightTupleSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/ReteooBuilderPerformanceTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/ReteooBuilderPerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/ReteooBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/ReteooBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/XpathAnalysisTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/XpathAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/JavaAndMVELCombinedTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/JavaAndMVELCombinedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/AccumulateTemplateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/AccumulateTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/AsmGeneratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/AsmGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/RuleBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/RuleBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/simulation/BatchRunFluentTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/simulation/BatchRunFluentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/test/Man.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/test/Man.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/test/Person.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/test/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/test/PositionalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/test/PositionalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/DumbFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/DumbFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/FactPopulatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/FactPopulatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/MockFactHandle.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/MockFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/RuleCoverageListenerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/testframework/RuleCoverageListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/util/debug/DebugList.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/util/debug/DebugList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/util/debug/SessionInspectorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/util/debug/SessionInspectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/BaseClassFieldExtractorsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/BaseClassFieldExtractorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/BooleanClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/BooleanClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/ByteClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/ByteClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/CharClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/CharClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/ClassFieldAccessorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/ClassFieldAccessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/DoubleClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/DoubleClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/FieldIndexEntryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/FieldIndexEntryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/FloatClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/FloatClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/IntClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/IntClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/LongClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/LongClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/MVELClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/MVELClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/ObjectClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/ObjectClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/ShortClassFieldExtractorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/extractors/ShortClassFieldExtractorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/AlphaNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/AlphaNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DRLDumperTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DRLDumperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DateCoercionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DateCoercionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DateComparisonTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DateComparisonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DeclarativeAgendaTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DeclarativeAgendaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsEventList.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsEventList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsEventListTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsEventListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsFromRHSTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsFromRHSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DslTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DslTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicEvalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicEvalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRuleLoadTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRuleLoadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRuleRemovalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRuleRemovalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRulesChangesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRulesChangesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRulesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/EdgeCaseNonExecModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/EdgeCaseNonExecModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/EnableAuditLogCommandTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/EnableAuditLogCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/EnumTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/EnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExecutionFlowControlTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExecutionFlowControlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExistentialOperatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExistentialOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExtendsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExtendsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FailureOnRemovalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FailureOnRemovalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireAllRulesCommandTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireAllRulesCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireUntilHaltAccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireUntilHaltAccumulateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireUntilHaltTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireUntilHaltTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FirstOrderLogicTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FirstOrderLogicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FunctionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/GeneratedBeansTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/GeneratedBeansTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/GenericsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/GenericsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/HelloWorldTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/HelloWorldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/I18nTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/I18nTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/IntegrationInterfacesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/IntegrationInterfacesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/IteratorToList.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/IteratorToList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JBRULESTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JBRULESTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBaseIncludesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBaseIncludesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieCompilationCacheTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieCompilationCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieContainerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieDefaultPackageTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieDefaultPackageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieHelloWorldTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieHelloWorldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieLoggersTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieLoggersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieRepositoryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieRepositoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieRuntimeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieRuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieServicesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieSessionIterationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieSessionIterationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KmoduleXmlTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KmoduleXmlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnowledgeBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnowledgeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnowledgeContextTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnowledgeContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnownExecModelDifferenceTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnownExecModelDifferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LargeRuleBase.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LargeRuleBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LengthSlidingWindowTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LengthSlidingWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LifecycleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LifecycleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LinkingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LinkingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ListenersTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ListenersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MBeansMonitoringTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MBeansMonitoringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MTEntryPointsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MTEntryPointsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MVELEmptyCollectionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MVELEmptyCollectionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MVELTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MVELTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MapConstraintTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MapConstraintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MarshallingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MarshallingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MatchTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MergePackageTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MergePackageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MessageImplTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MessageImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NamedConsequencesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NamedConsequencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NewLineAtEoFTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NewLineAtEoFTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NodePositionInPathTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NodePositionInPathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NodesPartitioningTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NodesPartitioningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullCheckOnExistentialNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullCheckOnExistentialNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullSafeDereferencingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullSafeDereferencingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ObjectTypeNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ObjectTypeNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/OutOfMemoryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/OutOfMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PackageProtected.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PackageProtected.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelBuildTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelBuildTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelEvaluationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelEvaluationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelExecutionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelExecutionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParserTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PassiveQueryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PassiveQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PathEndNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PathEndNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PhreakConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PhreakConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PolymorphismTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PolymorphismTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertyReactivityBlockerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertyReactivityBlockerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertyReactivityTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertyReactivityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertySpecificTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertySpecificTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PseudoClockEventsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PseudoClockEventsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Query2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Query2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Query3Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Query3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryCepFireUntilHaltTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryCepFireUntilHaltTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryCepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryInRHSCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryInRHSCepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleEventListenerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleEventListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleExecutionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleExecutionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleExtensionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleExtensionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleMetadataTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleMetadataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentCreationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentCreationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentMemorySegmentPrototypeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentMemorySegmentPrototypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializationHelper.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTwoSteps1Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTwoSteps1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTwoSteps2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTwoSteps2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SeveralKieSessionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SeveralKieSessionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ShadowProxyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ShadowProxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StatelessStressTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StatelessStressTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StrEvaluatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StrEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StrictAnnotationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StrictAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SwitchOverStringTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SwitchOverStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TemporalOperatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TemporalOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TestFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TestFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TestObject.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TestObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TreeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TypeDeclarationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TypeDeclarationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/UnlinkingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/UnlinkingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/VarargsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/VarargsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/WindowTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/WindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/WorkingMemoryActionsSerializationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/WorkingMemoryActionsSerializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/XSDResourceTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/XSDResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/AbstractConcurrentInsertionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/AbstractConcurrentInsertionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/AbstractConcurrentTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/AbstractConcurrentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/BasicConcurrentInsertionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/BasicConcurrentInsertionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/ConcurrentBasesParallelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/ConcurrentBasesParallelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/ConcurrentInsertionsToSubnetworksTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/ConcurrentInsertionsToSubnetworksTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/DataTypeEvaluationConcurrentSessionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/DataTypeEvaluationConcurrentSessionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/EnumEvaluationConcurrentSessionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/EnumEvaluationConcurrentSessionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/JoinsConcurrentSessionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/JoinsConcurrentSessionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/SharedSessionParallelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/SharedSessionParallelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/SubnetworkConcurrentSessionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/SubnetworkConcurrentSessionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/AbstractEventListener.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/AbstractEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/Event.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/Event.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/PseudoSessionClock.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/PseudoSessionClock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/SimpleEventGenerator.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/SimpleEventGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/SimpleEventGeneratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/SimpleEventGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/SimpleEventListener.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/SimpleEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/ExampleScenario.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/ExampleScenario.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/FailureEvent.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/FailureEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/HeartbeatEvent.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/HeartbeatEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/ProductionEvent.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/ProductionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/Resource.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/Resource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/SlidingWindow.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/SlidingWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/Status.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/Status.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/StatusChangedEvent.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/StatusChangedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/Tools.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/example/Tools.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/AFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/AFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/AnEnum.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/AnEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/BasicEvent.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/BasicEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/BeanA.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/BeanA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/BeanB.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/BeanB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/CategoryTypeEnum.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/CategoryTypeEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ChildFact1.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ChildFact1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ChildFact2.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ChildFact2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ChildFact3WithEnum.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ChildFact3WithEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ChildFact4WithFirings.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ChildFact4WithFirings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ClassA.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ClassA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ClassB.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/ClassB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithBigDecimal.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithBigDecimal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithBoolean.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithBoolean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithByte.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithByte.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithCharacter.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithCharacter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithDouble.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithDouble.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithEnum.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithFloat.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithFloat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithInteger.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithInteger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithList.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithLong.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithLong.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithMap.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithObject.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithShort.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithShort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithString.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/FactWithString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/InterfaceA.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/InterfaceA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/InterfaceB.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/InterfaceB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/Product.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/Product.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/RootFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/RootFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/TestEvent.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/TestEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/VarargsFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/VarargsFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/DieselCar.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/DieselCar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/DieselEngine.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/DieselEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/ElectricCar.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/ElectricCar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/ElectricEngine.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/ElectricEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/Engine.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/Engine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/Vehicle.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/facts/vehicles/Vehicle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/marshalling/InputStreamMarkResetTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/marshalling/InputStreamMarkResetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/A.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/B.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/B.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BaseLeftTuplesBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BaseLeftTuplesBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BetaNodeBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BetaNodeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/C.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/E.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/E.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/F.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/F.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/FakeBetaNodeFieldConstraint.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/FakeBetaNodeFieldConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/FakeContextEntry.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/FakeContextEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/LeftBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/LeftBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/LeftMemory.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/LeftMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/MVELConstraintTestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/MVELConstraintTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Pair.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Pair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakLiaNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakLiaNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakNotNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakNotNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ReteTesterHelper.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ReteTesterHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RightBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RightBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RightMemory.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RightMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Scenario.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Scenario.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ScenarioTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ScenarioTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/StagedBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/StagedBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/X.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/X.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Y.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Y.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/sequential/SequentialTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/sequential/SequentialTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/AgendaFilterTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/AgendaFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/BasicUpdateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/BasicUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/CrossProductTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/CrossProductTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/DeleteTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/DeleteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/EntryPointTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/EntryPointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/FieldAccessTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/FieldAccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/InsertTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/InsertTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/LocaleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/LocaleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/RuleRuntimeEventTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/RuleRuntimeEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/SessionsPoolTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/SessionsPoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/StatefulSessionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/StatefulSessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/StatelessSessionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/StatelessSessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/TypeCoercionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/TypeCoercionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/UpdateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/UpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Edge.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Edge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Junction.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Junction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Line.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Line.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/ReteOOWaltzTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/ReteOOWaltzTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Stage.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Stage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Waltz.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Waltz.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/WaltzMain.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/WaltzMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/WaltzUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/WaltzUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/model/Cheese.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/model/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/model/CheeseInterface.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/model/CheeseInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/model/MockObjectSource.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/model/MockObjectSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/DeclarationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/DeclarationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/EnumSerialiationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/EnumSerialiationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/GroupElementTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/GroupElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/PackageCompilationDataTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/PackageCompilationDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/PatternTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/PatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/RuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/rule/RuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/util/RightTupleIndexHashTableTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/util/RightTupleIndexHashTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/workitem/CustomWorkItemHandler.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/workitem/CustomWorkItemHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/workitem/CustomWorkItemHandlerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/workitem/CustomWorkItemHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/reteevaluator/ReteEvaluatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/reteevaluator/ReteEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-nomvel/src/test/java/org/drools/compiler/integrationtests/nomvel/TestUtil.java
+++ b/drools-test-coverage/test-integration-nomvel/src/test/java/org/drools/compiler/integrationtests/nomvel/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-nomvel/src/test/java/org/drools/compiler/integrationtests/nomvel/TimerTest.java
+++ b/drools-test-coverage/test-integration-nomvel/src/test/java/org/drools/compiler/integrationtests/nomvel/TimerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-nomvel/src/test/java/org/drools/compiler/integrationtests/nomvel/VerifyTest.java
+++ b/drools-test-coverage/test-integration-nomvel/src/test/java/org/drools/compiler/integrationtests/nomvel/VerifyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-notms/src/test/java/org/drools/compiler/integrationtests/notms/NoTmsTest.java
+++ b/drools-test-coverage/test-integration-notms/src/test/java/org/drools/compiler/integrationtests/notms/NoTmsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-noxml/src/test/java/org/drools/compiler/integrationtests/noxml/CommandTest.java
+++ b/drools-test-coverage/test-integration-noxml/src/test/java/org/drools/compiler/integrationtests/noxml/CommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-noxml/src/test/java/org/drools/compiler/integrationtests/noxml/NoXmlTest.java
+++ b/drools-test-coverage/test-integration-noxml/src/test/java/org/drools/compiler/integrationtests/noxml/NoXmlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-jar/src/main/java/org/drools/compiler/integrationtests/ruleunits/HelloJarUnit.java
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-jar/src/main/java/org/drools/compiler/integrationtests/ruleunits/HelloJarUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/RuleUnitInJarTest.java
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/RuleUnitInJarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/decisiontables/Applicant.java
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/decisiontables/Applicant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/decisiontables/DecisionTablesTest.java
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/decisiontables/DecisionTablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/decisiontables/LoanApplication.java
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/decisiontables/LoanApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/decisiontables/LoanUnit.java
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/src/test/java/org/drools/compiler/integrationtests/ruleunits/decisiontables/LoanUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/model/functions/NativeImageTestUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/model/functions/NativeImageTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/KieSessionTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/KieSessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/listener/OrderListener.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/listener/OrderListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/listener/TrackingAgendaEventListener.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/listener/TrackingAgendaEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/A.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/AFact.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/AFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/AbstractBean.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/AbstractBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Address.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/AggregableFact.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/AggregableFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Alarm.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Alarm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Attribute.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/B.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/B.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/C.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Cell.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Cell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Cheese.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Cheesery.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Cheesery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ChildEventA.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ChildEventA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ChildEventB.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ChildEventB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ClassA.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ClassA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ClassB.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ClassB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Customer.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Customer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/D.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/D.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/DomainObject.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/DomainObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/DomainObjectHolder.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/DomainObjectHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/E.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/E.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Employee.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Employee.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Event.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Event.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/EventA.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/EventA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/EventB.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/EventB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FactA.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FactA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FactB.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FactB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FactC.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FactC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FactWithList.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FactWithList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FirstClass.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/FirstClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InterfaceA.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InterfaceA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InterfaceB.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InterfaceB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InternationalAddress.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InternationalAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Interval.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Interval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ListHolder.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ListHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/LongAddress.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/LongAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Message.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MessageEvent.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MessageEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MyComparable.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MyComparable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MyComparableHolder.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MyComparableHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MyFact.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MyFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Order.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Order.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/OrderEvent.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/OrderEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/OrderItem.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/OrderItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/OuterClass.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/OuterClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Overloaded.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Overloaded.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ParentEvent.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ParentEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/PersonWithSpecificEquals.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/PersonWithSpecificEquals.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Pet.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Pet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Primitives.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Primitives.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Promotion.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Promotion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Record.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Record.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Result.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Sale.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Sale.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Sample.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Sample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/SecondClass.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/SecondClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Sensor.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Sensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/SimplePerson.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/SimplePerson.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/State.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/State.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/StockTick.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/StockTick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/StockTickEvent.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/StockTickEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Subject.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Subject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/TestEnum.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/TestEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/TestEvent.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/TestEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/TestParam.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/TestParam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/DebugList.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/DebugList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/EngineTestConfiguration.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/EngineTestConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/FileUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/FileUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseModelProvider.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieSessionModelProvider.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieSessionModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieSessionTestConfiguration.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieSessionTestConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieSessionUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieSessionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/MavenUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/MavenUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/PropertiesUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/PropertiesUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/ResourceUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/ResourceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/SerializationHelper.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/SerializationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/Session.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/Session.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestConstants.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtil2.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtil2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtilTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TimeUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TimeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/DecisionTableTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/DecisionTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/DeclarativeAgendaTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/DeclarativeAgendaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/DuplicityTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/DuplicityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/FactHandleTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/FactHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/InternalMatchGroupTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/InternalMatchGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/KieContainerDefaultsTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/KieContainerDefaultsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/KieContainerTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/KieContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/KieRepositoryTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/KieRepositoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/LiveQueriesBadResultTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/LiveQueriesBadResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/LogicalInsertFromCollectionTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/LogicalInsertFromCollectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/QueryBadResultTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/QueryBadResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/ResourcesTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/ResourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/RuleTemplateTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/RuleTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/TemplatesTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/TemplatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/UnicodeTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/UnicodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/decisiontable/DecisionTableKieContainerTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/decisiontable/DecisionTableKieContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/model/BuildtimeUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/model/BuildtimeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/model/RulesWithInTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/model/RulesWithInTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathCepTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathCepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathDslTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathDslTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathDtablesTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathDtablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathSmokeTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathSmokeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DrlParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DrlParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DslParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DslParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/ParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/SmokeParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/SmokeParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/memory/KieScannerMemoryTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/memory/KieScannerMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/AbstractCompositeRestrictionTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/AbstractCompositeRestrictionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/AccumulateRecalculationTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/AccumulateRecalculationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/AmbiguousExceptionTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/AmbiguousExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/BetaMemoryLeakOnDeleteTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/BetaMemoryLeakOnDeleteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/DateExtendingFactTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/DateExtendingFactTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/DeclarationWithOrTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/DeclarationWithOrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/DeserializationWithCompositeTriggerTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/DeserializationWithCompositeTriggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/DroolsGcCausesNPETest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/DroolsGcCausesNPETest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/EqualityKeyOverrideTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/EqualityKeyOverrideTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/EscapesInMetadataTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/EscapesInMetadataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/EventDeserializationInPastTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/EventDeserializationInPastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/EventFactHandleDeserializationTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/EventFactHandleDeserializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/FixedPatternTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/FixedPatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/FromGenericCollectionTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/FromGenericCollectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/FusionAfterBeforeTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/FusionAfterBeforeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/GenericsWithModifyTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/GenericsWithModifyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/GlobalOnLHSTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/GlobalOnLHSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/ImportReplaceTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/ImportReplaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/InaccurateComparisonTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/InaccurateComparisonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/InternalMatchTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/InternalMatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/LogicalInsertionsSerializationTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/LogicalInsertionsSerializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MultiRestrictionPatternTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MultiRestrictionPatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MultipleKieBaseListenersTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MultipleKieBaseListenersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MultipleSalienceUpdateFactTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MultipleSalienceUpdateFactTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MultipleSheetsLoadingTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MultipleSheetsLoadingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MvelOverloadedMethodsUsageTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/MvelOverloadedMethodsUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/NonStringCompareTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/NonStringCompareTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/NotInFusionTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/NotInFusionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/NullInListInFromTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/NullInListInFromTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/NumberRestriction.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/NumberRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/POJOAnnotationMergeTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/POJOAnnotationMergeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/PropertyListenerTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/PropertyListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/SerializableGeneratedTypesTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/SerializableGeneratedTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/SerializableInstantiationTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/SerializableInstantiationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/SerializationWithCollectTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/SerializationWithCollectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/SessionInsertMultiThreadingTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/SessionInsertMultiThreadingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/StarImportTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/StarImportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/TruthMaintenanceSystemConcurrencyTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/TruthMaintenanceSystemConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/UnwantedStringConversionTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/UnwantedStringConversionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/XSDResourceTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/XSDResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/mvel/MvelLinkageErrorTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/mvel/MvelLinkageErrorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/mvel/NotLoadableClass.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/mvel/NotLoadableClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/AbductiveQuery.java
+++ b/drools-tms/src/main/java/org/drools/tms/AbductiveQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/BeliefSystemFactory.java
+++ b/drools-tms/src/main/java/org/drools/tms/BeliefSystemFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/LogicalDependency.java
+++ b/drools-tms/src/main/java/org/drools/tms/LogicalDependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/SimpleMode.java
+++ b/drools-tms/src/main/java/org/drools/tms/SimpleMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemAgendaComponentFactory.java
+++ b/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemAgendaComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemEqualityKey.java
+++ b/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemEqualityKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemFactoryImpl.java
+++ b/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemImpl.java
+++ b/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemKnowledgeHelper.java
+++ b/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemKnowledgeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemKnowledgeHelperFactoryImpl.java
+++ b/drools-tms/src/main/java/org/drools/tms/TruthMaintenanceSystemKnowledgeHelperFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/agenda/TruthMaintenanceSystemInternalMatch.java
+++ b/drools-tms/src/main/java/org/drools/tms/agenda/TruthMaintenanceSystemInternalMatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/agenda/TruthMaintenanceSystemRuleTerminalNodeLeftTuple.java
+++ b/drools-tms/src/main/java/org/drools/tms/agenda/TruthMaintenanceSystemRuleTerminalNodeLeftTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/BeliefSet.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/BeliefSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/BeliefSystem.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/BeliefSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/BeliefSystemMode.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/BeliefSystemMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/ModedAssertion.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/ModedAssertion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/abductive/Abducible.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/abductive/Abducible.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/abductive/Abductive.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/abductive/Abductive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibilityStatus.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibilityStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Defeasible.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Defeasible.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleBeliefSet.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleBeliefSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleBeliefSystem.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleBeliefSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleLogicalDependency.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleLogicalDependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleMode.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleRuleNature.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/DefeasibleRuleNature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Defeater.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Defeater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Defeats.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Defeats.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Join.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Join.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Strict.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/defeasible/Strict.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSBeliefSet.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSBeliefSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSBeliefSetImpl.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSBeliefSetImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSBeliefSystem.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSBeliefSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSMode.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/jtms/JTMSMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/BeliefSystemLogicalCallback.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/BeliefSystemLogicalCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleBeliefSet.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleBeliefSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleBeliefSystem.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleBeliefSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleLogicalDependency.java
+++ b/drools-tms/src/main/java/org/drools/tms/beliefsystem/simple/SimpleLogicalDependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/main/java/org/drools/tms/util/CustomKeyTransformerHashMap.java
+++ b/drools-tms/src/main/java/org/drools/tms/util/CustomKeyTransformerHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/test/java/org/drools/tms/EqualityKeyTest.java
+++ b/drools-tms/src/test/java/org/drools/tms/EqualityKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/test/java/org/drools/tms/LazyTMSEnablingTest.java
+++ b/drools-tms/src/test/java/org/drools/tms/LazyTMSEnablingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-tms/src/test/java/org/drools/tms/TMSMockInternalMatch.java
+++ b/drools-tms/src/test/java/org/drools/tms/TMSMockInternalMatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/compiler/builder/impl/TraitTypeDeclarationBuilderFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/compiler/builder/impl/TraitTypeDeclarationBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/compiler/builder/impl/TraitsTypeDeclarationBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/compiler/builder/impl/TraitsTypeDeclarationBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/base/TraitHelperImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/base/TraitHelperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/base/TraitUtils.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/base/TraitUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/base/evaluators/IsAEvaluatorDefinition.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/base/evaluators/IsAEvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/common/TraitDefaultFactHandle.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/common/TraitDefaultFactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/common/TraitEntryPointFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/common/TraitEntryPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/common/TraitNamedEntryPoint.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/common/TraitNamedEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/definitions/impl/TraitKnowledgePackageImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/definitions/impl/TraitKnowledgePackageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/AbstractPropertyWrapperClassBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/AbstractPropertyWrapperClassBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/AbstractProxyClassBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/AbstractProxyClassBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/AbstractTraitFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/AbstractTraitFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/AbstractTriple.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/AbstractTriple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/BitMaskKey.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/BitMaskKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/CodedHierarchy.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/CodedHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/Entity.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/Entity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/ExternalizableLinkedHashMap.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/ExternalizableLinkedHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/Fact.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/Fact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/Field.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/Field.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/HierarchyEncoder.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/HierarchyEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/IndexedTypeHierarchy.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/IndexedTypeHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/Jenerator.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/Jenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/Key.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/Key.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/LatticeElement.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/LatticeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/LogicalMapCore.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/LogicalMapCore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/LogicalTypeInconsistencyException.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/LogicalTypeInconsistencyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/MapCore.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/MapCore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/MapWrapper.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/MapWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/NullTraitType.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/NullTraitType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/ThingProxyImplPlaceHolder.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/ThingProxyImplPlaceHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitBuilderUtil.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitBuilderUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitClassBuilderFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitClassBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitClassBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitClassBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitCoreWrapperClassBuilder.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitCoreWrapperClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitCoreWrapperClassBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitCoreWrapperClassBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitFactoryImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitFieldDefaultValue.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitFieldDefaultValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitFieldImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitFieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitFieldTMSImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitFieldTMSImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitMapPropertyWrapperClassBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitMapPropertyWrapperClassBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitMapProxyClassBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitMapProxyClassBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitPropertyWrapperClassBuilder.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitPropertyWrapperClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitProxy.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitProxyClassBuilder.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitProxyClassBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitProxyImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitProxyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitRegistry.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitRegistryImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitTriplePropertyWrapperClassBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitTriplePropertyWrapperClassBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitTripleProxyClassBuilderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitTripleProxyClassBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitTypeMapImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitTypeMapImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitableMap.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TraitableMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/Triple.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/Triple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleBasedBean.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleBasedBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleBasedStruct.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleBasedStruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleBasedTypes.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleBasedTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleFactoryImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleStore.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TripleStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TypeCache.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TypeCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TypeHierarchy.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TypeHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TypeLattice.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TypeLattice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/TypeWrapper.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/TypeWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/factmodel/VirtualPropertyMode.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/factmodel/VirtualPropertyMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/AbstractWMTask.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/AbstractWMTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ClassLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ClassLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/Don.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/Don.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/DonLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/DonLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/Identifiable.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/Identifiable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/InverseManyValuedMetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/InverseManyValuedMetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/InverseOneValuedMetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/InverseOneValuedMetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/InvertibleMetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/InvertibleMetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/InvertiblePropertyLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/InvertiblePropertyLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/Lit.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/Lit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyToManyPropertyLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyToManyPropertyLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyToManyValuedMetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyToManyValuedMetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyToOnePropertyLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyToOnePropertyLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyToOneValuedMetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyToOneValuedMetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyValuedMetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ManyValuedMetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/MetaCallableTask.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/MetaCallableTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/MetaClass.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/MetaClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/MetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/MetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/MetadataContainer.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/MetadataContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/MetadataHolder.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/MetadataHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/Metadatable.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/Metadatable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/Modify.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/Modify.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ModifyLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ModifyLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ModifyTask.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ModifyTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/NewInstance.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/NewInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/NewInstanceLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/NewInstanceLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/OneToManyPropertyLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/OneToManyPropertyLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/OneToManyValuedMetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/OneToManyValuedMetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/OneToOnePropertyLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/OneToOnePropertyLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/OneToOneValuedMetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/OneToOneValuedMetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/OneValuedMetaProperty.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/OneValuedMetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/PropertyLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/PropertyLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/Shed.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/Shed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ToManyPropertyLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ToManyPropertyLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/ToOnePropertyLiteral.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/ToOnePropertyLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/With.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/With.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/metadata/WorkingMemoryTask.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/metadata/WorkingMemoryTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitAlphaNode.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitAlphaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitCoreComponentFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitCoreComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitFactHandleFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitFactHandleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitObjectTypeNode.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitObjectTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitPhreakNodeFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitPhreakNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitProxyObjectTypeNode.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitProxyObjectTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitRuntimeComponentFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitRuntimeComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitRuntimeComponentFactoryImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitRuntimeComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/util/AbstractBitwiseHierarchyImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/util/AbstractBitwiseHierarchyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/util/AbstractCodedHierarchyImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/util/AbstractCodedHierarchyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/util/CodedHierarchyImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/util/CodedHierarchyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/util/HierNode.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/util/HierNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/util/HierarchyEncoderImpl.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/util/HierarchyEncoderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/main/java/org/drools/traits/core/util/StandaloneTraitFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/util/StandaloneTraitFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/UseOfRuleFlowGroupPlusLockOnTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/UseOfRuleFlowGroupPlusLockOnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/Address.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/Cheese.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/Cheese.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/CommonTraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/CommonTraitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/Option.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/Option.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/Person.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/PersonInterface.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/PersonInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/Pet.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/Pet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/ReviseTraitTestWithPRAlwaysCategory.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/ReviseTraitTestWithPRAlwaysCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/DoSomethingProxyImpl.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/DoSomethingProxyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/IDoSomething.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/IDoSomething.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/IPerson.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/IPerson.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/IRole.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/IRole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/ISomethingWithBehaviour.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/ISomethingWithBehaviour.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/IStudent.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/IStudent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/Imp.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/Imp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/Imp2.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/Imp2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/ImpCoreWrapper.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/ImpCoreWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LegacyTraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LegacyTraitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LogicalTraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/LogicalTraitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/Message.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/PojoFact.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/PojoFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/SomeClass.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/SomeClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/SomeInterface.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/SomeInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/SomethingImpl.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/SomethingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StandaloneTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StandaloneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentImpl.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyImpl2.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyImpl2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyImpl3.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyImpl3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyWrapper2.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyWrapper2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyWrapper3.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/StudentProxyWrapper3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitFieldsAndLegacyClassesTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitFieldsAndLegacyClassesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitMapCoreTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitMapCoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTestUtils.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/compiler/integrationtests/TraitTypeGenerationTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/integrationtests/TraitTypeGenerationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/factmodel/ClassBuilderTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/factmodel/ClassBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/factmodel/InstancesHashcodedTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/factmodel/InstancesHashcodedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/factmodel/JeneratorTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/factmodel/JeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/factmodel/TripleStoreTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/factmodel/TripleStoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/MetadataTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/MetadataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/AnotherKlass.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/AnotherKlass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/AnotherKlassImpl.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/AnotherKlassImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/AnotherKlass_.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/AnotherKlass_.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/Klass.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/Klass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/KlassImpl.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/KlassImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/Klass_.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/Klass_.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/SubKlass.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/SubKlass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/SubKlassImpl.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/SubKlassImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/SubKlass_.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/meta/org/test/SubKlass_.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/core/util/HierarchyTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/core/util/HierarchyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/persistence/DroolsPersistenceUtil.java
+++ b/drools-traits/src/test/java/org/drools/traits/persistence/DroolsPersistenceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-traits/src/test/java/org/drools/traits/persistence/PersistenceTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/persistence/PersistenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/ClassTypeResolver.java
+++ b/drools-util/src/main/java/org/drools/util/ClassTypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/ClassUtils.java
+++ b/drools-util/src/main/java/org/drools/util/ClassUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/CoercionUtil.java
+++ b/drools-util/src/main/java/org/drools/util/CoercionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/Config.java
+++ b/drools-util/src/main/java/org/drools/util/Config.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/DateUtils.java
+++ b/drools-util/src/main/java/org/drools/util/DateUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/IncompatibleGetterOverloadException.java
+++ b/drools-util/src/main/java/org/drools/util/IncompatibleGetterOverloadException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/IoUtils.java
+++ b/drools-util/src/main/java/org/drools/util/IoUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/JarUtils.java
+++ b/drools-util/src/main/java/org/drools/util/JarUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/MathUtils.java
+++ b/drools-util/src/main/java/org/drools/util/MathUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/MethodUtils.java
+++ b/drools-util/src/main/java/org/drools/util/MethodUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/ObjectPool.java
+++ b/drools-util/src/main/java/org/drools/util/ObjectPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/Pair.java
+++ b/drools-util/src/main/java/org/drools/util/Pair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/ResourceHelper.java
+++ b/drools-util/src/main/java/org/drools/util/ResourceHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/StreamUtils.java
+++ b/drools-util/src/main/java/org/drools/util/StreamUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/StringUtils.java
+++ b/drools-util/src/main/java/org/drools/util/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/TypeResolver.java
+++ b/drools-util/src/main/java/org/drools/util/TypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/AllSetBitMask.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/AllSetBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/AllSetButLastBitMask.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/AllSetButLastBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/AllSetMask.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/AllSetMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/BitMask.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/BitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/BitMaskUtil.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/BitMaskUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/EmptyBitMask.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/EmptyBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/EmptyButLastBitMask.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/EmptyButLastBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/EmptyMask.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/EmptyMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/LongBitMask.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/LongBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/bitmask/SingleLongBitMask.java
+++ b/drools-util/src/main/java/org/drools/util/bitmask/SingleLongBitMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/main/java/org/drools/util/functions/TriConsumer.java
+++ b/drools-util/src/main/java/org/drools/util/functions/TriConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/test/java/org/drools/util/JarUtilsTest.java
+++ b/drools-util/src/test/java/org/drools/util/JarUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/test/java/org/drools/util/KiePathTest.java
+++ b/drools-util/src/test/java/org/drools/util/KiePathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/test/java/org/drools/util/ResourceHelperTest.java
+++ b/drools-util/src/test/java/org/drools/util/ResourceHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/test/java/org/drools/util/StringUtilsTest.java
+++ b/drools-util/src/test/java/org/drools/util/StringUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/test/java/org/drools/util/TypeResolverTest.java
+++ b/drools-util/src/test/java/org/drools/util/TypeResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-util/src/test/java/org/drools/util/bitmask/LongBitMaskTest.java
+++ b/drools-util/src/test/java/org/drools/util/bitmask/LongBitMaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/Callback.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/Callback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/CancellableRepeatingCommand.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/CancellableRepeatingCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/Command.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/Reporter.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/Reporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/Status.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/Status.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/StatusUpdate.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/StatusUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/CheckType.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/CheckType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/IllegalVerifierStateIssue.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/IllegalVerifierStateIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/ImpossibleMatchIssue.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/ImpossibleMatchIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/Issue.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/Issue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/Issues.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/Issues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/MultipleValuesForOneActionIssue.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/MultipleValuesForOneActionIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/RedundantConditionsIssue.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/RedundantConditionsIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/Severity.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/Severity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/SingleHitLostIssue.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/SingleHitLostIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/ValueForActionIsSetTwiceIssue.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/ValueForActionIsSetTwiceIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/ValueForFactFieldIsSetTwiceIssue.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/ValueForFactFieldIsSetTwiceIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/RuleInspectorCache.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/RuleInspectorCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/FieldActionsInspectorMultiMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/FieldActionsInspectorMultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/FieldInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/FieldInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/PatternInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/PatternInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/RuleInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/RuleInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/RuleInspectorDumper.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/RuleInspectorDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/RuleInspectorUpdater.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/RuleInspectorUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/ActionInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/ActionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/ActionInspectorFactory.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/ActionInspectorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/ActionsInspectorMultiMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/ActionsInspectorMultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/BRLActionInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/BRLActionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/FieldActionInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/action/FieldActionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/BRLConditionInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/BRLConditionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/BooleanConditionInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/BooleanConditionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/ComparableConditionInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/ComparableConditionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/ConditionInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/ConditionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/ConditionInspectorFactory.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/ConditionInspectorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/ConditionsInspectorMultiMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/ConditionsInspectorMultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/ComparableWrapper.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/ComparableWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectConflictingRowsCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectConflictingRowsCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectDeficientRowsCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectDeficientRowsCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectEmptyRowCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectEmptyRowCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectImpossibleMatchCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectImpossibleMatchCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectMissingActionCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectMissingActionCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectMissingConditionCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectMissingConditionCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectMultipleValuesForOneActionCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectMultipleValuesForOneActionCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantActionBase.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantActionBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantActionFactFieldCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantActionFactFieldCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantActionValueCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantActionValueCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantConditionsCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantConditionsCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantRowsCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/DetectRedundantRowsCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/SingleHitCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/SingleHitCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/SingleRangeCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/SingleRangeCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/Check.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/Check.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckBase.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckFactory.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckRunManager.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckRunManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckRunner.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckStorage.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/CheckStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/ChecksRepeatingCommand.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/ChecksRepeatingCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/JavaCheckRunner.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/JavaCheckRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/OneToManyCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/OneToManyCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/PairCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/PairCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/PairCheckBundle.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/PairCheckBundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/PairCheckStorage.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/PairCheckStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/PriorityListCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/PriorityListCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/SingleCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/base/SingleCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/configuration/AnalyzerConfiguration.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/configuration/AnalyzerConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/configuration/CheckConfiguration.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/configuration/CheckConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/configuration/DateTimeFormatProvider.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/configuration/DateTimeFormatProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/configuration/RunnerType.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/configuration/RunnerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/Index.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/Index.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/IndexImpl.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/IndexImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/IndexKey.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/IndexKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/Key.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/Key.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/KeyType.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/KeyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/UUIDKey.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/UUIDKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/UUIDKeyProvider.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/UUIDKeyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/UpdatableKey.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/UpdatableKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/Value.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/Value.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/Values.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/keys/Values.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/ComparableMatchers.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/ComparableMatchers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/ExactMatcher.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/ExactMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/FieldMatchers.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/FieldMatchers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/FromMatcher.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/FromMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/KeyMatcher.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/KeyMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/Matcher.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/Matcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/ToMatcher.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/ToMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/UUIDMatcher.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/UUIDMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/UUIDMatchers.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/matchers/UUIDMatchers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Action.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Action.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ActionSuperType.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ActionSuperType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Actions.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Actions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ActivationTime.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ActivationTime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/BRLAction.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/BRLAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/BRLCondition.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/BRLCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Column.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Column.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Columns.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Columns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Condition.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Condition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ConditionSuperType.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ConditionSuperType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Conditions.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Conditions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/DateEffectiveRuleAttribute.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/DateEffectiveRuleAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/DateExpiresRuleAttribute.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/DateExpiresRuleAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Field.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Field.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/FieldAction.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/FieldAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/FieldBase.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/FieldBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/FieldCondition.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/FieldCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Fields.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Fields.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/FieldsBase.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/FieldsBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ObjectField.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ObjectField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ObjectFields.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ObjectFields.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ObjectType.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ObjectTypes.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ObjectTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Pattern.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Patterns.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Patterns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/RetractAction.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/RetractAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Rule.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/RuleAttribute.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/RuleAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Rules.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Rules.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/WorkItemAction.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/WorkItemAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/MapBy.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/MapBy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/Matchers.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/Matchers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/Query.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/QueryableIndex.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/QueryableIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/Where.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/query/Where.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/AllListener.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/AllListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/ChangeHelper.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/ChangeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/ExactMatcherSearch.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/ExactMatcherSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/FirstListener.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/FirstListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/LastListener.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/LastListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/Listen.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/Listen.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/QueryCallback.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/QueryCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/Select.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/select/Select.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/main/Analyzer.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/main/Analyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/main/Reporter.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/main/Reporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/ArrayListSubMapProvider.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/ArrayListSubMapProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/ArrayMultiMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/ArrayMultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/ChangeHandledMultiMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/ChangeHandledMultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/IndexedKeyTreeMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/IndexedKeyTreeMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/InspectorFactory.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/InspectorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/InspectorList.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/InspectorList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/InspectorMultiMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/InspectorMultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/KeyChangeListener.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/KeyChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/KeyDefinition.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/KeyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/KeyTreeMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/KeyTreeMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/LeafInspectorList.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/LeafInspectorList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/MultiMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/MultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/MultiMapChangeHandler.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/MultiMapChangeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/MultiMapFactory.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/MultiMapFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/MultiSet.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/MultiSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/NewSubMapProvider.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/NewSubMapProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/RawMultiMap.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/RawMultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/RetractHandler.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/RetractHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/UUIDKeySet.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/UUIDKeySet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/UpdatableInspectorList.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/UpdatableInspectorList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasConflicts.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasConflicts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasIndex.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasKeys.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasKeys.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasRedundancy.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasRedundancy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasUUID.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/HasUUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/RedundancyResult.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/maps/util/RedundancyResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/Conflict.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/Conflict.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/ConflictResolver.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/ConflictResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/Conflicts.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/Conflicts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/HumanReadable.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/HumanReadable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsConflicting.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsConflicting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsDeficient.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsDeficient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsOverlapping.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsOverlapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsRedundant.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsRedundant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsSubsuming.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/IsSubsuming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/Operator.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/Operator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/Relation.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/Relation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/RelationResolver.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/RelationResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/SubsumptionBlocker.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/SubsumptionBlocker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/SubsumptionBlockers.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/SubsumptionBlockers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/SubsumptionResolver.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/relations/SubsumptionResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/util/PortablePreconditions.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/util/PortablePreconditions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/api/reporting/IllegalVerifierStateIssueTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/api/reporting/IllegalVerifierStateIssueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/AnalyzerConfigurationMock.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/AnalyzerConfigurationMock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/RuleInspectorCacheTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/RuleInspectorCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/ConditionsInspectorTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/ConditionsInspectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/FieldInspectorRelationsTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/FieldInspectorRelationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/FieldInspectorUpdateTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/FieldInspectorUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/PatternInspectorTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/PatternInspectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/action/ActionInspectorConflictResolverTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/action/ActionInspectorConflictResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/BooleanConditionInspectorTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/BooleanConditionInspectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/ComparableConditionInspectorConflictResolverTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/ComparableConditionInspectorConflictResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/ComparableConditionInspectorSubsumptionTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/ComparableConditionInspectorSubsumptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/ConditionInspectorUtils.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/ConditionInspectorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/DateConditionInspectorSubsumptionTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/DateConditionInspectorSubsumptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/DoubleComparableConditionInspectorCoverTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/DoubleComparableConditionInspectorCoverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorConflictResolverOverlapTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorConflictResolverOverlapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorSubsumptionResolverTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorSubsumptionResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorSubsumptionTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorSubsumptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorConflictResolverOverlapTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorConflictResolverOverlapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorCoverTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorCoverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorOverlapTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorOverlapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorSubsumptionResolverTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorSubsumptionResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorSubsumptionTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorSubsumptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorToHumanReadableTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/cache/inspectors/condition/StringConditionInspectorToHumanReadableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/CheckRunManagerTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/CheckRunManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/ComparableWrapperTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/ComparableWrapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/base/CheckFactoryTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/base/CheckFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/base/CheckRunManagerRepeatingCommandTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/base/CheckRunManagerRepeatingCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/base/PairCheckStorageListTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/checks/base/PairCheckStorageListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/ActionTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/ActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/ConditionTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/ConditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/ConditionsListenerTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/ConditionsListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/keys/KeyTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/keys/KeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/keys/ValueNullTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/keys/ValueNullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/keys/ValueTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/keys/ValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/keys/ValuesTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/keys/ValuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/model/ActivationTimeTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/model/ActivationTimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/query/QueryableIndexTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/query/QueryableIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ExactMatcherSearchTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ExactMatcherSearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/Item.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ListenAddTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ListenAddTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ListenAddToEmptyTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ListenAddToEmptyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ListenAllTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ListenAllTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ListenRemoveTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/ListenRemoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/Person.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectEmptyMapTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectEmptyMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectExactMatcherNegateTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectExactMatcherNegateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectExactMatcherTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectExactMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectKeyMatcherTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectKeyMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectNoMatchesTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectNoMatchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectNullTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectNullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectWithNegativeExactMatcherWhenTheValueIsNotInTheMapTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/select/SelectWithNegativeExactMatcherWhenTheValueIsNotInTheMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/ChangeHandledMultiMapPreExistingDataTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/ChangeHandledMultiMapPreExistingDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/ChangeHandledMultiMapTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/ChangeHandledMultiMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/IndexedKeyTreeMapTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/IndexedKeyTreeMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyDefinitionBuilderTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyDefinitionBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyTreeMapMergeTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyTreeMapMergeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyTreeMapMultiValueKeyTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyTreeMapMultiValueKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyTreeMapTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyTreeMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyTreeMapUUIDKeyTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KeyTreeMapUUIDKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KnownKeysKeyTreeMapTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/KnownKeysKeyTreeMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/MultiMapFactoryTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/MultiMapFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/UpdatableInspectorListTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/maps/UpdatableInspectorListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/relations/OperatorTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/relations/OperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/relations/RelationResolverConflictsTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/relations/RelationResolverConflictsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/relations/RelationResolverSubsumptionTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/relations/RelationResolverSubsumptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/DefaultVerifierConfiguration.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/DefaultVerifierConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/EmptyVerifierConfiguration.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/EmptyVerifierConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/Verifier.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/Verifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/VerifierConfiguration.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/VerifierConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/VerifierConfigurationImpl.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/VerifierConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/VerifierConfigurationOptions.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/VerifierConfigurationOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/VerifierError.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/VerifierError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/ScopesAgendaFilter.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/ScopesAgendaFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilder.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderConfiguration.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderConfigurationImpl.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderError.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderErrors.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderErrors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderFactory.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderImpl.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierImpl.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierKnowledgeBaseBuilder.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierKnowledgeBaseBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierPackageBuilder.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/builder/VerifierPackageBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/BooleanRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/BooleanRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ChildComponent.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ChildComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Consequence.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Consequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/DateRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/DateRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/EntryPoint.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/EntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/EnumField.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/EnumField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/EnumRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/EnumRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Eval.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Eval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Field.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Field.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/FieldVariable.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/FieldVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Import.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Import.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/InlineEvalDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/InlineEvalDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/LiteralRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/LiteralRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/NamedConsequence.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/NamedConsequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/NumberRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/NumberRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ObjectType.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/OperatorDescrType.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/OperatorDescrType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PackageComponent.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PackageComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Pattern.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternComponent.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternComponentSource.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternComponentSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternEval.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternEval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternOperatorDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternOperatorDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternVariable.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/PatternVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Possibility.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Possibility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/QualifiedIdentifierRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/QualifiedIdentifierRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Restriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Restriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ReturnValueFieldDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ReturnValueFieldDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ReturnValueRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/ReturnValueRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/RuleComponent.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/RuleComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/RuleEval.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/RuleEval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/RuleOperatorDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/RuleOperatorDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/RulePackage.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/RulePackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Source.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Source.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/StringRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/StringRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/SubPattern.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/SubPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/SubRule.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/SubRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/TextConsequence.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/TextConsequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Variable.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Variable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VariableRestriction.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VariableRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierAccessorDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierAccessorDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierAccumulateDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierAccumulateDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierCollectDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierCollectDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierComponentSource.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierComponentSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierComponentType.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierComponentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierFieldAccessDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierFieldAccessDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierFromDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierFromDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierFunctionCallDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierFunctionCallDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierMethodAccessDescr.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierMethodAccessDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierRule.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/VerifierRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/WorkingMemory.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/WorkingMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierComponent.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierData.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierDataKnowledgeSession.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierDataKnowledgeSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierDataMaps.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierDataMaps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierReport.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierReportFactory.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierReportFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierReportImpl.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/data/VerifierReportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/doc/DroolsDocsBuilder.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/doc/DroolsDocsBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/doc/DroolsDocsComponentFactory.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/doc/DroolsDocsComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/jarloader/PackageHeaderLoader.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/jarloader/PackageHeaderLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/jarloader/VerifierMapBackedClassLoader.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/jarloader/VerifierMapBackedClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/DrlPackageParser.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/DrlPackageParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/DrlRuleParser.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/DrlRuleParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/FindMissingNumber.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/FindMissingNumber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/Multimap.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/misc/Multimap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/PlainTextReportWriter.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/PlainTextReportWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/VerfierReportConfigurationOptions.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/VerfierReportConfigurationOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/VerifierReportConfiguration.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/VerifierReportConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/VerifierReportWriter.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/VerifierReportWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/VerifierReportWriterFactory.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/VerifierReportWriterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/XMLReportWriter.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/XMLReportWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/AlwaysTrue.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/AlwaysTrue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Cause.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Cause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Equivalence.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Equivalence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Gap.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Gap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Incompatibility.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Incompatibility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/MessageType.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/MessageType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/MissingNumberPattern.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/MissingNumberPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/MissingRange.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/MissingRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Opposites.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Opposites.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Overlap.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Overlap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/PartialRedundancy.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/PartialRedundancy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Reason.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Reason.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/ReasonType.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/ReasonType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Redundancy.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Redundancy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Severity.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Severity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Subsumption.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/Subsumption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/VerifierMessage.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/VerifierMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/VerifierMessageBase.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/VerifierMessageBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/VerifierRangeCheckMessage.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/components/VerifierRangeCheckMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/ComponentsReportVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/ComponentsReportVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/HTMLReportWriter.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/HTMLReportWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/MissingRangesReportVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/MissingRangesReportVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/ReportModeller.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/ReportModeller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/ReportVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/ReportVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/UrlFactory.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/UrlFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/VerifierMessagesVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/VerifierMessagesVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/solver/PatternSolver.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/solver/PatternSolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/solver/RuleSolver.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/solver/RuleSolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/solver/Solver.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/solver/Solver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/solver/Solvers.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/solver/Solvers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/ConditionalElementDescrVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/ConditionalElementDescrVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/ExprConstraintDescrVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/ExprConstraintDescrVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/FieldConstraintDescrVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/FieldConstraintDescrVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/ObjectTypeFactory.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/ObjectTypeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/PackageDescrVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/PackageDescrVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/PatternDescrVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/PatternDescrVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/RuleDescrVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/RuleDescrVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/TypeDeclarationDescrVisitor.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/TypeDeclarationDescrVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/UnknownDescriptionException.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/visitor/UnknownDescriptionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/ConditionalBranchDescrTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/ConditionalBranchDescrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/PatternSolverDRLTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/PatternSolverDRLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckCleanTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckCleanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckDatesTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckDatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckDoublesTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckDoublesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckIntegersTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckIntegersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/RangeCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/SolversTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/SolversTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/TestBase.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/TestBaseOld.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/TestBaseOld.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/VerifierComponentMockFactory.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/VerifierComponentMockFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/VerifierTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/VerifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/VerifierTestStandalone.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/VerifierTestStandalone.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/VerifyingScopeTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/VerifyingScopeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/alwaysFalse/AlwaysFalseTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/alwaysFalse/AlwaysFalseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/alwaysTrue/AlwaysTruePatternTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/alwaysTrue/AlwaysTruePatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/alwaysTrue/AlwaysTrueRuleTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/alwaysTrue/AlwaysTrueRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/components/LiteralRestrictionTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/components/LiteralRestrictionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/consequence/ConsequenceTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/consequence/ConsequenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/consequence/NamedConsequencesTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/consequence/NamedConsequencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/data/VerifierDataMapsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/data/VerifierDataMapsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/doc/StandaloneDocBuilder.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/doc/StandaloneDocBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/equivalence/EquivalentRulesTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/equivalence/EquivalentRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incoherence/IncoherentPatternsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incoherence/IncoherentPatternsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incoherence/IncoherentRestrictionsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incoherence/IncoherentRestrictionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incompatibility/IncompatibilityBase.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incompatibility/IncompatibilityBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incompatibility/IncompatibilityPatternsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incompatibility/IncompatibilityPatternsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incompatibility/IncompatibilityRestrictionsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/incompatibility/IncompatibilityRestrictionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/jarloader/PackageHeaderLoaderTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/jarloader/PackageHeaderLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/jarloader/VerifierMapBackedClassLoaderTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/jarloader/VerifierMapBackedClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/misc/DrlPackageDataTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/misc/DrlPackageDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/misc/DrlRuleDataTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/misc/DrlRuleDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/misc/FindMissingNumberTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/misc/FindMissingNumberTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/missingEquality/MissingEqualityTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/missingEquality/MissingEqualityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/opposites/OppositePatternsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/opposites/OppositePatternsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/opposites/OppositeRestrictionsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/opposites/OppositeRestrictionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/opposites/OppositesBase.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/opposites/OppositesBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/optimisation/PatternOrderTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/optimisation/PatternOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/optimisation/RestrictionOrderTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/optimisation/RestrictionOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/overlaps/OverlappingRestrictionsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/overlaps/OverlappingRestrictionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/redundancy/NotesTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/redundancy/NotesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/redundancy/RedundancyTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/redundancy/RedundancyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/redundancy/WarningsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/redundancy/WarningsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/report/VerifierReportBuilderTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/report/VerifierReportBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/report/components/CauseTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/report/components/CauseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/solver/PatternSolverTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/solver/PatternSolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/subsumption/SubsumptantRestrictionsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/subsumption/SubsumptantRestrictionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/subsumption/SubsumptantSubPatternsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/subsumption/SubsumptantSubPatternsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/subsumption/SubsumptantSubRulesTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/subsumption/SubsumptantSubRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/ExprConstraintDescrVisitorTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/ExprConstraintDescrVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/NestedPatternsTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/NestedPatternsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/PackageDescrVisitorTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/PackageDescrVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/PatternDescrVisitorTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/PatternDescrVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/VerifierComponentTest.java
+++ b/drools-verifier/drools-verifier-drl/src/test/java/org/drools/verifier/visitor/VerifierComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-test-jar/src/main/java/org/test/Person.java
+++ b/drools-verifier/drools-verifier-test-jar/src/main/java/org/test/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-test-jar/src/main/java/org/test/Pet.java
+++ b/drools-verifier/drools-verifier-test-jar/src/main/java/org/test/Pet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-verifier/drools-verifier-test-jar/src/main/java/org/test/Rambo.java
+++ b/drools-verifier/drools-verifier-test-jar/src/main/java/org/test/Rambo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/ComponentsFactory.java
+++ b/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/ComponentsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/ComponentsSupplier.java
+++ b/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/ComponentsSupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/ResourceProvider.java
+++ b/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/ResourceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/classloader/ProjectClassLoader.java
+++ b/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/classloader/ProjectClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/util/ByteArrayClassLoader.java
+++ b/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/util/ByteArrayClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/util/ClassUtils.java
+++ b/drools-wiring/drools-wiring-api/src/main/java/org/drools/wiring/api/util/ClassUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-api/src/test/java/org/drools/wiring/api/classloader/ProjectClassLoaderTest.java
+++ b/drools-wiring/drools-wiring-api/src/test/java/org/drools/wiring/api/classloader/ProjectClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-dynamic/src/main/java/org/drools/wiring/dynamic/DynamicComponentsSupplier.java
+++ b/drools-wiring/drools-wiring-dynamic/src/main/java/org/drools/wiring/dynamic/DynamicComponentsSupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-dynamic/src/main/java/org/drools/wiring/dynamic/DynamicProjectClassLoader.java
+++ b/drools-wiring/drools-wiring-dynamic/src/main/java/org/drools/wiring/dynamic/DynamicProjectClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-dynamic/src/main/java/org/drools/wiring/dynamic/PackageClassLoader.java
+++ b/drools-wiring/drools-wiring-dynamic/src/main/java/org/drools/wiring/dynamic/PackageClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-dynamic/src/test/java/org/drools/dynamic/ClassLoaderTest.java
+++ b/drools-wiring/drools-wiring-dynamic/src/test/java/org/drools/dynamic/ClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticComponentsSupplier.java
+++ b/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticComponentsSupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticProjectClassLoader.java
+++ b/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticProjectClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-wiring/drools-wiring-static/src/test/java/org/drools/wiring/statics/DummyByteArrayClassLoaderTest.java
+++ b/drools-wiring/drools-wiring-static/src/test/java/org/drools/wiring/statics/DummyByteArrayClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/XMLSupportImpl.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/XMLSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/XStreamHelper.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/XStreamHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/XStreamJSon.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/XStreamJSon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/XStreamXML.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/XStreamXML.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/containers/CommandsObjectContainer.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/containers/CommandsObjectContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/containers/IdentifiersContainer.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/containers/IdentifiersContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/containers/ObjectsObjectContainer.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/containers/ObjectsObjectContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/containers/ParameterContainer.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/containers/ParameterContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/containers/RowItemContainer.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/containers/RowItemContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/containers/WorkItemResultsContainer.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/containers/WorkItemResultsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/AbstractXStreamConverter.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/AbstractXStreamConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/ChannelConverter.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/ChannelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/KBaseConverter.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/KBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/KSessionConverter.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/KSessionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/KieModuleConverter.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/KieModuleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/KieModuleMarshaller.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/KieModuleMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/KieModuleValidator.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/KieModuleValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/ListenerConverter.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/ListenerConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/QualifierConverter.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/QualifierConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/RuleTemplateConverter.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/RuleTemplateConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/main/java/org/drools/xml/support/converters/WorkItemHandelerConverter.java
+++ b/drools-xml-support/src/main/java/org/drools/xml/support/converters/WorkItemHandelerConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/test/java/org/drools/xml/support/CommandSerializationTest.java
+++ b/drools-xml-support/src/test/java/org/drools/xml/support/CommandSerializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/drools-xml-support/src/test/java/org/drools/xml/support/XStreamXMLTest.java
+++ b/drools-xml-support/src/test/java/org/drools/xml/support/XStreamXMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-common-utils/src/main/java/org/kie/efesto/common/utils/CommonCodegenUtils.java
+++ b/efesto/efesto-common-utils/src/main/java/org/kie/efesto/common/utils/CommonCodegenUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-common-utils/src/main/java/org/kie/efesto/common/utils/JavaParserUtils.java
+++ b/efesto/efesto-common-utils/src/main/java/org/kie/efesto/common/utils/JavaParserUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-common-utils/src/main/java/org/kie/efesto/common/utils/PackageClassNameUtils.java
+++ b/efesto/efesto-common-utils/src/main/java/org/kie/efesto/common/utils/PackageClassNameUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/cache/EfestoClassKey.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/cache/EfestoClassKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/cache/EfestoIdentifierClassKey.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/cache/EfestoIdentifierClassKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/constants/Constants.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/constants/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/exceptions/KieEfestoCommonException.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/exceptions/KieEfestoCommonException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/AppRoot.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/AppRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/ComponentRoot.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/ComponentRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/Id.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/Id.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/LocalId.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/LocalId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/LocalUri.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/LocalUri.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/LocalUriId.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/LocalUriId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/ReflectiveAppRoot.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/ReflectiveAppRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/RemoteId.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/identifiers/RemoteId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/io/IndexFile.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/io/IndexFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/listener/EfestoListener.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/listener/EfestoListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/EfestoContext.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/EfestoContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedClassResource.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedClassResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedClassesRepository.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedClassesRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedExecutableResource.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedExecutableResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedRedirectResource.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedRedirectResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedResource.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedResources.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/model/GeneratedResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/utils/CollectionUtils.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/utils/CollectionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/utils/EfestoAppRootHelper.java
+++ b/efesto/efesto-core/efesto-common-api/src/main/java/org/kie/efesto/common/api/utils/EfestoAppRootHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/cache/EfestoClassKeyTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/cache/EfestoClassKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/cache/EfestoIdentifierClassKeyTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/cache/EfestoIdentifierClassKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/AppRootTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/AppRootTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/ModelLocalUriIdTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/ModelLocalUriIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/ReflectiveAppRootTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/ReflectiveAppRootTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/ComponentFoo.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/ComponentFoo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/ComponentRootA.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/ComponentRootA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/ComponentRootB.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/ComponentRootB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/EfestoComponentRootBar.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/EfestoComponentRootBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/LocalComponentIdA.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/LocalComponentIdA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/LocalComponentIdB.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/LocalComponentIdB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/LocalComponentIdFoo.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/identifiers/componentroots/LocalComponentIdFoo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/io/IndexFileTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/io/IndexFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/io/MemoryFileTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/io/MemoryFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/model/GeneratedResourcesTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/model/GeneratedResourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/utils/FileNameUtilsTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/utils/FileNameUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/utils/MemoryFileUtilsTest.java
+++ b/efesto/efesto-core/efesto-common-api/src/test/java/org/kie/efesto/common/api/utils/MemoryFileUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/main/java/org/kie/efesto/common/core/serialization/ModelLocalUriIdSerializer.java
+++ b/efesto/efesto-core/efesto-common-core/src/main/java/org/kie/efesto/common/core/serialization/ModelLocalUriIdSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/main/java/org/kie/efesto/common/core/utils/JSONUtils.java
+++ b/efesto/efesto-core/efesto-common-core/src/main/java/org/kie/efesto/common/core/utils/JSONUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/ComponentFoo.java
+++ b/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/ComponentFoo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/ComponentRootA.java
+++ b/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/ComponentRootA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/ComponentRootB.java
+++ b/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/ComponentRootB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/LocalComponentIdA.java
+++ b/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/LocalComponentIdA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/LocalComponentIdB.java
+++ b/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/LocalComponentIdB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/LocalComponentIdFoo.java
+++ b/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/identifiers/componentroots/LocalComponentIdFoo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/serialization/ModelLocalUriIdSerializerTest.java
+++ b/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/serialization/ModelLocalUriIdSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/utils/JSONUtilsTest.java
+++ b/efesto/efesto-core/efesto-common-core/src/test/java/org/kie/efesto/common/core/utils/JSONUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/exceptions/EfestoCompilationManagerException.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/exceptions/EfestoCompilationManagerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/AbstractEfestoCallableCompilationOutput.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/AbstractEfestoCallableCompilationOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoCallableOutput.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoCallableOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoClassesContainer.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoClassesContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoCompilationOutput.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoCompilationOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoFileResource.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoFileResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoFileSetResource.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoFileSetResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoInputStreamResource.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoInputStreamResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoOutputClassesContainer.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoOutputClassesContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoRedirectOutput.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoRedirectOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoResource.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoSetResource.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/model/EfestoSetResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/service/CompilationManager.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/main/java/org/kie/efesto/compilationmanager/api/service/CompilationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/test/java/org/kie/efesto/compilationmanager/api/model/EfestoRedirectOutputTest.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/src/test/java/org/kie/efesto/compilationmanager/api/model/EfestoRedirectOutputTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/main/java/org/kie/efesto/compilationmanager/core/utils/CompilationManagerUtils.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/main/java/org/kie/efesto/compilationmanager/core/utils/CompilationManagerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/AbstractMockKieCompilerService.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/AbstractMockKieCompilerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/AbstractMockOutput.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/AbstractMockOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoInputF.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoInputF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputA.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputB.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputC.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputD.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputE.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockEfestoRedirectOutputE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockKieCompilerServiceAB.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockKieCompilerServiceAB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockKieCompilerServiceC.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/mocks/MockKieCompilerServiceC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/utils/CompilationManagerUtilsTest.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/utils/CompilationManagerUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/utils/TestSPIUtils.java
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/src/test/java/org/kie/efesto/compilationmanager/core/utils/TestSPIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/exceptions/EfestoRuntimeManagerException.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/exceptions/EfestoRuntimeManagerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/exceptions/KieRuntimeServiceException.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/exceptions/KieRuntimeServiceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/BaseEfestoInput.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/BaseEfestoInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/EfestoInput.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/EfestoInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/EfestoMapInputDTO.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/EfestoMapInputDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/EfestoOriginalTypeGeneratedType.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/EfestoOriginalTypeGeneratedType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/EfestoOutput.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/model/EfestoOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/service/KieRuntimeService.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/main/java/org/kie/efesto/runtimemanager/api/service/KieRuntimeService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/test/java/org/kie/efesto/runtimemanager/api/model/EfestoInputTest.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/src/test/java/org/kie/efesto/runtimemanager/api/model/EfestoInputTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/main/java/org/kie/efesto/runtimemanager/core/model/EfestoRuntimeContextUtils.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/main/java/org/kie/efesto/runtimemanager/core/model/EfestoRuntimeContextUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/AbstractMockKieRuntimeService.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/AbstractMockKieRuntimeService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/MockEfestoInputA.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/MockEfestoInputA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/MockEfestoInputB.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/MockEfestoInputB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/MockEfestoInputC.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/MockEfestoInputC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/MockEfestoInputD.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/mocks/MockEfestoInputD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/utils/GeneratedResourceUtilsTest.java
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/src/test/java/org/kie/efesto/runtimemanager/core/utils/GeneratedResourceUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/KieBase.java
+++ b/kie-api/src/main/java/org/kie/api/KieBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/KieBaseConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/KieBaseConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/KieServices.java
+++ b/kie-api/src/main/java/org/kie/api/KieServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/PropertiesConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/PropertiesConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/CompilationErrorsException.java
+++ b/kie-api/src/main/java/org/kie/api/builder/CompilationErrorsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/Include.java
+++ b/kie-api/src/main/java/org/kie/api/builder/Include.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/KieBuilder.java
+++ b/kie-api/src/main/java/org/kie/api/builder/KieBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/KieFileSystem.java
+++ b/kie-api/src/main/java/org/kie/api/builder/KieFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/KieModule.java
+++ b/kie-api/src/main/java/org/kie/api/builder/KieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/KieRepository.java
+++ b/kie-api/src/main/java/org/kie/api/builder/KieRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/KieScanner.java
+++ b/kie-api/src/main/java/org/kie/api/builder/KieScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/KieScannerFactoryService.java
+++ b/kie-api/src/main/java/org/kie/api/builder/KieScannerFactoryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/Message.java
+++ b/kie-api/src/main/java/org/kie/api/builder/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/ReleaseId.java
+++ b/kie-api/src/main/java/org/kie/api/builder/ReleaseId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/ReleaseIdComparator.java
+++ b/kie-api/src/main/java/org/kie/api/builder/ReleaseIdComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/Results.java
+++ b/kie-api/src/main/java/org/kie/api/builder/Results.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/model/ChannelModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/ChannelModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/model/FileLoggerModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/FileLoggerModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/model/KieBaseModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/KieBaseModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/model/KieModuleModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/KieModuleModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/model/KieSessionModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/KieSessionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/model/ListenerModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/ListenerModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/model/QualifierModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/QualifierModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/model/RuleTemplateModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/RuleTemplateModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/builder/model/WorkItemHandlerModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/WorkItemHandlerModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/command/BatchExecutionCommand.java
+++ b/kie-api/src/main/java/org/kie/api/command/BatchExecutionCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/command/Command.java
+++ b/kie-api/src/main/java/org/kie/api/command/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/command/ExecutableCommand.java
+++ b/kie-api/src/main/java/org/kie/api/command/ExecutableCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/command/KieCommands.java
+++ b/kie-api/src/main/java/org/kie/api/command/KieCommands.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/command/Setter.java
+++ b/kie-api/src/main/java/org/kie/api/command/Setter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/concurrent/KieExecutors.java
+++ b/kie-api/src/main/java/org/kie/api/concurrent/KieExecutors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/BetaRangeIndexOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/BetaRangeIndexOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/ConfigurationKey.java
+++ b/kie-api/src/main/java/org/kie/api/conf/ConfigurationKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/DeclarativeAgendaOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/DeclarativeAgendaOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/EqualityBehaviorOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/EqualityBehaviorOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/EventProcessingOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/EventProcessingOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/KieBaseMutabilityOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/KieBaseMutabilityOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/KieBaseOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/KieBaseOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/KieBaseOptionsConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/conf/KieBaseOptionsConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/MBeansOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/MBeansOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/MultiValueKieBaseOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/MultiValueKieBaseOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/MultiValueOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/MultiValueOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/MultiValueRuleBaseOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/MultiValueRuleBaseOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/Option.java
+++ b/kie-api/src/main/java/org/kie/api/conf/Option.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/OptionKey.java
+++ b/kie-api/src/main/java/org/kie/api/conf/OptionKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/OptionsConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/conf/OptionsConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/PrototypesOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/PrototypesOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/RemoveIdentitiesOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/RemoveIdentitiesOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/SequentialOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/SequentialOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/SessionsPoolOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/SessionsPoolOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/SingleValueKieBaseOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/SingleValueKieBaseOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/SingleValueOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/SingleValueOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/conf/SingleValueRuleBaseOption.java
+++ b/kie-api/src/main/java/org/kie/api/conf/SingleValueRuleBaseOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/KieDefinition.java
+++ b/kie-api/src/main/java/org/kie/api/definition/KieDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/KieDescr.java
+++ b/kie-api/src/main/java/org/kie/api/definition/KieDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/KiePackage.java
+++ b/kie-api/src/main/java/org/kie/api/definition/KiePackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/process/Connection.java
+++ b/kie-api/src/main/java/org/kie/api/definition/process/Connection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/process/Node.java
+++ b/kie-api/src/main/java/org/kie/api/definition/process/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/process/NodeContainer.java
+++ b/kie-api/src/main/java/org/kie/api/definition/process/NodeContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/process/NodeType.java
+++ b/kie-api/src/main/java/org/kie/api/definition/process/NodeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/process/Process.java
+++ b/kie-api/src/main/java/org/kie/api/definition/process/Process.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/process/WorkflowElement.java
+++ b/kie-api/src/main/java/org/kie/api/definition/process/WorkflowElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/process/WorkflowElementIdentifier.java
+++ b/kie-api/src/main/java/org/kie/api/definition/process/WorkflowElementIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/process/WorkflowProcess.java
+++ b/kie-api/src/main/java/org/kie/api/definition/process/WorkflowProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/rule/ActivationListener.java
+++ b/kie-api/src/main/java/org/kie/api/definition/rule/ActivationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/rule/All.java
+++ b/kie-api/src/main/java/org/kie/api/definition/rule/All.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/rule/Direct.java
+++ b/kie-api/src/main/java/org/kie/api/definition/rule/Direct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/rule/Global.java
+++ b/kie-api/src/main/java/org/kie/api/definition/rule/Global.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/rule/Propagation.java
+++ b/kie-api/src/main/java/org/kie/api/definition/rule/Propagation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/rule/Query.java
+++ b/kie-api/src/main/java/org/kie/api/definition/rule/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/rule/Rule.java
+++ b/kie-api/src/main/java/org/kie/api/definition/rule/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/rule/Watch.java
+++ b/kie-api/src/main/java/org/kie/api/definition/rule/Watch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Annotation.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Annotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/ClassReactive.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/ClassReactive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Description.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Description.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Duration.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Duration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Expires.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Expires.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/FactField.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/FactField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/FactType.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/FactType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Key.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Key.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Label.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Label.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Modifies.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Modifies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Position.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Position.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/PropertyChangeSupport.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/PropertyChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/PropertyReactive.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/PropertyReactive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Role.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Role.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/Timestamp.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/Timestamp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/definition/type/TypeSafe.java
+++ b/kie-api/src/main/java/org/kie/api/definition/type/TypeSafe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/KieRuntimeEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/KieRuntimeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/KieRuntimeEventManager.java
+++ b/kie-api/src/main/java/org/kie/api/event/KieRuntimeEventManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/AfterFunctionRemovedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/AfterFunctionRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/AfterKieBaseLockedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/AfterKieBaseLockedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/AfterKieBaseUnlockedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/AfterKieBaseUnlockedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/AfterKiePackageAddedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/AfterKiePackageAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/AfterKiePackageRemovedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/AfterKiePackageRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/AfterProcessAddedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/AfterProcessAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/AfterProcessRemovedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/AfterProcessRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/AfterRuleAddedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/AfterRuleAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/AfterRuleRemovedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/AfterRuleRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeFunctionRemovedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeFunctionRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeKieBaseLockedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeKieBaseLockedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeKieBaseUnlockedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeKieBaseUnlockedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeKiePackageAddedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeKiePackageAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeKiePackageRemovedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeKiePackageRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeProcessAddedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeProcessAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeProcessRemovedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeProcessRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeRuleAddedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeRuleAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeRuleRemovedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/BeforeRuleRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/DefaultKieBaseEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/DefaultKieBaseEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/KieBaseEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/KieBaseEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/KieBaseEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/KieBaseEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiebase/KieBaseEventManager.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiebase/KieBaseEventManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiescanner/DefaultKieScannerEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiescanner/DefaultKieScannerEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiescanner/KieScannerEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiescanner/KieScannerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiescanner/KieScannerEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiescanner/KieScannerEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiescanner/KieScannerStatusChangeEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiescanner/KieScannerStatusChangeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/kiescanner/KieScannerUpdateResultsEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/kiescanner/KieScannerUpdateResultsEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/DefaultProcessEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/DefaultProcessEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ErrorEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ErrorEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/MessageEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/MessageEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessCompletedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessCompletedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessEventManager.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessEventManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessMigrationEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessMigrationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessNodeEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessNodeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessNodeLeftEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessNodeLeftEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessNodeTriggeredEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessNodeTriggeredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessRetriggeredEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessRetriggeredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessStartedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessStartedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessStateChangeEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessStateChangeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessVariableChangedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessVariableChangedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/SLAViolatedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/SLAViolatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/process/SignalEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/SignalEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/AfterMatchFiredEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/AfterMatchFiredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/AgendaEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/AgendaEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/AgendaGroupEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/AgendaGroupEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/AgendaGroupPoppedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/AgendaGroupPoppedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/AgendaGroupPushedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/AgendaGroupPushedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/BeforeMatchFiredEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/BeforeMatchFiredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/DebugAgendaEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/DebugAgendaEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/DebugRuleRuntimeEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/DebugRuleRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/DefaultAgendaEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/DefaultAgendaEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/DefaultRuleRuntimeEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/DefaultRuleRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/MatchCancelledCause.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/MatchCancelledCause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/MatchCancelledEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/MatchCancelledEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/MatchCreatedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/MatchCreatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/MatchEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/MatchEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/ObjectDeletedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/ObjectDeletedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/ObjectInsertedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/ObjectInsertedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/ObjectUpdatedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/ObjectUpdatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/RuleFlowGroupActivatedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/RuleFlowGroupActivatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/RuleFlowGroupDeactivatedEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/RuleFlowGroupDeactivatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/RuleFlowGroupEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/RuleFlowGroupEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/RuleRuntimeEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/RuleRuntimeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/RuleRuntimeEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/RuleRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/event/rule/RuleRuntimeEventManager.java
+++ b/kie-api/src/main/java/org/kie/api/event/rule/RuleRuntimeEventManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblerService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblers.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/ProcessedResource.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/ProcessedResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/io/ResourceTypePackage.java
+++ b/kie-api/src/main/java/org/kie/api/internal/io/ResourceTypePackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/runtime/KieRuntimeService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/runtime/KieRuntimeService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/runtime/KieRuntimes.java
+++ b/kie-api/src/main/java/org/kie/api/internal/runtime/KieRuntimes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/utils/KieService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/utils/KieService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/utils/KieServiceLoader.java
+++ b/kie-api/src/main/java/org/kie/api/internal/utils/KieServiceLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/weaver/KieWeaverService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/weaver/KieWeaverService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/internal/weaver/KieWeavers.java
+++ b/kie-api/src/main/java/org/kie/api/internal/weaver/KieWeavers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/io/KieResources.java
+++ b/kie-api/src/main/java/org/kie/api/io/KieResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/io/Resource.java
+++ b/kie-api/src/main/java/org/kie/api/io/Resource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/io/ResourceConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/io/ResourceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/io/ResourceType.java
+++ b/kie-api/src/main/java/org/kie/api/io/ResourceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/io/ResourceWithConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/io/ResourceWithConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/logger/KieLoggers.java
+++ b/kie-api/src/main/java/org/kie/api/logger/KieLoggers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/logger/KieRuntimeLogger.java
+++ b/kie-api/src/main/java/org/kie/api/logger/KieRuntimeLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/management/GAV.java
+++ b/kie-api/src/main/java/org/kie/api/management/GAV.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/management/GenericKieSessionMonitoringMXBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/GenericKieSessionMonitoringMXBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/management/KieBaseConfigurationMonitorMBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/KieBaseConfigurationMonitorMBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/management/KieContainerMonitorMXBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/KieContainerMonitorMXBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/management/KieManagementAgentMBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/KieManagementAgentMBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/management/KieSessionMonitoringMXBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/KieSessionMonitoringMXBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/management/ObjectTypeNodeMonitorMBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/ObjectTypeNodeMonitorMBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/management/StatelessKieSessionMonitoringMXBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/StatelessKieSessionMonitoringMXBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/marshalling/KieMarshallers.java
+++ b/kie-api/src/main/java/org/kie/api/marshalling/KieMarshallers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/marshalling/Marshaller.java
+++ b/kie-api/src/main/java/org/kie/api/marshalling/Marshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/marshalling/MarshallingConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/marshalling/MarshallingConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/marshalling/ObjectMarshallingStrategy.java
+++ b/kie-api/src/main/java/org/kie/api/marshalling/ObjectMarshallingStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/marshalling/ObjectMarshallingStrategyAcceptor.java
+++ b/kie-api/src/main/java/org/kie/api/marshalling/ObjectMarshallingStrategyAcceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/marshalling/ObjectMarshallingStrategyStore.java
+++ b/kie-api/src/main/java/org/kie/api/marshalling/ObjectMarshallingStrategyStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/persistence/jpa/KieStoreServices.java
+++ b/kie-api/src/main/java/org/kie/api/persistence/jpa/KieStoreServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/AbstractOutput.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/AbstractOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/DoubleFieldOutput.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/DoubleFieldOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/IntegerFieldOutput.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/IntegerFieldOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/OutputFieldFactory.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/OutputFieldFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/PMML4AbstractField.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMML4AbstractField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/PMML4Data.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMML4Data.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/PMML4DataField.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMML4DataField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/PMML4DataType.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMML4DataType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/PMML4Field.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMML4Field.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/PMML4Output.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMML4Output.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/PMML4OutputField.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMML4OutputField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/PMML4Result.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMML4Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/PMMLRequestData.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMMLRequestData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/ParameterInfo.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/ParameterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/pmml/StringFieldOutput.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/StringFieldOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/prototype/Prototype.java
+++ b/kie-api/src/main/java/org/kie/api/prototype/Prototype.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/prototype/PrototypeBuilder.java
+++ b/kie-api/src/main/java/org/kie/api/prototype/PrototypeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/prototype/PrototypeEvent.java
+++ b/kie-api/src/main/java/org/kie/api/prototype/PrototypeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/prototype/PrototypeEventInstance.java
+++ b/kie-api/src/main/java/org/kie/api/prototype/PrototypeEventInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/prototype/PrototypeFact.java
+++ b/kie-api/src/main/java/org/kie/api/prototype/PrototypeFact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/prototype/PrototypeFactInstance.java
+++ b/kie-api/src/main/java/org/kie/api/prototype/PrototypeFactInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/remote/Remotable.java
+++ b/kie-api/src/main/java/org/kie/api/remote/Remotable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/BatchRequestMessage.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/BatchRequestMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/Calendars.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/Calendars.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/Channel.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/Channel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/ClassObjectFilter.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/ClassObjectFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/CommandExecutor.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/CommandExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/Context.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/Environment.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/Environment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/EnvironmentName.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/EnvironmentName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/Executable.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/Executable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/ExecutableRunner.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/ExecutableRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/ExecutionResults.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/ExecutionResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/Globals.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/Globals.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/KieContainer.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/KieContainerSessionsPool.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieContainerSessionsPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/KieContext.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/KieRuntime.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/KieRuntimeBuilder.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieRuntimeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/KieRuntimeFactory.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieRuntimeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/KieSession.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/KieSessionConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieSessionConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/KieSessionsPool.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieSessionsPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/ObjectFilter.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/ObjectFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/RequestContext.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/RequestContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/RuntimeSession.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/RuntimeSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/StatelessKieSession.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/StatelessKieSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/AccumulateNullPropagationOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/AccumulateNullPropagationOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/BeliefSystemTypeOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/BeliefSystemTypeOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/ClockTypeOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/ClockTypeOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/DirectFiringOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/DirectFiringOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/KeepReferenceOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/KeepReferenceOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/KieSessionOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/KieSessionOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/KieSessionOptionsConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/KieSessionOptionsConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/MultiValueKieSessionOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/MultiValueKieSessionOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/MultiValueRuleRuntimeOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/MultiValueRuleRuntimeOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/PersistedSessionOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/PersistedSessionOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/QueryListenerOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/QueryListenerOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/SingleValueKieSessionOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/SingleValueKieSessionOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/SingleValueRuleRuntimeOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/SingleValueRuleRuntimeOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/ThreadSafeOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/ThreadSafeOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/TimedRuleExecutionFilter.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/TimedRuleExecutionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/TimedRuleExecutionOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/TimedRuleExecutionOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/TimerJobFactoryOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/TimerJobFactoryOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/WorkItemHandlerOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/WorkItemHandlerOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/DataTransformer.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/DataTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/EventListener.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/EventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/NodeInstance.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/NodeInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/NodeInstanceContainer.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/NodeInstanceContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/ProcessContext.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/ProcessContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/ProcessInstance.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/ProcessInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/ProcessRuntime.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/ProcessRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/ProcessWorkItemHandlerException.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/ProcessWorkItemHandlerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/StatefulProcessSession.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/StatefulProcessSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/StatelessProcessSession.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/StatelessProcessSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/WorkItem.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/WorkItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/WorkItemHandler.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/WorkItemHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/WorkItemManager.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/WorkItemManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/process/WorkflowProcessInstance.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/WorkflowProcessInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/AccumulateFunction.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/AccumulateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/ActivationGroup.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/ActivationGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/Agenda.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/Agenda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/AgendaFilter.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/AgendaFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/AgendaGroup.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/AgendaGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/AttachedViewChangedEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/AttachedViewChangedEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/ConsequenceException.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/ConsequenceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/ConsequenceExceptionHandler.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/ConsequenceExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/EntryPoint.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/EntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/Evaluator.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/Evaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/EvaluatorDefinition.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/EvaluatorDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/EventHandle.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/EventHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/FactHandle.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/FactHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/LiveQuery.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/LiveQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/Match.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/Match.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/Operator.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/Operator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/PropagationContext.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/PropagationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/QueryResults.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/QueryResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/QueryResultsRow.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/QueryResultsRow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/Row.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/Row.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/RuleContext.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/RuleContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/RuleFlowGroup.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/RuleFlowGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/RuleRuntime.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/RuleRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/StatefulRuleSession.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/StatefulRuleSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/StatelessRuleSession.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/StatelessRuleSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/Variable.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/Variable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/runtime/rule/ViewChangedEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/ViewChangedEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/time/Calendar.java
+++ b/kie-api/src/main/java/org/kie/api/time/Calendar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/time/SessionClock.java
+++ b/kie-api/src/main/java/org/kie/api/time/SessionClock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/main/java/org/kie/api/time/SessionPseudoClock.java
+++ b/kie-api/src/main/java/org/kie/api/time/SessionPseudoClock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/test/java/org/kie/api/KModuleXSDTest.java
+++ b/kie-api/src/test/java/org/kie/api/KModuleXSDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/test/java/org/kie/api/internal/utils/AnotherMockAssemblersImpl.java
+++ b/kie-api/src/test/java/org/kie/api/internal/utils/AnotherMockAssemblersImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/test/java/org/kie/api/internal/utils/MockAssemblersImpl.java
+++ b/kie-api/src/test/java/org/kie/api/internal/utils/MockAssemblersImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/test/java/org/kie/api/internal/utils/MockChildAssemblerService.java
+++ b/kie-api/src/test/java/org/kie/api/internal/utils/MockChildAssemblerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-api/src/test/java/org/kie/api/io/ResourceTypeTest.java
+++ b/kie-api/src/test/java/org/kie/api/io/ResourceTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-dmn-archetype/src/main/resources/archetype-resources/src/test/java/ScenarioJunitActivatorTest.java
+++ b/kie-archetypes/kie-drools-dmn-archetype/src/main/resources/archetype-resources/src/test/java/ScenarioJunitActivatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-dmn-archetype/src/main/resources/archetype-resources/src/test/java/TrafficViolationTest.java
+++ b/kie-archetypes/kie-drools-dmn-archetype/src/main/resources/archetype-resources/src/test/java/TrafficViolationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-dmn-archetype/src/main/resources/archetype-resources/src/test/java/utils/shim/Map.java
+++ b/kie-archetypes/kie-drools-dmn-archetype/src/main/resources/archetype-resources/src/test/java/utils/shim/Map.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-dmn-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/ScenarioJunitActivatorTest.java
+++ b/kie-archetypes/kie-drools-dmn-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/ScenarioJunitActivatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-dmn-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/TrafficViolationTest.java
+++ b/kie-archetypes/kie-drools-dmn-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/TrafficViolationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-dmn-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/utils/shim/Map.java
+++ b/kie-archetypes/kie-drools-dmn-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/utils/shim/Map.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/MeasurementUnit.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/main/java/MeasurementUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/MeasurementUnit.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/MeasurementUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-yaml-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
+++ b/kie-archetypes/kie-drools-yaml-archetype/src/main/resources/archetype-resources/src/main/java/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-yaml-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
+++ b/kie-archetypes/kie-drools-yaml-archetype/src/main/resources/archetype-resources/src/test/java/RuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-yaml-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
+++ b/kie-archetypes/kie-drools-yaml-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/main/java/it/pkg/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-archetypes/kie-drools-yaml-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
+++ b/kie-archetypes/kie-drools-yaml-archetype/src/test/resources/projects/integrationtestDefaults/reference/src/test/java/it/pkg/RuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/kie-ci-test-jars/kie-ci-test-jar-with-dep/src/main/java/org/kie/ci/test/dep/Main.java
+++ b/kie-ci/kie-ci-test-jars/kie-ci-test-jar-with-dep/src/main/java/org/kie/ci/test/dep/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/kie-ci-test-jars/kie-ci-test-jar/src/main/java/org/kie/ci/test/Main.java
+++ b/kie-ci/kie-ci-test-jars/kie-ci-test-jar/src/main/java/org/kie/ci/test/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/FluentKieModuleDeploymentHelper.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/FluentKieModuleDeploymentHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentConfig.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelper.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelperImpl.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/SingleKieModuleDeploymentHelper.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/SingleKieModuleDeploymentHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/KieInJarModuleMetaDataImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieInJarModuleMetaDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/KieMavenRepository.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieMavenRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/KieModuleMetaData.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieModuleMetaData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/KieModuleMetaDataImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieModuleMetaDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/KieScannerFactoryServiceImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieScannerFactoryServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/KieScannersRegistry.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieScannersRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/KieURLClassLoader.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieURLClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/MavenClassLoaderResolver.java
+++ b/kie-ci/src/main/java/org/kie/scanner/MavenClassLoaderResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/management/KieScannerMBean.java
+++ b/kie-ci/src/main/java/org/kie/scanner/management/KieScannerMBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/management/KieScannerMBeanImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/management/KieScannerMBeanImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/main/java/org/kie/scanner/management/MBeanUtils.java
+++ b/kie-ci/src/main/java/org/kie/scanner/management/MBeanUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/api/builder/helper/KieModuleDeploymentHelperLoadResourcesTest.java
+++ b/kie-ci/src/test/java/org/kie/api/builder/helper/KieModuleDeploymentHelperLoadResourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/api/builder/helper/KieModuleDeploymentHelperTest.java
+++ b/kie-ci/src/test/java/org/kie/api/builder/helper/KieModuleDeploymentHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/declarativetypes/JavaBeansEventRoleTest.java
+++ b/kie-ci/src/test/java/org/kie/declarativetypes/JavaBeansEventRoleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/AbstractKieCiTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/AbstractKieCiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/DependentScopeNamedBeanTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/DependentScopeNamedBeanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleBuilderTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleIncrementalCompilationTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleIncrementalCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleMavenTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleMavenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleMetaDataImplTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleMetaDataImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleMetaDataTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleMetaDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerNexusTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerNexusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/KieScannerIncrementalCompilationTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieScannerIncrementalCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/concurrent/ConcurrentBuildTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/concurrent/ConcurrentBuildTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/embedder/MavenDeployTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/embedder/MavenDeployTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-ci/src/test/java/org/kie/scanner/management/KieScannerMBeanTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/management/KieScannerMBeanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/AfterGeneratingSourcesListener.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/AfterGeneratingSourcesListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNCompiler.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNCompilerConfiguration.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNCompilerConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNContext.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNDecisionResult.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNDecisionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNMessage.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNMessageContainer.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNMessageContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNMessageType.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNMessageType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNMetadata.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNModel.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNPackage.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNResult.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNRuntime.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNType.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNUnaryTest.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNUnaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/EvaluatorResult.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/EvaluatorResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/FEELPropertyAccessible.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/FEELPropertyAccessible.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/GeneratedSource.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/GeneratedSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/BusinessKnowledgeModelNode.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/BusinessKnowledgeModelNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/DMNNode.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/DMNNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/DecisionNode.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/DecisionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/DecisionServiceNode.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/DecisionServiceNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/InputDataNode.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/InputDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/ItemDefNode.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/ast/ItemDefNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateAllEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateAllEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateBKMEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateBKMEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateConditionalEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateConditionalEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateContextEntryEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateContextEntryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateDecisionEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateDecisionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateDecisionServiceEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateDecisionServiceEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterInvokeBKMEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterInvokeBKMEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateAllEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateAllEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateBKMEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateBKMEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateContextEntryEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateContextEntryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateDecisionEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateDecisionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateDecisionServiceEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateDecisionServiceEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateDecisionTableEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateDecisionTableEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeInvokeBKMEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeInvokeBKMEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/DMNEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/DMNEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/DMNRuntimeEventListener.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/DMNRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/DMNRuntimeEventManager.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/DMNRuntimeEventManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/feel/runtime/events/FEELEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/feel/runtime/events/FEELEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/feel/runtime/events/FEELEventListener.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/feel/runtime/events/FEELEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/marshalling/DMNExtensionRegister.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/marshalling/DMNExtensionRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/marshalling/DMNMarshaller.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/marshalling/DMNMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/CustomStaxReader.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/CustomStaxReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/CustomStaxWriter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/CustomStaxWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ArtifactConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ArtifactConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/AssociationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/AssociationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/AuthorityRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/AuthorityRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/BindingConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/BindingConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/BusinessContextElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/BusinessContextElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/BusinessKnowledgeModelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/BusinessKnowledgeModelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ContextConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ContextConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ContextEntryConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ContextEntryConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNElementReferenceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNElementReferenceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNListConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNListConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNModelInstrumentedBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNModelInstrumentedBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DRGElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DRGElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionRuleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionRuleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionServiceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionServiceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionTableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionTableConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DefinitionsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DefinitionsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ElementCollectionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ElementCollectionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ExtensionElementsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ExtensionElementsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/FunctionDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/FunctionDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ImportConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ImportConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ImportedValuesConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ImportedValuesConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InformationItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InformationItemConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InformationRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InformationRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InputDataConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InputDataConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InvocationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/InvocationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ItemDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ItemDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/KnowledgeRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/KnowledgeRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/KnowledgeSourceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/KnowledgeSourceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/LiteralExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/LiteralExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/MarshallingUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/MarshallingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/NamedElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/NamedElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/OrganizationUnitConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/OrganizationUnitConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/OutputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/OutputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/PerformanceIndicatorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/PerformanceIndicatorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/QNameConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/QNameConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/RelationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/RelationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/TextAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/TextAnnotationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/UnaryTestsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/UnaryTestsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/extensions/DecisionServicesConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/extensions/DecisionServicesConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/extensions/DecisionServicesExtensionRegister.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/extensions/DecisionServicesExtensionRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ArtifactConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ArtifactConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/AssociationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/AssociationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/AuthorityRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/AuthorityRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/BindingConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/BindingConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/BoundsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/BoundsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/BusinessContextElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/BusinessContextElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/BusinessKnowledgeModelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/BusinessKnowledgeModelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ColorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ColorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ContextConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ContextConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ContextEntryConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ContextEntryConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNDIConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNDIConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNDecisionServiceDividerLineConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNDecisionServiceDividerLineConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNDiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNDiagramConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNEdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNEdgeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNElementReferenceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNElementReferenceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNLabelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNLabelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNListConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNListConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNModelInstrumentedBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNModelInstrumentedBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNShapeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNStyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNStyleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DRGElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DRGElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DecisionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DecisionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DecisionRuleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DecisionRuleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DecisionServiceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DecisionServiceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DecisionTableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DecisionTableConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DefinitionsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DefinitionsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DiagramConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DiagramElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DiagramElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DiagramElementExtensionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DiagramElementExtensionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DimensionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DimensionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/EdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/EdgeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ElementCollectionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ElementCollectionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ExtensionElementsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ExtensionElementsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/FormatUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/FormatUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/FunctionDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/FunctionDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ImportConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ImportConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ImportedValuesConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ImportedValuesConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InformationItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InformationItemConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InformationRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InformationRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InputDataConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InputDataConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InvocableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InvocableConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InvocationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/InvocationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ItemDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ItemDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/KnowledgeRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/KnowledgeRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/KnowledgeSourceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/KnowledgeSourceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/LiteralExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/LiteralExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/MarshallingUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/MarshallingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/NamedElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/NamedElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/OrganizationUnitConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/OrganizationUnitConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/OutputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/OutputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/PerformanceIndicatorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/PerformanceIndicatorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/PointConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/PointConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/QNameConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/QNameConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/RelationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/RelationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/RuleAnnotationClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/RuleAnnotationClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/RuleAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/RuleAnnotationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/ShapeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/StyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/StyleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/TextAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/TextAnnotationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/UnaryTestsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/UnaryTestsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/XStreamMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ArtifactConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ArtifactConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AssociationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AssociationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AuthorityRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AuthorityRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BindingConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BindingConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BoundsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BoundsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessContextElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessContextElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessKnowledgeModelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessKnowledgeModelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ColorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ColorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextEntryConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextEntryConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDIConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDIConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDecisionServiceDividerLineConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDecisionServiceDividerLineConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDiagramConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNEdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNEdgeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementReferenceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementReferenceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNLabelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNLabelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNListConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNListConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNModelInstrumentedBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNModelInstrumentedBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNShapeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNStyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNStyleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DRGElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DRGElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionRuleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionRuleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionServiceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionServiceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionTableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionTableConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DefinitionsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DefinitionsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementExtensionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementExtensionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DimensionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DimensionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/EdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/EdgeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ElementCollectionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ElementCollectionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExtensionElementsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExtensionElementsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FormatUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FormatUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FunctionDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FunctionDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FunctionItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FunctionItemConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/GroupConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/GroupConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportedValuesConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportedValuesConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationItemConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputDataConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputDataConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocableConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ItemDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ItemDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeSourceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeSourceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/LiteralExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/LiteralExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/MarshallingUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/MarshallingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/NamedElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/NamedElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OrganizationUnitConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OrganizationUnitConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OutputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OutputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PerformanceIndicatorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PerformanceIndicatorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PointConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PointConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/QNameConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/QNameConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RelationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RelationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ShapeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/StyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/StyleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/TextAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/TextAnnotationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/UnaryTestsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/UnaryTestsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/XStreamMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ArtifactConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ArtifactConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/AssociationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/AssociationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/AuthorityRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/AuthorityRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/BindingConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/BindingConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/BusinessContextElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/BusinessContextElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/BusinessKnowledgeModelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/BusinessKnowledgeModelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ChildExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ChildExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ConditionalConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ConditionalConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ContextConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ContextConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ContextEntryConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ContextEntryConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNElementReferenceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNElementReferenceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNListConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNListConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNModelInstrumentedBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DMNModelInstrumentedBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DRGElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DRGElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DecisionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DecisionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DecisionRuleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DecisionRuleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DecisionServiceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DecisionServiceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DecisionTableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DecisionTableConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DefinitionsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/DefinitionsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ElementCollectionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ElementCollectionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/EveryConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/EveryConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ExtensionElementsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ExtensionElementsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/FilterConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/FilterConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ForConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ForConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/FormatUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/FormatUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/FunctionDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/FunctionDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/FunctionItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/FunctionItemConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/GroupConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/GroupConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ImportConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ImportConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ImportedValuesConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ImportedValuesConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InformationItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InformationItemConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InformationRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InformationRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InputDataConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InputDataConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InvocableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InvocableConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InvocationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/InvocationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ItemDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/ItemDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/IteratorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/IteratorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/KnowledgeRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/KnowledgeRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/KnowledgeSourceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/KnowledgeSourceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/LiteralExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/LiteralExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/MarshallingUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/MarshallingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/NamedElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/NamedElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/OrganizationUnitConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/OrganizationUnitConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/OutputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/OutputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/PerformanceIndicatorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/PerformanceIndicatorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/QNameConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/QNameConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/QuantifiedConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/QuantifiedConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/RelationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/RelationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/RuleAnnotationClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/RuleAnnotationClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/RuleAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/RuleAnnotationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/SomeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/SomeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/TextAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/TextAnnotationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/TypedChildExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/TypedChildExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/UnaryTestsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/UnaryTestsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_4/xstream/XStreamMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ArtifactConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ArtifactConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/AssociationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/AssociationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/AuthorityRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/AuthorityRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/BindingConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/BindingConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/BoundsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/BoundsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/BusinessContextElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/BusinessContextElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/BusinessKnowledgeModelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/BusinessKnowledgeModelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ChildExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ChildExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ColorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ColorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ConditionalConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ConditionalConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ContextConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ContextConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ContextEntryConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ContextEntryConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNDIConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNDIConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNDecisionServiceDividerLineConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNDecisionServiceDividerLineConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNDiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNDiagramConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNEdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNEdgeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNElementReferenceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNElementReferenceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNLabelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNLabelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNListConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNListConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNModelInstrumentedBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNModelInstrumentedBaseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNShapeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNStyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DMNStyleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DRGElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DRGElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DecisionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DecisionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DecisionRuleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DecisionRuleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DecisionServiceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DecisionServiceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DecisionTableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DecisionTableConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DefinitionsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DefinitionsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DiagramConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DiagramElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DiagramElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DiagramElementExtensionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DiagramElementExtensionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DimensionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/DimensionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/EdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/EdgeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ElementCollectionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ElementCollectionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/EveryConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/EveryConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ExtensionElementsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ExtensionElementsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/FilterConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/FilterConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ForConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ForConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/FormatUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/FormatUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/FunctionDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/FunctionDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/FunctionItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/FunctionItemConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/GroupConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/GroupConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ImportConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ImportConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ImportedValuesConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ImportedValuesConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InformationItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InformationItemConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InformationRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InformationRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InputDataConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InputDataConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InvocableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InvocableConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InvocationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/InvocationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ItemDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ItemDefinitionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/IteratorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/IteratorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/KnowledgeRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/KnowledgeRequirementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/KnowledgeSourceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/KnowledgeSourceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/LiteralExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/LiteralExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/MarshallingUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/MarshallingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/NamedElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/NamedElementConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/OrganizationUnitConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/OrganizationUnitConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/OutputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/OutputClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/PerformanceIndicatorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/PerformanceIndicatorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/PointConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/PointConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/QNameConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/QNameConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/QuantifiedConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/QuantifiedConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/RelationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/RelationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/RuleAnnotationClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/RuleAnnotationClauseConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/RuleAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/RuleAnnotationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/ShapeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/SomeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/SomeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/StyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/StyleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/TextAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/TextAnnotationConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/TypedChildExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/TypedChildExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/UnaryTestsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/UnaryTestsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_5/xstream/XStreamMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1x/ConverterDefinesExpressionNodeName.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1x/ConverterDefinesExpressionNodeName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1x/DMNMarshallerFactory.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1x/DMNMarshallerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1x/DMNXStream.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1x/DMNXStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/DMNXMLLoaderTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/DMNXMLLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/MarshallingUtilsTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/MarshallingUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/UnmarshalMarshalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyDroolsExt.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyDroolsExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyKieExt.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyKieExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyTestRegister.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyTestRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/extensions/MyDroolsExt.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/extensions/MyDroolsExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/extensions/MyKieExt.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/extensions/MyKieExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/extensions/MyTestRegister.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/extensions/MyTestRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/UnmarshalMarshalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/extensions/ProjectCharter.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/extensions/ProjectCharter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/extensions/TrisoExtensionRegister.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/extensions/TrisoExtensionRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_4/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_4/UnmarshalMarshalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_5/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_5/UnmarshalMarshalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223-jq/src/main/java/org/kie/dmn/core/jsr223/jq/JQScriptEngine.java
+++ b/kie-dmn/kie-dmn-core-jsr223-jq/src/main/java/org/kie/dmn/core/jsr223/jq/JQScriptEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223-jq/src/main/java/org/kie/dmn/core/jsr223/jq/JQScriptEngineFactory.java
+++ b/kie-dmn/kie-dmn-core-jsr223-jq/src/main/java/org/kie/dmn/core/jsr223/jq/JQScriptEngineFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223-jq/src/test/java/org/kie/dmn/core/jsr223/jq/BasicTest.java
+++ b/kie-dmn/kie-dmn-core-jsr223-jq/src/test/java/org/kie/dmn/core/jsr223/jq/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223DTExpressionEvaluator.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223DTExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223EvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223EvaluatorCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223EvaluatorCompilerFactory.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223EvaluatorCompilerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223LiteralExpressionEvaluator.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223LiteralExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223ScriptEngineEvaluator.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223ScriptEngineEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223Utils.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/main/java/org/kie/dmn/core/jsr223/JSR223Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/test/java/org/kie/dmn/core/jsr223/EscapeTest.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/test/java/org/kie/dmn/core/jsr223/EscapeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/test/java/org/kie/dmn/core/jsr223/GraalJSTest.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/test/java/org/kie/dmn/core/jsr223/GraalJSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/test/java/org/kie/dmn/core/jsr223/JQTest.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/test/java/org/kie/dmn/core/jsr223/JQTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core-jsr223/src/test/java/org/kie/dmn/core/jsr223/NashornTest.java
+++ b/kie-dmn/kie-dmn-core-jsr223/src/test/java/org/kie/dmn/core/jsr223/NashornTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/api/DMNExpressionEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/api/DMNExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/api/DMNFactory.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/api/DMNFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/api/DMNMessageManager.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/api/DMNMessageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/api/event/DefaultDMNRuntimeEventListener.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/api/event/DefaultDMNRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNResource.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNResourceDependenciesSorter.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNResourceDependenciesSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/BusinessKnowledgeModelNodeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/BusinessKnowledgeModelNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNBaseNode.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNBaseNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNContextEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNContextEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDTExpressionEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDTExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDecisionServiceEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDecisionServiceEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDecisionServiceFunctionDefinitionEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDecisionServiceFunctionDefinitionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNFilterEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNFilterEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNFunctionDefinitionEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNFunctionDefinitionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNFunctionWithReturnType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNFunctionWithReturnType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNInvocationEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNInvocationEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNIteratorEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNIteratorEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNListEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNListEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNRelationEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNRelationEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DecisionNodeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DecisionNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DecisionServiceNodeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DecisionServiceNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/EvaluatorResultImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/EvaluatorResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/InputDataNodeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/InputDataNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/ItemDefNodeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/ItemDefNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/AlphaNetworkOption.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/AlphaNetworkOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/BusinessKnowledgeModelCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/BusinessKnowledgeModelCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/CoerceDecisionServiceSingletonOutputOption.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/CoerceDecisionServiceSingletonOutputOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerConfigurationImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerContext.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerHelper.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNDecisionLogicCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNDecisionLogicCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNDecisionLogicCompilerFactory.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNDecisionLogicCompilerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNImportsUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNImportsUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNOption.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNProfile.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNScope.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistry.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryAbstract.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryAbstract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV11.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV11.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV12.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV12.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV13.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV13.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV14.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV14.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV15.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV15.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DRGElementCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DRGElementCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DecisionCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DecisionCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DecisionServiceCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DecisionServiceCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ExecModelCompilerOption.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ExecModelCompilerOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/InputDataCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/InputDataCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/KnowledgeSourceCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/KnowledgeSourceCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/RuntimeTypeCheckOption.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/RuntimeTypeCheckOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/AlphaNetworkCreation.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/AlphaNetworkCreation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/AlphaNetworkEvaluationContext.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/AlphaNetworkEvaluationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/CanBeInlinedAlphaNode.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/CanBeInlinedAlphaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ColumnDefinition.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ColumnDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNAlphaNetworkCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNAlphaNetworkCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNAlphaNetworkEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNAlphaNetworkEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNAlphaNetworkEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNAlphaNetworkEvaluatorCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNAlphaNetworkEvaluatorImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNAlphaNetworkEvaluatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNResultCollector.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNResultCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNResultCollectorAlphaSink.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNResultCollectorAlphaSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DTQNameToTypeResolver.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DTQNameToTypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/FeelDecisionTable.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/FeelDecisionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/GeneratedSources.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/GeneratedSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/PropertyEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/PropertyEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/Results.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/Results.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ReteBuilderContext.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ReteBuilderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableCell.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableCells.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableCells.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableIndex.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/UnaryTestClass.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/UnaryTestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/ColumnValidator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/ColumnValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/OutputClausesWithType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/OutputClausesWithType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/TestEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/TestEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfile.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateBKMEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateBKMEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateConditionalEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateConditionalEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateContextEntryEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateContextEntryEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateDecisionEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateDecisionEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateDecisionServiceEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateDecisionServiceEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterInvokeBKMEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterInvokeBKMEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BaseDMNTypeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BaseDMNTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateBKMEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateBKMEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateContextEntryEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateContextEntryEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateDecisionEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateDecisionEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateDecisionServiceEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateDecisionServiceEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateDecisionTableEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateDecisionTableEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeInvokeBKMEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeInvokeBKMEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/CompositeTypeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/CompositeTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFEELCtxWrapper.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFEELCtxWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFPAImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFPAImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNDecisionResultImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNDecisionResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNEventUtils.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNEventUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNKnowledgeBuilderError.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNKnowledgeBuilderError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNMessageImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNMessageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNMetadataImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNMetadataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNPackageImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNPackageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNResultImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNResultImplFactory.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNResultImplFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeEventManagerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeEventManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeKB.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeKB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeKBWrappingIKB.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeKBWrappingIKB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/SimpleFnTypeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/SimpleFnTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/SimpleTypeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/SimpleTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/TupleIdentifier.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/TupleIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/VoidDMNRuntimeKB.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/VoidDMNRuntimeKB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DMNEvaluationUtils.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DMNEvaluationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilder.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DRGAnalysisUtils.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DRGAnalysisUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DynamicDMNContextBuilder.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DynamicDMNContextBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/FailedConversionException.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/FailedConversionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/MapBackedDMNContext.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/MapBackedDMNContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/MarshallingStubUtils.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/MarshallingStubUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/pmml/DMNPMMLModelInfo.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/pmml/DMNPMMLModelInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/pmml/PMMLInfo.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/pmml/PMMLInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/pmml/PMMLModelInfo.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/pmml/PMMLModelInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/runtime/DMNRuntimeService.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/runtime/DMNRuntimeService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/runtime/service/DMNEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/runtime/service/DMNEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/CoerceUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/CoerceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/DefaultDMNMessagesManager.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/DefaultDMNMessagesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/IterableRange.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/IterableRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/KieHelper.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/KieHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/MsgUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/MsgUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/NamespaceUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/NamespaceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/weaver/DMNWeaverService.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/weaver/DMNWeaverService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/AbstractDMNSetType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/AbstractDMNSetType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNAllTypesIndex.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNAllTypesIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNDeclaredField.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNDeclaredField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNDeclaredType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNDeclaredType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNInputSetType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNInputSetType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNModelTypesIndex.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNModelTypesIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNOutputSetType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNOutputSetType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNStronglyCodeGenConfig.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNStronglyCodeGenConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNTypeSafeException.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNTypeSafeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNTypeSafePackageName.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNTypeSafePackageName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNTypeSafeTypeGenerator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNTypeSafeTypeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNTypeUtils.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNTypeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/FEELPropertyAccessibleImplementation.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/FEELPropertyAccessibleImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/FieldGenStrategy.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/FieldGenStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/IndexKey.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/IndexKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/ColumnValidatorTemplate.java
+++ b/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/ColumnValidatorTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/DMNAlphaNetworkTemplate.java
+++ b/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/DMNAlphaNetworkTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/impl/DMNTypeSafeTypeTemplate.java
+++ b/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/impl/DMNTypeSafeTypeTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseDMNContextTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseDMNContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsAlphaNetworkTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsAlphaNetworkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsCompiledTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsCompiledTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsCompiledTestCanonicalKieModule.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsCompiledTestCanonicalKieModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantNonTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantNonTypeSafeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAndCanonicalModelTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAndCanonicalModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAssemblerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAssemblerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNBuildFromReaderTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNBuildFromReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableWithSymbolsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableWithSymbolsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNMessagesAPITest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNMessagesAPITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTypeCheckTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTypeCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNStronglyTypedSupportTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNStronglyTypedSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNTwoValueLogicTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNTwoValueLogicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNTypeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNUpdateTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/FlightRebookingTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/FlightRebookingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/OnlineDatingTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/OnlineDatingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/VacationDaysTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/VacationDaysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/WBCommonServicesBackendTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/WBCommonServicesBackendTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/AlphaNetworkSupportInLargeDecisionTableTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/AlphaNetworkSupportInLargeDecisionTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/DMNDecisionTableAlphaSupportingTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/DMNDecisionTableAlphaSupportingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/ast/DMNContextEvaluatorTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/ast/DMNContextEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNClassloaderTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNClassloaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNEvalHelperAccessorCacheTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNEvalHelperAccessorCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerBKMTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerBKMTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerDSTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerDSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DTAnnotationListenerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DTAnnotationListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/DMNExtensionRegisterTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/DMNExtensionRegisterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/FirstNameDescription.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/FirstNameDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/FirstNameDescriptionRegister.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/FirstNameDescriptionRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/FirstNameLastNameProfile.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/FirstNameLastNameProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/LastNameDescription.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/LastNameDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/LastNameDescriptionRegister.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/extensions/LastNameDescriptionRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/CustomModelCountDMNProfile.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/CustomModelCountDMNProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/CustomModelCountFunction.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/CustomModelCountFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/DMNProfilesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/DMNProfilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfileTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/ExtendedDMNProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/Just47DMNProfile.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/Just47DMNProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/Just47Function.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/profiles/Just47Function.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTypecheckDSxyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisionservices/DMNDecisionServicesTypecheckDSxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisiontable/DTListenerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/decisiontable/DTListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/extra/DMNRecursionTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/extra/DMNRecursionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/extra/YCombinatorTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/extra/YCombinatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/DMNContextFEELCtxWrapperTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/DMNContextFEELCtxWrapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/DMNContextImplTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/DMNContextImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/DMNModelImplTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/DMNModelImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/TupleIdentifierTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/TupleIdentifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/DMNIncrementalCompilationTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/DMNIncrementalCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/WBCompilationTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/WBCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilderTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DRGAnalysisUtilsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DRGAnalysisUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DynamicDMNContextBuilderTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/DynamicDMNContextBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/MapBackedDMNContextTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/MapBackedDMNContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/MarshallingStubUtilsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/internal/utils/MarshallingStubUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/jandex/KieDMNCoreJandexTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/jandex/KieDMNCoreJandexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/model/Person.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/model/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/AnnotationsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/AnnotationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNRuntimeTypesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNRuntimeTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/JavadocTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/JavadocTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/typeref/DMNTyperefTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/typeref/DMNTyperefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/CoerceUtilTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/CoerceUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNRuntimeUtil.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNRuntimeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNTestUtil.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DynamicTypeUtils.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DynamicTypeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_2/DMN12specificTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_2/DMN12specificTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_2/DMNDecisionServicesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_2/DMNDecisionServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTestNonTypesafe.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTestNonTypesafe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14GenericSynthTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14GenericSynthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14specificTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_4/DMN14specificTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/incrementalcompilation/v1/Person.java
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/incrementalcompilation/v1/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/incrementalcompilation/v2/Person.java
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/incrementalcompilation/v2/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/FEEL.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/FEEL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTUnaryTestTransform.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTUnaryTestTransform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CodegenConstants.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CodegenConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CodegenStringUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CodegenStringUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompilationErrorNotifier.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompilationErrorNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledCustomFEELFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledCustomFEELFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELUnaryTests.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELUnaryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompilerBytecodeLoader.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompilerBytecodeLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Constants.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DMNCodegenConstants.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DMNCodegenConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/FEELCompilationError.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/FEELCompilationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/FunctionDefs.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/FunctionDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedFEELUnit.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedFEELUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedUnaryTest.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedUnaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/SyntaxErrorListener.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/SyntaxErrorListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/exceptions/EndpointOfForIterationDifferentTypeException.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/exceptions/EndpointOfForIterationDifferentTypeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/exceptions/EndpointOfForIterationNotValidTypeException.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/exceptions/EndpointOfForIterationNotValidTypeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/CompiledExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/CompiledExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/CompilerContext.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/CompilerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/CompositeType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/CompositeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/EvaluationContext.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/EvaluationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELDialect.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELDialect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELProfile.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELProperty.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/Scope.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/Scope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/SimpleType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/SimpleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/Symbol.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/Symbol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ASTBuilderFactory.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ASTBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ASTNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ASTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/AtLiteralNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/AtLiteralNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BaseNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BaseNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BetweenNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BetweenNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BooleanNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BooleanNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/CTypeNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/CTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextEntryNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextEntryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextTypeNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/DashNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/DashNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FilterExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FilterExpressionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FormalParameterNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FormalParameterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionDefNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionDefNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionInvocationNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionInvocationNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionTypeNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IfExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IfExpressionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InfixOpNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InfixOpNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InfixOperator.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InfixOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InstanceOfNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InstanceOfNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IterationContextNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IterationContextNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ListNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ListTypeNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ListTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NameDefNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NameDefNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NameRefNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NameRefNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NamedParameterNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NamedParameterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NullNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NullNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NumberNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NumberNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/PathExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/PathExpressionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/QualifiedNameNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/QualifiedNameNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/QuantifiedExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/QuantifiedExpressionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/RangeTypeNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/RangeTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright
  * ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the
  * License at

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/SignedUnaryNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/SignedUnaryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/StringNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/StringNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/TemporalConstantNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/TemporalConstantNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestListNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UndefinedValueNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UndefinedValueNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/Visitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/Visitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/BigDecimalRangeIterator.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/BigDecimalRangeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/Direction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/Direction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ForIteration.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ForIteration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ForIterationUtils.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ForIterationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/LocalDateRangeIterator.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/LocalDateRangeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ZonedDateTimeRangeIterator.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ZonedDateTimeRangeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/AddExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/AddExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/AndExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/AndExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/DivExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/DivExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/EqExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/EqExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/GtExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/GtExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/GteExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/GteExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/InfixExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/InfixExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/InfixExecutorUtils.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/InfixExecutorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/LtExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/LtExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/LteExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/LteExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/MultExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/MultExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/NeExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/NeExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/OrExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/OrExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/PowExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/PowExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/SubExecutor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/infixexecutors/SubExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/visitor/ASTHeuristicCheckerVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/visitor/ASTHeuristicCheckerVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/visitor/ASTTemporalConstantVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/visitor/ASTTemporalConstantVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/visitor/DefaultedVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/visitor/DefaultedVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompiledExecutableExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompiledExecutableExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompiledExpressionImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompiledExpressionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompilerContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompilerContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/ExecutionFrame.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/ExecutionFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/ExecutionFrameImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/ExecutionFrameImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELBuilder.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELEventListenersManager.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELEventListenersManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/InterpretedExecutableExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/InterpretedExecutableExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/JavaBackedType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/JavaBackedType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/MapBackedType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/MapBackedType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/NamedParameter.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/NamedParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/RootExecutionFrame.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/RootExecutionFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/SilentWrappingEvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/SilentWrappingEvaluationContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestCompiledExecutableExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestCompiledExecutableExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestInterpretedExecutableExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestInterpretedExecutableExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/AliasFEELType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/AliasFEELType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/BaseSymbol.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/BaseSymbol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/BuiltInTypeSymbol.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/BuiltInTypeSymbol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/DefaultBuiltinFEELTypeRegistry.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/DefaultBuiltinFEELTypeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/FEELTypeRegistry.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/FEELTypeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/FunctionSymbol.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/FunctionSymbol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/GenListType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/GenListType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/GenRangeType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/GenRangeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright
  * ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the
  * License at

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/ScopeImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/ScopeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/SymbolTable.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/SymbolTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/TypeSymbol.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/TypeSymbol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/VariableSymbol.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/VariableSymbol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/WrappingScopeImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/WrappingScopeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/impl/ComparablePeriod.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/impl/ComparablePeriod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/impl/ImmutableFPAWrappingPOJO.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/impl/ImmutableFPAWrappingPOJO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/impl/InterceptNotComparableComparator.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/impl/InterceptNotComparableComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/listeners/SyntaxErrorListener.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/listeners/SyntaxErrorListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/marshaller/FEELCodeMarshaller.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/marshaller/FEELCodeMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/marshaller/FEELMarshaller.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/marshaller/FEELMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/marshaller/FEELStringMarshaller.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/marshaller/FEELStringMarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ASTBuilderVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ASTBuilderVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParser.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ParserHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ParserHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ScopeHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ScopeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/profiles/DoCompileFEELProfile.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/profiles/DoCompileFEELProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/profiles/FEELv12Profile.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/profiles/FEELv12Profile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/profiles/KieExtendedFEELProfile.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/profiles/KieExtendedFEELProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELBooleanFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELBooleanFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELCollectionFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELCollectionFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELDurationFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELDurationFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELNumberFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELNumberFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELStringFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/FEELStringFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/Range.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/Range.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/UnaryTest.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/UnaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/UnaryTestImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/UnaryTestImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DTDecisionRule.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DTDecisionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DTInputClause.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DTInputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DTOutputClause.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DTOutputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTable.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/HitPolicy.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/HitPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/Indexed.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/Indexed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/SingleValueOrContextCollector.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/SingleValueOrContextCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/ASTEventBase.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/ASTEventBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/ASTHeuristicCheckEvent.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/ASTHeuristicCheckEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/DecisionTableRulesMatchedEvent.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/DecisionTableRulesMatchedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/DecisionTableRulesSelectedEvent.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/DecisionTableRulesSelectedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/FEELEventBase.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/FEELEventBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/HitPolicyViolationEvent.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/HitPolicyViolationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/InvalidInputEvent.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/InvalidInputEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/InvalidParametersEvent.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/InvalidParametersEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/SyntaxErrorEvent.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/SyntaxErrorEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/UnknownVariableErrorEvent.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/events/UnknownVariableErrorEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AbsFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AbsFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AbstractCustomFEELFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AbstractCustomFEELFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AllFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AllFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AnyFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AnyFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AppendFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AppendFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/BuiltInFunctions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/BuiltInFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/CeilingFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/CeilingFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContainsFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContainsFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContextFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContextFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContextMergeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContextMergeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/CountFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/CountFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/CustomFEELFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/CustomFEELFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DTInvokerFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DTInvokerFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateAndTimeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateAndTimeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DayOfWeekFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DayOfWeekFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DayOfYearFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DayOfYearFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DecimalFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DecimalFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DecisionTableFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DecisionTableFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DurationFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DurationFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/EndsWithFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/EndsWithFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/EvenFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/EvenFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ExpFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ExpFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FEELConversionFunctionNames.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FEELConversionFunctionNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FEELFnResult.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FEELFnResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FlattenFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FlattenFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FloorFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FloorFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/GetEntriesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/GetEntriesFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/IndexOfFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/IndexOfFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/InsertBeforeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/InsertBeforeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/JavaFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/JavaFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ListContainsFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ListContainsFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ListReplaceFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ListReplaceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/LogFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/LogFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MatchesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MatchesFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MaxFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MaxFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MeanFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MeanFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MedianFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MedianFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MinFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MinFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ModeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ModeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ModuloFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ModuloFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MonthOfYearFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MonthOfYearFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NotFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NotFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NowFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NowFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NumberFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NumberFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/OddFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/OddFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ParameterName.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ParameterName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ProductFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ProductFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RemoveFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RemoveFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReplaceFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReplaceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReverseFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReverseFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RoundDownFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RoundDownFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RoundHalfDownFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RoundHalfDownFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RoundHalfUpFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RoundHalfUpFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RoundUpFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RoundUpFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ScoreHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ScoreHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SortFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SortFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SplitFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SplitFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SqrtFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SqrtFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StartsWithFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StartsWithFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StddevFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StddevFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringJoinFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringJoinFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringLengthFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringLengthFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringLowerCaseFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringLowerCaseFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringUpperCaseFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringUpperCaseFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SublistFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SublistFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringBeforeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringBeforeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SumFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SumFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/TodayFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/TodayFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/UnionFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/UnionFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/WeekOfYearFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/WeekOfYearFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/YearsAndMonthsFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/YearsAndMonthsFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/CodeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/CodeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/DateFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/DateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/InvokeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/InvokeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/KieExtendedDMNFunctions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/KieExtendedDMNFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/TimeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/TimeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/AfterFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/AfterFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/CoincidesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/CoincidesFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/DuringFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/DuringFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/FinishedByFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/FinishedByFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/FinishesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/FinishesFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/IncludesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/IncludesFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/MeetsFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/MeetsFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/MetByFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/MetByFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/OverlapsAfterFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/OverlapsAfterFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/OverlapsBeforeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/OverlapsBeforeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/OverlapsFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/OverlapsFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/StartedByFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/StartedByFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/StartsFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/interval/StartsFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNAllFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNAllFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNAnyFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNAnyFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNCountFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNCountFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNMaxFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNMaxFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNMeanFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNMeanFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNMedianFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNMedianFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNMinFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNMinFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNModeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNModeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNStddevFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNStddevFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNSumFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNSumFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/TwoValueLogicFunctions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/TwoValueLogicFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/impl/RangeImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/impl/RangeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/ClassLoaderUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/ClassLoaderUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/CodegenUtils.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/CodegenUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/CoerceUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/CoerceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/DateTimeEvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/DateTimeEvalHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Either.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Either.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Generated.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Generated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Msg.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Msg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/MsgUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/MsgUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/NumberEvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/NumberEvalHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Pair.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Pair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/StringEvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/StringEvalHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TokenTree.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TokenTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/resources/TemplateCompiledFEELExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/resources/TemplateCompiledFEELExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/main/resources/TemplateCompiledFEELUnaryTests.java
+++ b/kie-dmn/kie-dmn-feel/src/main/resources/TemplateCompiledFEELUnaryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/CodegenFEELUnaryTestsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/CodegenFEELUnaryTestsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/ADocFEELExamplesTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/ADocFEELExamplesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/FromSpecificationNotInAdocTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/FromSpecificationNotInAdocTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/jandex/AbstractJandexTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/jandex/AbstractJandexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/jandex/KieDMNFEELJandexTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/jandex/KieDMNFEELJandexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/InfixOperatorTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/InfixOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/RangeTypeNodeTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/RangeTypeNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/BigDecimalRangeIteratorTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/BigDecimalRangeIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ForIterationTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ForIterationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ForIterationUtilsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ForIterationUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/LocalDateRangeIteratorTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/LocalDateRangeIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ZonedDateTimeRangeIteratorTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/forexpressioniterators/ZonedDateTimeRangeIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/infixexecutors/InfixExecutorUtilsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/infixexecutors/InfixExecutorUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/CompileEvaluateTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/CompileEvaluateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/ExamplesBaseTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/ExamplesBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/ExamplesTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/ExamplesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/SomeTestUtilClass.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/examples/SomeTestUtilClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/FEELProfileTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/FEELProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/JavaBackedTypeTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/JavaBackedTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/MapBackedTypeTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/MapBackedTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/TemporalConstantFoldingParserTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/TemporalConstantFoldingParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/types/impl/ImmutableFPAWrappingPOJOTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/types/impl/ImmutableFPAWrappingPOJOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELCodeMarshallerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELCodeMarshallerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELCodeMarshallerUnmarshallTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELCodeMarshallerUnmarshallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELStringMarshallerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELStringMarshallerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELStringMarshallerUnmarshallTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/marshaller/FEELStringMarshallerUnmarshallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/model/Address.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/model/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/model/Person.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/model/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/model/SupportRequest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/model/SupportRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserSeverityTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserSeverityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELTestRig.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELTestRig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELTestRigExample.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/parser/feel11/FEELTestRigExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BFEELTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BFEELTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELCompilerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEEL12ExtendedForLoopTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEEL12ExtendedForLoopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEEL12ExtendedFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEEL12ExtendedFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELCompilerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELConditionsAndLoopsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELConditionsAndLoopsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELContextsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELContextsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELDateTimeDurationTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELDateTimeDurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELErrorMessagesTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELErrorMessagesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELEventListenerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELEventListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELExpressionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELExpressionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionDefinitionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionDefinitionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELListsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELListsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELMathOperationsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELMathOperationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELNumberCoercionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELNumberCoercionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELOperatorsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELOperatorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStaticTypeTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStaticTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStringOperationsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStringOperationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELValuesComparisonTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELValuesComparisonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELValuesConstantsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELValuesConstantsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/TCFoldNotTCFoldTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/TCFoldNotTCFoldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/custom/ZoneTimeTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/custom/ZoneTimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AbsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AbsFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AppendFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AppendFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/BaseFEELFunctionHelperTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/BaseFEELFunctionHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/BuiltInFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/BuiltInFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CeilingFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CeilingFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CodeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CodeFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ComposingDifferentFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ComposingDifferentFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ContainsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ContainsFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ContextFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ContextFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CountFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CountFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateTimeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateTimeFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DayOfWeekTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DayOfWeekTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DayOfYearTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DayOfYearTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DecimalFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DecimalFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DurationFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DurationFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/EndsWithFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/EndsWithFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FlattenFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FlattenFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FloorFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FloorFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/IndexOfFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/IndexOfFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/InsertBeforeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/InsertBeforeFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ListContainsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ListContainsFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ListReplaceFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ListReplaceFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MaxFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MaxFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MeanFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MeanFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MinFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MinFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MonthOfYearTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MonthOfYearTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NotFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NotFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NowFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NowFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NumberFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NumberFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RemoveFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RemoveFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReverseFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReverseFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RoundDownFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RoundDownFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RoundHalfDownFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RoundHalfDownFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RoundHalfUpFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RoundHalfUpFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RoundUpFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RoundUpFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ScorerHelperTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ScorerHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SortFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SortFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StartsWithFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StartsWithFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringJoinFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringJoinFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringLengthFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringLengthFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringLowerCaseFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringLowerCaseFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringUpperCaseFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringUpperCaseFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SublistFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SublistFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringBeforeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringBeforeFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SumFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SumFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/TodayFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/TodayFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/UnionFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/UnionFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/WeekOfYearTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/WeekOfYearTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/YearsAndMonthsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/YearsAndMonthsFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/AfterFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/AfterFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/BeforeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/BeforeFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/CoincidesFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/CoincidesFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/DuringFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/DuringFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/FEELTemporalFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/FEELTemporalFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/FinishedByFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/FinishedByFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/FinishesFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/FinishesFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/FormulasTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/FormulasTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/IncludesFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/IncludesFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/MeetsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/MeetsFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/MetByFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/MetByFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/OverlapsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/OverlapsFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/StartedByFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/StartedByFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/StartsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/interval/StartsFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/CountFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/CountFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/MaxFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/MaxFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/MeanFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/MeanFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/MedianFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/MedianFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/MinFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/MinFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/ModeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/ModeFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNAllFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNAllFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNAnyFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/NNAnyFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/StddevFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/StddevFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/SumFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/twovaluelogic/SumFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/impl/RangeImplTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/impl/RangeImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/BooleanEvalHelperTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/BooleanEvalHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/CoerceUtilTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/CoerceUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/CompilerUtils.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/CompilerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/DynamicTypeUtils.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/DynamicTypeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvalHelperTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvalHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvaluationContextTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvaluationContextTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/NumberEvalHelperTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/NumberEvalHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/StringEvalHelperTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/StringEvalHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/BaseDMN1_1VariantTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/BaseDMN1_1VariantTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNAssemblerTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNAssemblerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNCompilerTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableHitPolicyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableWithSymbolsTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNDecisionTableWithSymbolsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNInputRuntimeTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNInputRuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/FlightRebookingTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/FlightRebookingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/OnlineDatingTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/OnlineDatingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/VacationDaysTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/VacationDaysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/decisionservices/DMNDecisionServicesTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/decisionservices/DMNDecisionServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/imports/ImportsTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/imports/ImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorArtifactTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorArtifactTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorAuthorityRequirementTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorAuthorityRequirementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessContextTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessKnowledgeModelTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorBusinessKnowledgeModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorContextTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDMNElementReferenceTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDMNElementReferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTableTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorDecisionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorImportTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorImportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInformationRequirementTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInformationRequirementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInputDataTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorInputDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeRequirementTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeRequirementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeSourceTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorKnowledgeSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTypeRefTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/validation/v1_1/ValidatorTypeRefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Artifact.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Artifact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Association.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Association.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/AssociationDirection.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/AssociationDirection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/AuthorityRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/AuthorityRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Binding.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Binding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/BuiltinAggregator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/BuiltinAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/BusinessContextElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/BusinessContextElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/BusinessKnowledgeModel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/BusinessKnowledgeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ChildExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ChildExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Conditional.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Conditional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Context.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ContextEntry.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ContextEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DMNElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DMNElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DMNElementReference.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DMNElementReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DMNModelInstrumentedBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DRGElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DRGElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Decision.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Decision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DecisionRule.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DecisionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DecisionService.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DecisionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DecisionTable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DecisionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DecisionTableOrientation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DecisionTableOrientation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ElementCollection.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ElementCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Every.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Every.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Expression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Expression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Filter.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Filter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/For.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/For.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/FunctionDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/FunctionDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/FunctionItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/FunctionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/FunctionKind.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/FunctionKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Group.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Group.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/HitPolicy.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/HitPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Import.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Import.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ImportedValues.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ImportedValues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/InformationItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/InformationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/InformationRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/InformationRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/InputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/InputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/InputData.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/InputData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Invocable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Invocable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Invocation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Invocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ItemDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Iterator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Iterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/KnowledgeRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/KnowledgeRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/KnowledgeSource.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/KnowledgeSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/List.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/List.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/LiteralExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/LiteralExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/NamedElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/NamedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/NamespaceConsts.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/NamespaceConsts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/OrganizationUnit.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/OrganizationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/OutputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/OutputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/PerformanceIndicator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/PerformanceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Quantified.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Quantified.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Relation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Relation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/RowLocation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/RowLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/RuleAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/RuleAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/RuleAnnotationClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/RuleAnnotationClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Some.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Some.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/TextAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/TextAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/TypedChildExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/TypedChildExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/UnaryTests.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/UnaryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/AlignmentKind.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/AlignmentKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Bounds.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Bounds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Color.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Color.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNDI.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNDI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNDecisionServiceDividerLine.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNDecisionServiceDividerLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNDiagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNDiagram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNEdge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNEdge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNLabel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNShape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNStyle.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DMNStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Diagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Diagram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DiagramElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/DiagramElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Dimension.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Dimension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Edge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Edge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/KnownColor.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/KnownColor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Point.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Point.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Shape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Shape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Style.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/dmndi/Style.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/KieDMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/KieDMNModelInstrumentedBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/NotADMNElementInV11.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/NotADMNElementInV11.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TArtifact.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TArtifact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TAssociation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TAssociation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TAuthorityRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TAuthorityRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TBinding.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TBusinessContextElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TBusinessContextElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TBusinessKnowledgeModel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TBusinessKnowledgeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TContext.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TContextEntry.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TContextEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDMNElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDMNElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDMNElementReference.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDMNElementReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDRGElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDRGElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDecision.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDecision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDecisionRule.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDecisionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDecisionService.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDecisionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDecisionTable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TDecisionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TElementCollection.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TElementCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TFunctionDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TFunctionDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TImport.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TImportedValues.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TImportedValues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInformationItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInformationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInformationRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInformationRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInputData.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInputData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInvocation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TInvocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TItemDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TKnowledgeRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TKnowledgeRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TKnowledgeSource.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TKnowledgeSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TList.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TLiteralExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TLiteralExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TNamedElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TNamedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TOrganizationUnit.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TOrganizationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TOutputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TOutputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TPerformanceIndicator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TPerformanceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TRelation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TRelation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TTextAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TTextAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TUnaryTests.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TUnaryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/extensions/DecisionServices.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/extensions/DecisionServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/KieDMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/KieDMNModelInstrumentedBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TArtifact.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TArtifact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TAssociation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TAssociation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TAuthorityRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TAuthorityRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TBinding.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TBusinessContextElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TBusinessContextElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TBusinessKnowledgeModel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TBusinessKnowledgeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TContext.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TContextEntry.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TContextEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDMNElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDMNElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDMNElementReference.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDMNElementReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDRGElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDRGElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecision.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecisionRule.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecisionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecisionService.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecisionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecisionTable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecisionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecisionTableOrientation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TDecisionTableOrientation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TElementCollection.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TElementCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TFunctionDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TFunctionDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TImport.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TImportedValues.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TImportedValues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInformationItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInformationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInformationRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInformationRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInputData.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInputData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInvocable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInvocable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInvocation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TInvocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TItemDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TKnowledgeRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TKnowledgeRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TKnowledgeSource.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TKnowledgeSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TList.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TLiteralExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TLiteralExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TNamedElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TNamedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TOrganizationUnit.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TOrganizationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TOutputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TOutputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TPerformanceIndicator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TPerformanceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TRelation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TRelation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TRuleAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TRuleAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TRuleAnnotationClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TRuleAnnotationClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TTextAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TTextAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TUnaryTests.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TUnaryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Bounds.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Bounds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Color.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Color.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNDI.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNDI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNDecisionServiceDividerLine.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNDecisionServiceDividerLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNDiagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNDiagram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNEdge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNEdge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNLabel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNShape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNStyle.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Diagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Diagram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DiagramElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DiagramElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Dimension.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Dimension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Edge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Edge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Point.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Point.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Shape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Shape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Style.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/Style.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/KieDMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/KieDMNModelInstrumentedBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TArtifact.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TArtifact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TAssociation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TAssociation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TAuthorityRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TAuthorityRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBinding.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBusinessContextElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBusinessContextElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBusinessKnowledgeModel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBusinessKnowledgeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TContext.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TContextEntry.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TContextEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDMNElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDMNElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDMNElementReference.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDMNElementReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDRGElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDRGElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecision.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionRule.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionService.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionTable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionTableOrientation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionTableOrientation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TElementCollection.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TElementCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TFunctionDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TFunctionDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TFunctionItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TFunctionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TGroup.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TImport.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TImportedValues.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TImportedValues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInformationItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInformationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInformationRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInformationRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInputData.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInputData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInvocable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInvocable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInvocation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInvocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TItemDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TKnowledgeRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TKnowledgeRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TKnowledgeSource.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TKnowledgeSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TList.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TLiteralExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TLiteralExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TNamedElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TNamedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TOrganizationUnit.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TOrganizationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TOutputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TOutputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TPerformanceIndicator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TPerformanceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRelation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRelation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRuleAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRuleAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRuleAnnotationClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRuleAnnotationClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TTextAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TTextAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TUnaryTests.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TUnaryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Bounds.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Bounds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Color.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Color.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDI.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDecisionServiceDividerLine.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDecisionServiceDividerLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDiagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDiagram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNEdge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNEdge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNLabel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNShape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNStyle.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Diagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Diagram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DiagramElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DiagramElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Dimension.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Dimension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Edge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Edge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Point.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Point.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Shape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Shape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Style.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Style.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/KieDMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/KieDMNModelInstrumentedBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TArtifact.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TArtifact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TAssociation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TAssociation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TAuthorityRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TAuthorityRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TBinding.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TBusinessContextElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TBusinessContextElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TBusinessKnowledgeModel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TBusinessKnowledgeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TChildExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TChildExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TConditional.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TConditional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TContext.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TContextEntry.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TContextEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDMNElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDMNElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDMNElementReference.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDMNElementReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDRGElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDRGElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecision.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecisionRule.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecisionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecisionService.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecisionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecisionTable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecisionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecisionTableOrientation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TDecisionTableOrientation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TElementCollection.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TElementCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TEvery.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TEvery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TFilter.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TFor.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TFor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TFunctionDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TFunctionDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TFunctionItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TFunctionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TGroup.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TImport.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TImportedValues.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TImportedValues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInformationItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInformationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInformationRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInformationRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInputData.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInputData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInvocable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInvocable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInvocation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TInvocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TItemDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TIterator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TKnowledgeRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TKnowledgeRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TKnowledgeSource.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TKnowledgeSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TList.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TLiteralExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TLiteralExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TNamedElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TNamedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TOrganizationUnit.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TOrganizationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TOutputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TOutputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TPerformanceIndicator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TPerformanceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TQuantified.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TQuantified.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TRelation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TRelation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TRuleAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TRuleAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TRuleAnnotationClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TRuleAnnotationClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TSome.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TSome.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TTextAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TTextAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TTypedChildExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TTypedChildExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TUnaryTests.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_4/TUnaryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/KieDMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/KieDMNModelInstrumentedBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TArtifact.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TArtifact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TAssociation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TAssociation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TAuthorityRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TAuthorityRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TBinding.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TBusinessContextElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TBusinessContextElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TBusinessKnowledgeModel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TBusinessKnowledgeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TChildExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TChildExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TConditional.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TConditional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TContext.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TContextEntry.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TContextEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDMNElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDMNElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDMNElementReference.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDMNElementReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDRGElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDRGElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecision.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecisionRule.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecisionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecisionService.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecisionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecisionTable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecisionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecisionTableOrientation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TDecisionTableOrientation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TElementCollection.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TElementCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TEvery.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TEvery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TFilter.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TFor.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TFor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TFunctionDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TFunctionDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TFunctionItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TFunctionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TGroup.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TImport.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TImportedValues.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TImportedValues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInformationItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInformationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInformationRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInformationRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInputData.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInputData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInvocable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInvocable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInvocation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TInvocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TItemDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TIterator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TKnowledgeRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TKnowledgeRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TKnowledgeSource.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TKnowledgeSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TList.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TLiteralExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TLiteralExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TNamedElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TNamedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TOrganizationUnit.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TOrganizationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TOutputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TOutputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TPerformanceIndicator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TPerformanceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TQuantified.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TQuantified.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TRelation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TRelation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TRuleAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TRuleAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TRuleAnnotationClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TRuleAnnotationClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TSome.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TSome.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TTextAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TTextAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TTypedChildExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TTypedChildExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TUnaryTests.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/TUnaryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Bounds.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Bounds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Color.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Color.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNDI.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNDI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNDecisionServiceDividerLine.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNDecisionServiceDividerLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNDiagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNDiagram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNEdge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNEdge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNLabel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNShape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNStyle.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DMNStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Diagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Diagram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DiagramElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/DiagramElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Dimension.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Dimension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Edge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Edge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Point.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Point.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Shape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Shape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Style.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_5/dmndi/Style.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/AssociationDirectionTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/AssociationDirectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/DecisionTableOrientationTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/DecisionTableOrientationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/FunctionKindTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/FunctionKindTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/HitPolicyTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/HitPolicyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/RowLocationTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/RowLocationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/TUnaryTestsTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/TUnaryTestsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/dmndi/AlignmentKindTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/dmndi/AlignmentKindTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/dmndi/KnownColorTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/api/dmndi/KnownColorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/jandex/KieDMNModelJandexTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/jandex/KieDMNModelJandexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/DMNOASGenerator.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/DMNOASGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/DMNOASGeneratorFactory.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/DMNOASGeneratorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/NamingPolicy.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/NamingPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/BaseNodeSchemaMapper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/BaseNodeSchemaMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNOASConstants.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNOASConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNOASGeneratorImpl.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNOASGeneratorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNTypeSchemas.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNTypeSchemas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNUnaryTestsMapper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DMNUnaryTestsMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DefaultNamingPolicy.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/DefaultNamingPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/FEELBuiltinTypeSchemaMapper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/FEELBuiltinTypeSchemaMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/FEELFunctionSchemaMapper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/FEELFunctionSchemaMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/InfixOpNodeSchemaMapper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/InfixOpNodeSchemaMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/MapperHelper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/MapperHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/NamespaceAwareNamingPolicy.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/NamespaceAwareNamingPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapper.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/model/DMNModelIOSets.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/model/DMNModelIOSets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/model/DMNOASResult.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/model/DMNOASResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/AllowNullTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/AllowNullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/BaseDMNOASTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/BaseDMNOASTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/CH11Test.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/CH11Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/DMNDescriptionTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/DMNDescriptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/DS004decisionservicesTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/DS004decisionservicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/DSMultipleOutputTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/DSMultipleOutputTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/DiscouragedTypesTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/DiscouragedTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/EnumGenerationTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/EnumGenerationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/ImportingTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/ImportingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/JacksonUtils.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/JacksonUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/MultipleModelsTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/MultipleModelsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/MyOrderTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/MyOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/NumberAllowedValuesTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/NumberAllowedValuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/OneOfEachTypeTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/OneOfEachTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/PersonTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/PersonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/PersonsTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/PersonsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/ProcessItemTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/ProcessItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/TypeWithSpaceTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/TypeWithSpaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/UndefinedTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/UndefinedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNTypeSchemasTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNTypeSchemasTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNUnaryTestsMapperTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DMNUnaryTestsMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DefaultNamingPolicyTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/DefaultNamingPolicyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/FEELFunctionSchemaMapperTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/FEELFunctionSchemaMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/InfixOpNodeSchemaMapperTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/InfixOpNodeSchemaMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapperTest.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/RangeNodeSchemaMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/SchemaMapperTestUtils.java
+++ b/kie-dmn/kie-dmn-openapi/src/test/java/org/kie/dmn/openapi/impl/SchemaMapperTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNKMeansModelPMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNKMeansModelPMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNMiningModelPMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNMiningModelPMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNNaiveBayesPMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNNaiveBayesPMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNNeuralNetworkPMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNNeuralNetworkPMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNRegressionPMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNRegressionPMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNRuntimePMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNRuntimePMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNTreePMMLTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/DMNTreePMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLInfoTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLValidatorImportTest.java
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/src/test/java/org/kie/dmn/pmml/PMMLValidatorImportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn-cli/src/main/java/org/kie/dmn/ruleset2dmn/cli/App.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn-cli/src/main/java/org/kie/dmn/ruleset2dmn/cli/App.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn-cli/src/main/java/org/kie/dmn/ruleset2dmn/cli/RuleSet2DMNVersionProvider.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn-cli/src/main/java/org/kie/dmn/ruleset2dmn/cli/RuleSet2DMNVersionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/main/java/org/kie/dmn/ruleset2dmn/Converter.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/main/java/org/kie/dmn/ruleset2dmn/Converter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/main/java/org/kie/dmn/ruleset2dmn/SimpleRuleRow.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/main/java/org/kie/dmn/ruleset2dmn/SimpleRuleRow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/main/java/org/kie/dmn/ruleset2dmn/WeightComparator.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/main/java/org/kie/dmn/ruleset2dmn/WeightComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/AdultTest.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/AdultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/ChurnRulesFromSPSSModelerTest.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/ChurnRulesFromSPSSModelerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/ChurnTest.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/ChurnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/IrisTest.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/IrisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/MiniloanTest.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/MiniloanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/TestDMNRuntimeEventListener.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/TestDMNRuntimeEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/TestUtils.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/TotoTest.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/TotoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/WifiTest.java
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/src/test/java/org/kie/dmn/ruleset2dmn/WifiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/KieDMNSignavioProfile.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/KieDMNSignavioProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/MultiInstanceDecisionLogic.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/MultiInstanceDecisionLogic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/MultiInstanceDecisionLogicRegister.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/MultiInstanceDecisionLogicRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/AbsFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/AbsFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/AppendAllFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/AppendAllFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/AreElementsOfFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/AreElementsOfFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/AvgFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/AvgFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ConcatFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ConcatFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ContainsOnlyFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ContainsOnlyFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/DateTimeFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/DateTimeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/DayAddFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/DayAddFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/DayDiffFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/DayDiffFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/DayFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/DayFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/HourDiffFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/HourDiffFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/HourFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/HourFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IntegerFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IntegerFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IsAlphaFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IsAlphaFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IsAlphanumericFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IsAlphanumericFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IsNumericFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IsNumericFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IsSpacesFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/IsSpacesFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/LeftFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/LeftFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/LenFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/LenFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/LowerFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/LowerFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MedianFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MedianFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MidFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MidFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MinuteFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MinuteFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MinutesDiffFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MinutesDiffFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ModeFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ModeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ModuloFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ModuloFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MonthAddFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MonthAddFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MonthDiffFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MonthDiffFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MonthFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/MonthFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/NotContainsAnyFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/NotContainsAnyFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/NowFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/NowFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/PercentFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/PercentFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/PowerFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/PowerFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ProductFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ProductFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RemoveAllFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RemoveAllFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RightFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RightFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RoundDownFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RoundDownFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RoundFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RoundFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RoundUpFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/RoundUpFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SecondFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SecondFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SecondsDiffFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SecondsDiffFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SignavioEndsWithFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SignavioEndsWithFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SignavioNumberFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SignavioNumberFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SignavioRemoveFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SignavioRemoveFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SignavioStartsWithFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/SignavioStartsWithFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/TextFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/TextFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/TextOccurrencesFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/TextOccurrencesFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/TodayFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/TodayFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/TrimFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/TrimFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/UpperFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/UpperFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/WeekdayFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/WeekdayFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/YearAddFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/YearAddFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/YearDiffFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/YearDiffFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/YearFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/YearFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ZipFunction.java
+++ b/kie-dmn/kie-dmn-signavio/src/main/java/org/kie/dmn/signavio/feel/runtime/functions/ZipFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/MultiInstanceDecisionLogicTest.java
+++ b/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/MultiInstanceDecisionLogicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/SignavioTest.java
+++ b/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/SignavioTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/feel/runtime/ExtendedFunctionsBaseFEELTest.java
+++ b/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/feel/runtime/ExtendedFunctionsBaseFEELTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/feel/runtime/FEELExtendedFunctionsTest.java
+++ b/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/feel/runtime/FEELExtendedFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/util/DynamicTypeUtils.java
+++ b/kie-dmn/kie-dmn-signavio/src/test/java/org/kie/dmn/signavio/util/DynamicTypeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/TrisotechDMNProfile.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/TrisotechDMNProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/ConditionalConverter.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/ConditionalConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/FilterConverter.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/FilterConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/IteratorConverter.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/IteratorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/NamedExpressionConverter.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/NamedExpressionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/TrisotechBoxedExtensionRegister.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/TrisotechBoxedExtensionRegister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/ast/DMNConditionalEvaluator.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/ast/DMNConditionalEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/ast/DMNFilterEvaluator.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/ast/DMNFilterEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/ast/DMNIteratorEvaluator.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/ast/DMNIteratorEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/compiler/TrisotechDMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/compiler/TrisotechDMNEvaluatorCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/compiler/TrisotechDMNEvaluatorCompilerFactory.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/compiler/TrisotechDMNEvaluatorCompilerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/util/IterableRange.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/util/IterableRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/util/Msg.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/core/util/Msg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/api/Conditional.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/api/Conditional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/api/Filter.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/api/Filter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/api/Iterator.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/api/Iterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/api/NamedExpression.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/api/NamedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/v1_3/TConditional.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/v1_3/TConditional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/v1_3/TFilter.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/v1_3/TFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/v1_3/TIterator.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/v1_3/TIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/v1_3/TNamedExpression.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/model/v1_3/TNamedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/validation/TrisotechSchema.java
+++ b/kie-dmn/kie-dmn-trisotech/src/main/java/org/kie/dmn/trisotech/validation/TrisotechSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/backend/marshalling/v1_3/xstream/UnmarshalMarshalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/core/DMN14GenericSynthTest.java
+++ b/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/core/DMN14GenericSynthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/validation/TrisotechValidationTest.java
+++ b/kie-dmn/kie-dmn-trisotech/src/test/java/org/kie/dmn/trisotech/validation/TrisotechValidationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation-bootstrap/src/main/java/org/kie/dmn/validation/bootstrap/GenerateModel.java
+++ b/kie-dmn/kie-dmn-validation-bootstrap/src/main/java/org/kie/dmn/validation/bootstrap/GenerateModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation-bootstrap/src/main/java/org/kie/dmn/validation/bootstrap/ValidationBootstrapMain.java
+++ b/kie-dmn/kie-dmn-validation-bootstrap/src/main/java/org/kie/dmn/validation/bootstrap/ValidationBootstrapMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidator.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorFactory.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/MessageReporter.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/MessageReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/ValidatorUtil.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/ValidatorUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyser.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyserValueFromNodeVisitor.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyserValueFromNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalysisException.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalysisException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalysisMessage.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalysisMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/InternalDMNDTAnalyser.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/InternalDMNDTAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/InternalDMNDTAnalyserFactory.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/InternalDMNDTAnalyserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/MCDC2TCKGenerator.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/MCDC2TCKGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/MCDCAnalyser.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/MCDCAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/ObjectFactory.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/ObjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/TestCaseType.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/TestCaseType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/TestCases.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/TestCases.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/ValueType.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/ValueType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/package-info.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/mcdc/dmntck/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Bound.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Bound.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/BoundValueComparator.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/BoundValueComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Contraction.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Contraction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAInputClause.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAInputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAInputEntry.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAInputEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAOutputClause.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAOutputClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAOutputEntryExpression.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTAOutputEntryExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTARule.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTARule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTATable.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DDTATable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DTAnalysis.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/DTAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Domain.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Domain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Hyperrectangle.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Hyperrectangle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Interval.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Interval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/MaskedRule.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/MaskedRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/MisleadingRule.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/MisleadingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/NullBoundImpl.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/NullBoundImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Overlap.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Overlap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/RuleColumnCoordinate.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/RuleColumnCoordinate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Subsumption.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/model/Subsumption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/AbstractValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/AbstractValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/MessageReporterTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/MessageReporterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/UsingResourceValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/UsingResourceValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorArtifactTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorArtifactTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorAuthorityRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorAuthorityRequirementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessContextTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessKnowledgeModelTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessKnowledgeModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorContextTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMN14Test.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMN14Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNDITest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNDITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNElementReferenceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNElementReferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionServiceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorImportTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorImportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInformationRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInformationRequirementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInputDataTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInputDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeRequirementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeSourceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTypeRefTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTypeRefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/classloader/ValidatorClassloaderTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/classloader/ValidatorClassloaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AK0100domainOnTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AK0100domainOnTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AK0100v2domainOnTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AK0100v2domainOnTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AbstractDTAnalysisTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AbstractDTAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AgeKittenTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/AgeKittenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/BuiltinAndOtherValuesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/BuiltinAndOtherValuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check1stNFViolationTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check1stNFViolationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check2ndNFViolationTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Check2ndNFViolationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/ContractionRulesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/ContractionRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyserValueFromNodeVisitorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyserValueFromNodeVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalysisExceptionTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalysisExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DTNestingTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DTNestingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DTinBKMTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/DTinBKMTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/EnumerationWithNullTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/EnumerationWithNullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/FailingOutputConstraintsTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/FailingOutputConstraintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Gaps0100domainOnTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/Gaps0100domainOnTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsAndOverlaps1Test.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsAndOverlaps1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsAndOverlaps1domainOnTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsAndOverlaps1domainOnTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsCube3Test.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsCube3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsOverlapsBooleanTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsOverlapsBooleanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsXYTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/GapsXYTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/HitPolicyFirstTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/HitPolicyFirstTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/IntervalTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/IntervalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MaskTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MisleadingRulesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MisleadingRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MultipleModelsTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/MultipleModelsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NoGapsDateAdjacentTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NoGapsDateAdjacentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NoGapsDomainOnTypeRefTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NoGapsDomainOnTypeRefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NotTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NullTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/NullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapHitPolicyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapsMsgTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapsMsgTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/PiTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/PiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/PosDoubleNegHalfTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/PosDoubleNegHalfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RecommenderHitPolicyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RuleOrderDashTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/RuleOrderDashTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SRGapsOverlapsSubsumption2Test.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SRGapsOverlapsSubsumption2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SameMsgInAllAPITest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SameMsgInAllAPITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SimpleStringNoGapTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SimpleStringNoGapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SomeProblemTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SomeProblemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SomeProblemruleOutsideDomainTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SomeProblemruleOutsideDomainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/StringWithoutEnumNoGapTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/StringWithoutEnumNoGapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SubsumptionRulesTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SubsumptionRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SymbolInDTTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/SymbolInDTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/mcdc/ExampleMCDCTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/mcdc/ExampleMCDCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/model/NullBoundImplTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/model/NullBoundImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/utils/DTAnalysisMeta.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/utils/DTAnalysisMeta.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/v1_5/DMN15ValidationsTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/v1_5/DMN15ValidationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/App.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/App.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/DTHeaderInfo.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/DTHeaderInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/DTSheetListener.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/DTSheetListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/SameVMApp.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/SameVMApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/XLS2DMNException.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/XLS2DMNException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/XLS2DMNParser.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/XLS2DMNParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/XLS2DMNVersionProvider.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/main/java/org/kie/dmn/xls2dmn/cli/XLS2DMNVersionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/CardApprovalTest.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/CardApprovalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/ChineseLunarYearsTest.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/ChineseLunarYearsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/TestUtils.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/XLS2DMNParserTest.java
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/src/test/java/org/kie/dmn/xls2dmn/cli/XLS2DMNParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/DataSourceIds.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/DataSourceIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/DrlComponentRoot.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/DrlComponentRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/DrlIdFactory.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/DrlIdFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/DrlSessionIdFactory.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/DrlSessionIdFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/InstanceQueryId.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/InstanceQueryId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/InstanceQueryIds.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/InstanceQueryIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/InvalidRuleUnitIdException.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/InvalidRuleUnitIdException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/KieDrlComponentRoot.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/KieDrlComponentRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/LocalComponentIdDrl.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/LocalComponentIdDrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/LocalComponentIdDrlSession.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/LocalComponentIdDrlSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/QueryId.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/QueryId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/QueryIds.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/QueryIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitId.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitIdParser.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitIdParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitIds.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitInstanceId.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitInstanceId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitInstanceIds.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/RuleUnitInstanceIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/data/DataId.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/data/DataId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/data/DataIds.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/data/DataIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/data/DataSourceId.java
+++ b/kie-drl/kie-drl-api/src/main/java/org/kie/drl/api/identifiers/data/DataSourceId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/test/java/org/kie/drl/api/identifiers/DrlSessionIdFactoryTest.java
+++ b/kie-drl/kie-drl-api/src/test/java/org/kie/drl/api/identifiers/DrlSessionIdFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/test/java/org/kie/drl/api/identifiers/LocalComponentIdDrlSessionTest.java
+++ b/kie-drl/kie-drl-api/src/test/java/org/kie/drl/api/identifiers/LocalComponentIdDrlSessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-api/src/test/java/org/kie/kogito/incubation/rules/RuleUnitIdParserTest.java
+++ b/kie-drl/kie-drl-api/src/test/java/org/kie/kogito/incubation/rules/RuleUnitIdParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/AbstractDrlFileSetResource.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/AbstractDrlFileSetResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DecisionTableFileSetResource.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DecisionTableFileSetResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DrlCompilationContext.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DrlCompilationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DrlCompilationContextImpl.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DrlCompilationContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DrlFileSetResource.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DrlFileSetResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DrlPackageDescrSetResource.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/DrlPackageDescrSetResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/ExecutableModelClassesContainer.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/model/ExecutableModelClassesContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/service/KieCompilerServiceDecisionTable.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/service/KieCompilerServiceDecisionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/service/KieCompilerServiceDrl.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/service/KieCompilerServiceDrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/utils/DrlCompilerHelper.java
+++ b/kie-drl/kie-drl-compilation-common/src/main/java/org/kie/drl/engine/compilation/utils/DrlCompilerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/test/java/org/drools/ruleunit/example/AllAmounts.java
+++ b/kie-drl/kie-drl-compilation-common/src/test/java/org/drools/ruleunit/example/AllAmounts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/test/java/org/drools/ruleunit/example/Applicant.java
+++ b/kie-drl/kie-drl-compilation-common/src/test/java/org/drools/ruleunit/example/Applicant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/test/java/org/drools/ruleunit/example/LoanApplication.java
+++ b/kie-drl/kie-drl-compilation-common/src/test/java/org/drools/ruleunit/example/LoanApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/test/java/org/drools/ruleunit/example/LoanUnit.java
+++ b/kie-drl/kie-drl-compilation-common/src/test/java/org/drools/ruleunit/example/LoanUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/test/java/org/kie/drl/engine/compilation/KieCompilerServiceDrlTest.java
+++ b/kie-drl/kie-drl-compilation-common/src/test/java/org/kie/drl/engine/compilation/KieCompilerServiceDrlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-compilation-common/src/test/java/org/kie/drl/engine/compilation/utils/DrlCompilerHelperTest.java
+++ b/kie-drl/kie-drl-compilation-common/src/test/java/org/kie/drl/engine/compilation/utils/DrlCompilerHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/kie-drl-kiesession-local-runtime/src/main/java/org/kie/drl/engine/runtime/kiesession/local/model/EfestoInputDrlKieSessionLocal.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/kie-drl-kiesession-local-runtime/src/main/java/org/kie/drl/engine/runtime/kiesession/local/model/EfestoInputDrlKieSessionLocal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/kie-drl-kiesession-local-runtime/src/main/java/org/kie/drl/engine/runtime/kiesession/local/model/EfestoOutputDrlKieSessionLocal.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/kie-drl-kiesession-local-runtime/src/main/java/org/kie/drl/engine/runtime/kiesession/local/model/EfestoOutputDrlKieSessionLocal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/model/EfestoInputDrlMap.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/model/EfestoInputDrlMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/model/EfestoOutputDrlMap.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/model/EfestoOutputDrlMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/utils/MapInputSessionUtils.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/utils/MapInputSessionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/Applicant.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/Applicant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/DateUtils.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/DateUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/DomainClassesMetadataED2A293F9C55BB1943AA9A6A1A8BF64C.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/DomainClassesMetadataED2A293F9C55BB1943AA9A6A1A8BF64C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/LoanAppDto.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/LoanAppDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/LoanApplication.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/LoanApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/LoanDto.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/LoanDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P2F/LambdaPredicate2F3B4F1D1FFEB290777A54C8F3D34978.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P2F/LambdaPredicate2F3B4F1D1FFEB290777A54C8F3D34978.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P33/LambdaPredicate3384BFD77A71291E75C8C73A492233E3.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P33/LambdaPredicate3384BFD77A71291E75C8C73A492233E3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P4C/LambdaPredicate4C9797236624848F80F1DAA0797F33AF.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P4C/LambdaPredicate4C9797236624848F80F1DAA0797F33AF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P57/LambdaConsequence5740B486CC8DAC375E93235CC2B0815D.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P57/LambdaConsequence5740B486CC8DAC375E93235CC2B0815D.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P5F/LambdaConsequence5F2293C183CB858F420C12848B4E6D9C.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P5F/LambdaConsequence5F2293C183CB858F420C12848B4E6D9C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P89/LambdaPredicate896F205BB6DAC489283E534C8D4BF758.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/P89/LambdaPredicate896F205BB6DAC489283E534C8D4BF758.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PA2/LambdaPredicateA2AD3A5DB0C892BF59F8EDAD4B47E88C.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PA2/LambdaPredicateA2AD3A5DB0C892BF59F8EDAD4B47E88C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PA3/LambdaExtractorA32B8CB1183D0F49BCC4780851D79C38.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PA3/LambdaExtractorA32B8CB1183D0F49BCC4780851D79C38.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PB2/LambdaExtractorB2483B164D7AAF9439F4B88741DDDF9E.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PB2/LambdaExtractorB2483B164D7AAF9439F4B88741DDDF9E.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PC9/LambdaPredicateC91E5C2471BC7923781356677C372303.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PC9/LambdaPredicateC91E5C2471BC7923781356677C372303.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PD9/LambdaPredicateD9AE0C5DE12003E037A99BF48F72D864.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PD9/LambdaPredicateD9AE0C5DE12003E037A99BF48F72D864.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PE0/LambdaConsequenceE0E2A00590319D790395C8D009E4D36A.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PE0/LambdaConsequenceE0E2A00590319D790395C8D009E4D36A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PE7/LambdaExtractorE7AC7861C0CAFC6F617FD43B3B32B4DC.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PE7/LambdaExtractorE7AC7861C0CAFC6F617FD43B3B32B4DC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PF2/LambdaPredicateF2B64823F29DA45122941E0AD245653F.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PF2/LambdaPredicateF2B64823F29DA45122941E0AD245653F.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PF3/LambdaPredicateF388D9370A499303354D5F588D65FFF8.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/PF3/LambdaPredicateF388D9370A499303354D5F588D65FFF8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/RulesED2A293F9C55BB1943AA9A6A1A8BF64C.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/RulesED2A293F9C55BB1943AA9A6A1A8BF64C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/RulesED2A293F9C55BB1943AA9A6A1A8BF64CRuleMethods0.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/test/java/org/kie/drl/engine/mapinput/compilation/model/test/RulesED2A293F9C55BB1943AA9A6A1A8BF64CRuleMethods0.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-runtime-common/src/main/java/org/kie/drl/engine/runtime/model/EfestoInputDrl.java
+++ b/kie-drl/kie-drl-runtime-common/src/main/java/org/kie/drl/engine/runtime/model/EfestoInputDrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-runtime-common/src/main/java/org/kie/drl/engine/runtime/model/EfestoOutputDrl.java
+++ b/kie-drl/kie-drl-runtime-common/src/main/java/org/kie/drl/engine/runtime/model/EfestoOutputDrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-runtime-common/src/main/java/org/kie/drl/engine/runtime/utils/EfestoKieRuntimeDrlUtils.java
+++ b/kie-drl/kie-drl-runtime-common/src/main/java/org/kie/drl/engine/runtime/utils/EfestoKieRuntimeDrlUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-runtime-common/src/test/java/org/kie/drl/engine/compilation/model/test/Rulesefe9b92fdd254fbabc9e9002be0d51d6.java
+++ b/kie-drl/kie-drl-runtime-common/src/test/java/org/kie/drl/engine/compilation/model/test/Rulesefe9b92fdd254fbabc9e9002be0d51d6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests-without-index-file/src/test/java/org/drools/ruleunit/example/AllAmounts.java
+++ b/kie-drl/kie-drl-tests-without-index-file/src/test/java/org/drools/ruleunit/example/AllAmounts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests-without-index-file/src/test/java/org/drools/ruleunit/example/Applicant.java
+++ b/kie-drl/kie-drl-tests-without-index-file/src/test/java/org/drools/ruleunit/example/Applicant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests-without-index-file/src/test/java/org/drools/ruleunit/example/LoanApplication.java
+++ b/kie-drl/kie-drl-tests-without-index-file/src/test/java/org/drools/ruleunit/example/LoanApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests-without-index-file/src/test/java/org/drools/ruleunit/example/LoanUnit.java
+++ b/kie-drl/kie-drl-tests-without-index-file/src/test/java/org/drools/ruleunit/example/LoanUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/DomainClassesMetadataefe9b92fdd254fbabc9e9002be0d51d6.java
+++ b/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/DomainClassesMetadataefe9b92fdd254fbabc9e9002be0d51d6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/P70/LambdaConsequence7037A15B6FD94A0C410A07AD1B7BC897.java
+++ b/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/P70/LambdaConsequence7037A15B6FD94A0C410A07AD1B7BC897.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/Rulesefe9b92fdd254fbabc9e9002be0d51d6.java
+++ b/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/Rulesefe9b92fdd254fbabc9e9002be0d51d6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/Rulesefe9b92fdd254fbabc9e9002be0d51d6_rule_first.java
+++ b/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/Rulesefe9b92fdd254fbabc9e9002be0d51d6_rule_first.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/Rulesefe9b92fdd254fbabc9e9002be0d51d6_rule_second.java
+++ b/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/compilation/model/Rulesefe9b92fdd254fbabc9e9002be0d51d6_rule_second.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/testingmodule/utils/DrlTestUtils.java
+++ b/kie-drl/kie-drl-tests/src/main/java/org/kie/drl/engine/testingmodule/utils/DrlTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-drl/kie-drl-tests/src/test/java/org/kie/drl/engine/testingmodule/compilation/CompileDrlTest.java
+++ b/kie-drl/kie-drl-tests/src/test/java/org/kie/drl/engine/testingmodule/compilation/CompileDrlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/KieInternalServices.java
+++ b/kie-internal/src/main/java/org/kie/internal/KieInternalServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/AssemblerContext.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/AssemblerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/ChangeType.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/ChangeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/CompositeKnowledgeBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/CompositeKnowledgeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/DecisionTableConfiguration.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/DecisionTableConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/DecisionTableInputType.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/DecisionTableInputType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/IncrementalResults.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/IncrementalResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/InternalKieBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/InternalKieBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/InternalMessage.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/InternalMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/JaxbConfiguration.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/JaxbConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/JaxbConfigurationFactoryService.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/JaxbConfigurationFactoryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/KieBuilderSet.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KieBuilderSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderConfiguration.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderError.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderErrors.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderErrors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderFactoryService.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderFactoryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderResult.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderResults.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/ProcessBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/ProcessBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/ResourceChange.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/ResourceChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/ResourceChangeSet.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/ResourceChangeSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/ResultSeverity.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/ResultSeverity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/RuleBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/RuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/RuleTemplateConfiguration.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/RuleTemplateConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/AccumulateFunctionOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/AccumulateFunctionOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/AlphaNetworkCompilerOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/AlphaNetworkCompilerOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/DefaultDialectOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/DefaultDialectOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/DefaultPackageNameOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/DefaultPackageNameOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/DumpDirOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/DumpDirOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/EvaluatorOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/EvaluatorOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/ExternaliseCanonicalModelLambdaOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/ExternaliseCanonicalModelLambdaOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/GroupDRLsInKieBasesByFolderOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/GroupDRLsInKieBasesByFolderOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/KBuilderSeverityOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/KBuilderSeverityOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/KnowledgeBuilderOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/KnowledgeBuilderOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/KnowledgeBuilderOptionsConfiguration.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/KnowledgeBuilderOptionsConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/LanguageLevelOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/LanguageLevelOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/MultiValueKieBuilderOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/MultiValueKieBuilderOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/MultiValueKnowledgeBuilderOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/MultiValueKnowledgeBuilderOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/MultiValueRuleBuilderOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/MultiValueRuleBuilderOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/ParallelLambdaExternalizationOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/ParallelLambdaExternalizationOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/ParallelRulesBuildThresholdOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/ParallelRulesBuildThresholdOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/ProcessStringEscapesOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/ProcessStringEscapesOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/PropertySpecificOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/PropertySpecificOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/ReproducibleExecutableModelGenerationOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/ReproducibleExecutableModelGenerationOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/SingleValueKieBuilderOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/SingleValueKieBuilderOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/SingleValueKnowledgeBuilderOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/SingleValueKnowledgeBuilderOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/SingleValueRuleBuilderOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/SingleValueRuleBuilderOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/conf/TrimCellsInDTableOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/conf/TrimCellsInDTableOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/CommandBasedExecutable.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/CommandBasedExecutable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/ContextFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/ContextFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/DMNFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/DMNFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/ExecutableBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/ExecutableBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/KieContainerFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/KieContainerFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/KieSessionFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/KieSessionFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/ProcessFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/ProcessFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/Scope.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/Scope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/TimeFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/TimeFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/WorkItemManagerFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/WorkItemManagerFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/help/DroolsJaxbHelperProvider.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/help/DroolsJaxbHelperProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/help/KnowledgeBuilderHelper.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/help/KnowledgeBuilderHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/builder/impl/KieInternalServicesImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/impl/KieInternalServicesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/command/CommandFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/CommandFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/command/ContextManager.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/ContextManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/command/CorrelationKeyCommand.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/CorrelationKeyCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/command/ExtendedKieCommands.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/ExtendedKieCommands.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/command/ProcessInstanceIdCommand.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/ProcessInstanceIdCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/command/RegistryContext.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/RegistryContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/concurrent/ExecutorProviderFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/concurrent/ExecutorProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/AlphaRangeIndexThresholdOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/AlphaRangeIndexThresholdOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/AlphaThresholdOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/AlphaThresholdOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/CompositeBaseConfiguration.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/CompositeBaseConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/CompositeConfiguration.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/CompositeConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/CompositeKeyDepthOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/CompositeKeyDepthOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/ConfigurationFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/ConfigurationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/ConsequenceExceptionHandlerOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/ConsequenceExceptionHandlerOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/ConstraintJittingThresholdOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/ConstraintJittingThresholdOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/IndexLeftBetaMemoryOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/IndexLeftBetaMemoryOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/IndexPrecedenceOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/IndexPrecedenceOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/IndexRightBetaMemoryOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/IndexRightBetaMemoryOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/InternalPropertiesConfiguration.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/InternalPropertiesConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/MaxThreadsOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/MaxThreadsOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/ParallelExecutionOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/ParallelExecutionOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/SequentialAgendaOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/SequentialAgendaOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/ShareAlphaNodesOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/ShareAlphaNodesOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/conf/ShareBetaNodesOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/ShareBetaNodesOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/definition/GenericTypeDefinition.java
+++ b/kie-internal/src/main/java/org/kie/internal/definition/GenericTypeDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/definition/KnowledgeDefinition.java
+++ b/kie-internal/src/main/java/org/kie/internal/definition/KnowledgeDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/definition/KnowledgeDescr.java
+++ b/kie-internal/src/main/java/org/kie/internal/definition/KnowledgeDescr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/definition/rule/InternalRule.java
+++ b/kie-internal/src/main/java/org/kie/internal/definition/rule/InternalRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/event/rule/RuleEventListener.java
+++ b/kie-internal/src/main/java/org/kie/internal/event/rule/RuleEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/event/rule/RuleEventManager.java
+++ b/kie-internal/src/main/java/org/kie/internal/event/rule/RuleEventManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/identity/IdentityProvider.java
+++ b/kie-internal/src/main/java/org/kie/internal/identity/IdentityProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/io/ResourceFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/io/ResourceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/io/ResourceTypeImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/io/ResourceTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/io/ResourceWithConfigurationImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/io/ResourceWithConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/CorrelationKeyXmlAdapter.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/CorrelationKeyXmlAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/LocalDateTimeXmlAdapter.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/LocalDateTimeXmlAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/LocalDateXmlAdapter.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/LocalDateXmlAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/LocalTimeXmlAdapter.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/LocalTimeXmlAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/OffsetDateTimeXmlAdapter.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/OffsetDateTimeXmlAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyObjectValueEntry.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyObjectValueEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyObjectValueMap.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyObjectValueMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyObjectValueMapXmlAdapter.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyObjectValueMapXmlAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyStringValueEntry.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyStringValueEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyStringValueMap.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyStringValueMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyStringValueMapXmlAdapter.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyStringValueMapXmlAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/jci/CompilationProblem.java
+++ b/kie-internal/src/main/java/org/kie/internal/jci/CompilationProblem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/logger/KnowledgeRuntimeLoggerFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/logger/KnowledgeRuntimeLoggerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/marshalling/MarshallerFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/marshalling/MarshallerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/persistence/jpa/JPAKnowledgeService.java
+++ b/kie-internal/src/main/java/org/kie/internal/persistence/jpa/JPAKnowledgeService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/pmml/PMMLCommandExecutor.java
+++ b/kie-internal/src/main/java/org/kie/internal/pmml/PMMLCommandExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/pmml/PMMLCommandExecutorFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/pmml/PMMLCommandExecutorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/pmml/PMMLImplementationsUtil.java
+++ b/kie-internal/src/main/java/org/kie/internal/pmml/PMMLImplementationsUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/process/CorrelationAwareProcessRuntime.java
+++ b/kie-internal/src/main/java/org/kie/internal/process/CorrelationAwareProcessRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/process/CorrelationKey.java
+++ b/kie-internal/src/main/java/org/kie/internal/process/CorrelationKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/process/CorrelationKeyFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/process/CorrelationKeyFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/process/CorrelationProperty.java
+++ b/kie-internal/src/main/java/org/kie/internal/process/CorrelationProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/remote/PermissionConstants.java
+++ b/kie-internal/src/main/java/org/kie/internal/remote/PermissionConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitComponentFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitDescription.java
+++ b/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitUtil.java
+++ b/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitVariable.java
+++ b/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/Cacheable.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/Cacheable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/Closeable.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/Closeable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/CommandBasedStatefulKnowledgeSession.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/CommandBasedStatefulKnowledgeSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/KnowledgeContext.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/KnowledgeContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/StatefulKnowledgeSession.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/StatefulKnowledgeSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/StatelessKnowledgeSessionResults.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/StatelessKnowledgeSessionResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/AuditMode.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/AuditMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/BuilderHandler.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/BuilderHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/DeploymentDescriptor.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/DeploymentDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/DeploymentDescriptorBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/DeploymentDescriptorBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/ForceEagerActivationFilter.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/ForceEagerActivationFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/ForceEagerActivationOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/ForceEagerActivationOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/MergeMode.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/MergeMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/NamedObjectModel.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/NamedObjectModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/ObjectModel.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/ObjectModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/ObjectModelResolver.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/ObjectModelResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/ObjectModelResolverProvider.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/ObjectModelResolverProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/PersistenceMode.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/PersistenceMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/conf/RuntimeStrategy.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/conf/RuntimeStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorIO.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorIO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorManager.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorMerger.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/TransientNamedObjectModel.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/TransientNamedObjectModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/TransientObjectModel.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/TransientObjectModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/services/AbstractMultiService.java
+++ b/kie-internal/src/main/java/org/kie/internal/services/AbstractMultiService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/services/KieAssemblersImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/services/KieAssemblersImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/services/KieRuntimesImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/services/KieRuntimesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/services/KieWeaversImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/services/KieWeaversImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/simulation/Simulation.java
+++ b/kie-internal/src/main/java/org/kie/internal/simulation/Simulation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/simulation/SimulationPath.java
+++ b/kie-internal/src/main/java/org/kie/internal/simulation/SimulationPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/simulation/SimulationStep.java
+++ b/kie-internal/src/main/java/org/kie/internal/simulation/SimulationStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/task/exception/TaskError.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/exception/TaskError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/task/exception/TaskException.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/exception/TaskException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/task/service/ResponseHandler.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/service/ResponseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/ChainedProperties.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/ChainedProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/ClassLoaderResolver.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/ClassLoaderResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/ClassLoaderUtil.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/ClassLoaderUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/CompositeClassLoader.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/CompositeClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/FastClassLoader.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/FastClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/KieHelper.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/KieHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/KieTypeResolver.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/KieTypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/LazyLoaded.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/LazyLoaded.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/NoDepsClassLoaderResolver.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/NoDepsClassLoaderResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/main/java/org/kie/internal/utils/VariableIndexer.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/VariableIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorMergerTest.java
+++ b/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorMergerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorTest.java
+++ b/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/JaxbMarshalingTest.java
+++ b/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/JaxbMarshalingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/src/test/java-filtered/org/kie/maven/plugin/ittests/BuildPMMLTrustyTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/src/test/java-filtered/org/kie/maven/plugin/ittests/BuildPMMLTrustyTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/src/test/java-filtered/org/kie/maven/plugin/ittests/AlphaNetworkCompilerTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/src/test/java-filtered/org/kie/maven/plugin/ittests/AlphaNetworkCompilerTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/main/java/org/drools/ruleunit/example/AllAmounts.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/main/java/org/drools/ruleunit/example/AllAmounts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/main/java/org/drools/ruleunit/example/Applicant.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/main/java/org/drools/ruleunit/example/Applicant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/main/java/org/drools/ruleunit/example/LoanApplication.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/main/java/org/drools/ruleunit/example/LoanApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/main/java/org/drools/ruleunit/example/LoanUnit.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/main/java/org/drools/ruleunit/example/LoanUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/test/java/org/drools/ruleunit/example/LoanTest.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/src/test/java/org/drools/ruleunit/example/LoanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-15-yaml/src/main/java/org/yaml/Measurement.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-15-yaml/src/main/java/org/yaml/Measurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-15-yaml/src/test/java-filtered/org/kie/maven/plugin/ittests/YamlTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-15-yaml/src/test/java-filtered/org/kie/maven/plugin/ittests/YamlTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/src/main/java/org/kie/maven/plugin/test/Person.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/src/main/java/org/kie/maven/plugin/test/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/src/test/java/org/kie/maven/plugin/ittests/AdditionalPropertiesIntegrationTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/src/test/java/org/kie/maven/plugin/ittests/AdditionalPropertiesIntegrationTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/KJarWithDMNIntegrationTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/KJarWithDMNIntegrationTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/KJarWithDMNIntegrationTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/KJarWithDMNIntegrationTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/kie-maven-plugin-test-kjar-8-modA-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/MultiModuleTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/kie-maven-plugin-test-kjar-8-modA-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/MultiModuleTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/kie-maven-plugin-test-kjar-8-modA-no-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/MultiModuleTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/kie-maven-plugin-test-kjar-8-modA-no-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/MultiModuleTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/src/main/java/org/declaredtype/FactA.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/src/main/java/org/declaredtype/FactA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/DeclaredTypesTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/DeclaredTypesTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/src/main/java/org/declaredtype/FactA.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/src/main/java/org/declaredtype/FactA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/DeclaredTypesTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/DeclaredTypesTestIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/src/main/java/org/kie/maven/plugin/ittests/ITTestsUtils.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/src/main/java/org/kie/maven/plugin/ittests/ITTestsUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ArtifactItem.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ArtifactItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/DiskResourceStore.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/DiskResourceStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/KieMavenPluginContext.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/KieMavenPluginContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/PMMLResource.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/PMMLResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ProjectPomModel.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ProjectPomModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/enums/DMNModelMode.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/enums/DMNModelMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/enums/ExecModelMode.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/enums/ExecModelMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/BuildDrlExecutor.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/BuildDrlExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/GenerateANCExecutor.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/GenerateANCExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/GenerateDMNModelExecutor.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/GenerateDMNModelExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/GenerateModelExecutor.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/GenerateModelExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/GeneratePMMLModelExecutor.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/executors/GeneratePMMLModelExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/CompilerHelper.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/CompilerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/DMNModelModeHelper.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/DMNModelModeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/DMNValidationHelper.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/DMNValidationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/ExecModelModeHelper.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/ExecModelModeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/ExecutorHelper.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/ExecutorHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/GenerateCodeHelper.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/helpers/GenerateCodeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/mojos/AbstractKieMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/mojos/AbstractKieMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/mojos/BuildMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/mojos/BuildMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/mojos/PackageKjarDependenciesMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/mojos/PackageKjarDependenciesMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/mojos/ValidateDMNMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/mojos/ValidateDMNMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/test/java/org/kie/maven/plugin/ProjectPomModelTest.java
+++ b/kie-maven-plugin/src/test/java/org/kie/maven/plugin/ProjectPomModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-maven-plugin/src/test/java/org/kie/maven/plugin/helpers/DMNValidationHelperTest.java
+++ b/kie-maven-plugin/src/test/java/org/kie/maven/plugin/helpers/DMNValidationHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/AbstractJavaCompiler.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/AbstractJavaCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/CompilationProblem.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/CompilationProblem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/CompilationResult.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/CompilationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/JavaCompiler.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/JavaCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/JavaCompilerFactory.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/JavaCompilerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/JavaCompilerSettings.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/JavaCompilerSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/JavaConfiguration.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/JavaConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/KieMemoryCompiler.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/KieMemoryCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/KieMemoryCompilerException.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/KieMemoryCompilerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/StoreClassLoader.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/StoreClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/WritableClassLoader.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/WritableClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/JavaCompilerFinder.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/JavaCompilerFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeCompilationProblem.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeCompilationProblem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeJavaCompiler.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeJavaCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeJavaCompilerFinder.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeJavaCompilerFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeJavaCompilerSettings.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeJavaCompilerSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/MemoryResourceReader.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/MemoryResourceReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/MemoryResourceStore.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/MemoryResourceStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/ResourceReader.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/ResourceReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/ResourceStore.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/ResourceStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/test/java/org/kie/memorycompiler/KieMemoryCompilerTest.java
+++ b/kie-memory-compiler/src/test/java/org/kie/memorycompiler/KieMemoryCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-memory-compiler/src/test/java/org/kie/memorycompiler/jdknative/NativeJavaCompilerTest.java
+++ b/kie-memory-compiler/src/test/java/org/kie/memorycompiler/jdknative/NativeJavaCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/PMMLContext.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/PMMLContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/PMMLRuntimeFactory.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/PMMLRuntimeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/ARRAY_TYPE.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/ARRAY_TYPE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/BASELINE_METHOD.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/BASELINE_METHOD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/BOOLEAN_OPERATOR.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/BOOLEAN_OPERATOR.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/BUILTIN_FUNCTIONS.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/BUILTIN_FUNCTIONS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/CAST_INTEGER.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/CAST_INTEGER.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/CLOSURE.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/CLOSURE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/COUNT_HITS.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/COUNT_HITS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/DATA_TYPE.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/DATA_TYPE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/FIELD_USAGE_TYPE.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/FIELD_USAGE_TYPE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/INVALID_VALUE_TREATMENT_METHOD.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/INVALID_VALUE_TREATMENT_METHOD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/IN_NOTIN.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/IN_NOTIN.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/LOCAL_TERM_WEIGHTS.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/LOCAL_TERM_WEIGHTS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/MINING_FUNCTION.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/MINING_FUNCTION.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/MISSING_VALUE_TREATMENT_METHOD.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/MISSING_VALUE_TREATMENT_METHOD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/Named.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/Named.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/OPERATOR.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/OPERATOR.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/OP_TYPE.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/OP_TYPE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/OUTLIER_TREATMENT_METHOD.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/OUTLIER_TREATMENT_METHOD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_MODEL.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_MODEL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_STEP.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/PMML_STEP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/REASONCODE_ALGORITHM.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/REASONCODE_ALGORITHM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/RESULT_FEATURE.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/RESULT_FEATURE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/ResultCode.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/ResultCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/VALUE_PROPERTY.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/VALUE_PROPERTY.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/ArithmeticFunctions.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/ArithmeticFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/BooleanFunctions.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/BooleanFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/DateFunctions.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/DateFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/DistributionFunctions.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/DistributionFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/MathematicalFunctions.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/MathematicalFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/StringFunctions.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/builtinfunctions/StringFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/ExternalException.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/ExternalException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KieDataFieldException.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KieDataFieldException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KieEnumException.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KieEnumException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLException.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLInputDataException.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLInputDataException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLInternalException.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLInternalException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLValidationException.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLValidationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/LocalComponentIdRedirectPmml.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/LocalComponentIdRedirectPmml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/LocalPredictionId.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/LocalPredictionId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/PmmlComponentRoot.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/PmmlComponentRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/PmmlIdRedirectFactory.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/PmmlIdRedirectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/PredictionIds.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/identifiers/PredictionIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/iinterfaces/SerializableConsumer.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/iinterfaces/SerializableConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/iinterfaces/SerializableFunction.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/iinterfaces/SerializableFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/Interval.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/Interval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/OutputField.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/OutputField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/PMMLModel.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/PMMLModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/PMMLModelImpl.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/PMMLModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/PMMLStep.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/PMMLStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/TargetField.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/TargetField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/TargetValue.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/TargetValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/package-info.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLListener.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLRuntime.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/runtime/PMMLRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/utils/ConverterTypeUtil.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/utils/ConverterTypeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/utils/EnumUtils.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/utils/EnumUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/utils/PrimitiveBoxedUtils.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/utils/PrimitiveBoxedUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/utils/SourceUtils.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/utils/SourceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/BUILTIN_FUNCTIONSTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/BUILTIN_FUNCTIONSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/CAST_INTEGERTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/CAST_INTEGERTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/DATA_TYPETest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/DATA_TYPETest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/ArithmeticFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/ArithmeticFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/BooleanFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/BooleanFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/DateFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/DateFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/DistributionFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/DistributionFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/MathematicalFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/MathematicalFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/StringFunctionsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/enums/builtinfunctions/StringFunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/identifiers/LocalComponentIdPmmlTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/identifiers/LocalComponentIdPmmlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/identifiers/LocalComponentIdRedirectPmmlTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/identifiers/LocalComponentIdRedirectPmmlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/identifiers/LocalPredictionIdTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/identifiers/LocalPredictionIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/identifiers/PredictionIdsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/identifiers/PredictionIdsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/utils/ConverterTypeUtilTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/utils/ConverterTypeUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/utils/PrimitiveBoxedUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/test/java/org/kie/pmml/api/utils/PrimitiveBoxedUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/HasRedirectOutput.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/HasRedirectOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/HasRule.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/HasRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/HasNestedModels.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/HasNestedModels.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/HasSourcesMap.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/HasSourcesMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/IsDrools.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/IsDrools.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/IsInterpreted.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/IsInterpreted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLExtension.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLFactoryModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLFactoryModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLMiningField.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLMiningField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModelWithSources.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModelWithSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLOutputField.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLOutputField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLTarget.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLTarget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLTargetValue.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLTargetValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/ProcessingDTO.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/ProcessingDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/abstracts/AbstractKiePMMLComponent.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/abstracts/AbstractKiePMMLComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/abstracts/KiePMMLExtensionedTerm.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/abstracts/KiePMMLExtensionedTerm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/ExpressionsUtils.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/ExpressionsUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLApply.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLApply.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLConstant.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLConstant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretize.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeBin.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeBin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLExpression.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLFieldColumnPair.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLFieldColumnPair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLFieldRef.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLFieldRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLInlineTable.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLInlineTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLInterval.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLInterval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLLinearNorm.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLLinearNorm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLMapValues.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLMapValues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLNormContinuous.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLNormContinuous.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLNormDiscrete.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLNormDiscrete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLRow.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLRow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndex.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexNormalization.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexNormalization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/package-info.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLCompoundPredicate.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLCompoundPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLFalsePredicate.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLFalsePredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLPredicate.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLSimplePredicate.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLSimplePredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLSimpleSetPredicate.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLSimpleSetPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLTruePredicate.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/predicates/KiePMMLTruePredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLNameOpType.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLNameOpType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLNameValue.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLNameValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLProbabilityConfidence.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLProbabilityConfidence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLValueWeight.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLValueWeight.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLDefineFunction.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLDefineFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLDerivedField.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLDerivedField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLLocalTransformations.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLLocalTransformations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLParameterField.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLParameterField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLTransformationDictionary.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/transformations/KiePMMLTransformationDictionary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/utils/KiePMMLModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/utils/KiePMMLModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/utils/PMMLLoaderUtils.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/utils/PMMLLoaderUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/CommonTestingUtility.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/CommonTestingUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/compilation/model/TestMod.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/compilation/model/TestMod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/compilation/model/TestingModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/compilation/model/TestingModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLFactoryModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLFactoryModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLMiningFieldTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLMiningFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLModelWithSourcesTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLModelWithSourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLOutputFieldTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLOutputFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLTargetTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/KiePMMLTargetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLApplyTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLApplyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLConstantTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLConstantTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeBinTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeBinTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLDiscretizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLFieldRefTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLFieldRefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLInlineTableTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLInlineTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLIntervalTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLIntervalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLMapValuesTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLMapValuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLNormContinuousTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLNormContinuousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLNormDiscreteTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLNormDiscreteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLRowTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLRowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexNormalizationTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexNormalizationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/expressions/KiePMMLTextIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLCompoundPredicateTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLCompoundPredicateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLSimplePredicateTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLSimplePredicateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLSimpleSetPredicateTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/model/predicates/KiePMMLSimpleSetPredicateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/KiePMMLTestingModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/KiePMMLTestingModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/KiePMMLTestingModelWithSources.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/KiePMMLTestingModelWithSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/transformations/KiePMMLDefineFunctionTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/transformations/KiePMMLDefineFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/transformations/KiePMMLDerivedFieldTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/transformations/KiePMMLDerivedFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/utils/KiePMMLModelUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/utils/KiePMMLModelUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/utils/PMMLLoaderUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/utils/PMMLLoaderUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/dto/CommonCompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/dto/CommonCompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/dto/CompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/dto/CompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/provider/ModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/provider/ModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/provider/ModelImplementationProviderFinder.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/provider/ModelImplementationProviderFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/utils/ModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/utils/ModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/CommonTestingUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/CommonTestingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/mocks/TestModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/testutils/PMMLModelTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/testutils/PMMLModelTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/testutils/TestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/testutils/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/utils/ModelUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/test/java/org/kie/pmml/compiler/api/utils/ModelUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLApplyFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLApplyFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLCompoundPredicateFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLCompoundPredicateFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLConstantFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLConstantFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDefineFunctionFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDefineFunctionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDerivedFieldFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDerivedFieldFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeBinFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeBinFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLExpressionFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLExpressionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFalsePredicateFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFalsePredicateFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldColumnPairFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldColumnPairFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldRefFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldRefFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLInlineTableFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLInlineTableFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLIntervalFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLIntervalFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLLocalTransformationsFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLLocalTransformationsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMapValuesFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMapValuesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMiningFieldFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMiningFieldFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLModelFactoryUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLModelFactoryUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormContinuousFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormContinuousFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormDiscreteFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormDiscreteFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLOutputFieldFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLOutputFieldFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLParameterFieldFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLParameterFieldFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLPredicateFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLPredicateFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLRowFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLRowFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimplePredicateFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimplePredicateFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimpleSetPredicateFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimpleSetPredicateFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetValueFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetValueFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexNormalizationFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexNormalizationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTransformationDictionaryFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTransformationDictionaryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTruePredicateFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTruePredicateFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/TargetFieldFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/TargetFieldFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/TargetValueFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/TargetValueFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/dto/AbstractSpecificCompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/dto/AbstractSpecificCompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLApplyInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLApplyInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLCompoundPredicateInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLCompoundPredicateInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLConstantInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLConstantInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLDefineFunctionInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLDefineFunctionInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLDerivedFieldInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLDerivedFieldInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLDiscretizeBinInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLDiscretizeBinInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLDiscretizeInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLDiscretizeInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLExpressionInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLExpressionInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLExtensionInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLExtensionInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLFactoryFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLFactoryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLFalsePredicateInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLFalsePredicateInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLFieldColumnPairInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLFieldColumnPairInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLFieldRefInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLFieldRefInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLInlineTableInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLInlineTableInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLIntervalInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLIntervalInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLLinearNormInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLLinearNormInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLLocalTransformationsInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLLocalTransformationsInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLMapValuesInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLMapValuesInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLMiningFieldInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLMiningFieldInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLNormContinuousInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLNormContinuousInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLNormDiscreteInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLNormDiscreteInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLOutputFieldInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLOutputFieldInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLParameterFieldInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLParameterFieldInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLPredicateInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLPredicateInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLRowInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLRowInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLSimplePredicateInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLSimplePredicateInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLSimpleSetPredicateInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLSimpleSetPredicateInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTargetInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTargetInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTargetValueInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTargetValueInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTextIndexInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTextIndexInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTextIndexNormalizationInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTextIndexNormalizationInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTransformationDictionaryInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTransformationDictionaryInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTruePredicateInstanceFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/factories/KiePMMLTruePredicateInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/ModelImplementationProviderFinderImpl.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/ModelImplementationProviderFinderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/JavaParserUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/JavaParserUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtil.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLApplyFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLApplyFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLCompoundPredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLCompoundPredicateFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLConstantFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLConstantFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDefineFunctionFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDefineFunctionFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDerivedFieldFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDerivedFieldFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeBinFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeBinFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLDiscretizeFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFalsePredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFalsePredicateFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldColumnPairFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldColumnPairFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldRefFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLFieldRefFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLInlineTableFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLInlineTableFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLIntervalFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLIntervalFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLLocalTransformationsFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLLocalTransformationsFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMapValuesFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMapValuesFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMiningFieldFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLMiningFieldFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLModelFactoryUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLModelFactoryUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormContinuousFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormContinuousFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormDiscreteFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLNormDiscreteFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLParameterFieldFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLParameterFieldFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLRowFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLRowFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimplePredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimplePredicateFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimpleSetPredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLSimpleSetPredicateFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetValueFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTargetValueFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexNormalizationFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTextIndexNormalizationFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTransformationDictionaryFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTransformationDictionaryFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTruePredicateFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLTruePredicateFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetFieldFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetFieldFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetValueFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/codegenfactories/TargetValueFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/InstanceFactoriesTestCommon.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/InstanceFactoriesTestCommon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLApplyInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLApplyInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLCompoundPredicateInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLCompoundPredicateInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLConstantInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLConstantInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLDefineFunctionInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLDefineFunctionInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLDerivedFieldInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLDerivedFieldInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLDiscretizeBinInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLDiscretizeBinInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLDiscretizeInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLDiscretizeInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLExpressionInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLExpressionInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLExtensionInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLExtensionInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFactoryFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFactoryFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFalsePredicateInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFalsePredicateInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFieldColumnPairInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFieldColumnPairInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFieldRefInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLFieldRefInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLInlineTableInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLInlineTableInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLIntervalInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLIntervalInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLLinearNormInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLLinearNormInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLLocalTransformationsInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLLocalTransformationsInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLMapValuesInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLMapValuesInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLMiningFieldInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLMiningFieldInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLNormContinuousInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLNormContinuousInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLNormDiscreteInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLNormDiscreteInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLOutputFieldInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLOutputFieldInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLParameterFieldInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLParameterFieldInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLPredicateInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLPredicateInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLRowInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLRowInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLSimplePredicateInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLSimplePredicateInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLSimpleSetPredicateInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLSimpleSetPredicateInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTargetInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTargetInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTargetValueInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTargetValueInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTextIndexInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTextIndexInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTransformationDictionaryInstanceFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/factories/KiePMMLTransformationDictionaryInstanceFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetrieverTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetrieverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/ModelImplementationProviderFinderImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/ModelImplementationProviderFinderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/mocks/ExternalizableMock.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/mocks/ExternalizableMock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/mocks/PMMLCompilationContextMock.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/mocks/PMMLCompilationContextMock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/mocks/TestingModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/mocks/TestingModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/testutils/CodegenTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/testutils/CodegenTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/JavaParserUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/JavaParserUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLLoadedModelUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLLoadedModelUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtilTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/PMMLCompilationContextImpl.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/PMMLCompilationContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompiler.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/model/EfestoCallableOutputPMMLClassesContainer.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/model/EfestoCallableOutputPMMLClassesContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/model/EfestoRedirectOutputPMML.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/model/EfestoRedirectOutputPMML.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/service/PMMLCompilerService.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/service/PMMLCompilerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/service/PMMLCompilerServicePMMLFile.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/service/PMMLCompilerServicePMMLFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/PMMLCompilationContextImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/PMMLCompilationContextImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/PMMLTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/PMMLTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/model/EfestoRedirectOutputPMMLTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/model/EfestoRedirectOutputPMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/service/KieCompilerServicePMMLFileTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/service/KieCompilerServicePMMLFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/service/KieCompilerServicePMMLInputStreamTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/service/KieCompilerServicePMMLInputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/testingutils/TestModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/testingutils/TestModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/testingutils/TestingModel.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/java/org/kie/pmml/compiler/testingutils/TestingModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/org/kie/model/project/codegen/TestMod.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/org/kie/model/project/codegen/TestMod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/org/kie/model/project/codegen/TestingModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/test/resources/org/kie/model/project/codegen/TestingModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/container/PMMLPackage.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/container/PMMLPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/exceptions/KiePMMLModelException.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/exceptions/KiePMMLModelException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/executor/PMMLModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/executor/PMMLModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/executor/PMMLModelEvaluatorFinder.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/executor/PMMLModelEvaluatorFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/executor/PMMLModelEvaluatorFinderImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/executor/PMMLModelEvaluatorFinderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/implementations/AbstractPMMLStep.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/implementations/AbstractPMMLStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/implementations/PMMLRuntimeStep.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/implementations/PMMLRuntimeStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/model/EfestoInputPMML.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/model/EfestoInputPMML.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/model/EfestoOutputPMML.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/model/EfestoOutputPMML.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/KieRuntimeServicePMMLMapInput.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/KieRuntimeServicePMMLMapInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/Converter.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/Converter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/KnowledgeBaseUtils.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/KnowledgeBaseUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtils.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PMMLRequestDataBuilder.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PMMLRequestDataBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PostProcess.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PostProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/compilation/model/TestMod.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/compilation/model/TestMod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/compilation/model/TestingModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/compilation/model/TestingModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/PMMLRuntimeContextImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/PMMLRuntimeContextImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/model/EfestoInputPMMLTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/model/EfestoInputPMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImplTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/RuntimeServicesTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/service/RuntimeServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/testingutils/PMMLTestingModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/testingutils/PMMLTestingModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PMMLListenerUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PostProcessTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PostProcessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PreProcessTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PreProcessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/src/main/java/org/kie/pmml/evaluator/utils/PMMLRuntimeFactoryImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/src/main/java/org/kie/pmml/evaluator/utils/PMMLRuntimeFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/src/main/java/org/kie/pmml/evaluator/utils/SPIUtils.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/src/main/java/org/kie/pmml/evaluator/utils/SPIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/main/java/org/kie/pmml/models/clustering/compiler/dto/ClusteringCompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/main/java/org/kie/pmml/models/clustering/compiler/dto/ClusteringCompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/main/java/org/kie/pmml/models/clustering/compiler/executor/ClusteringModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/main/java/org/kie/pmml/models/clustering/compiler/executor/ClusteringModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/main/java/org/kie/pmml/models/clustering/compiler/factories/KiePMMLClusteringConversionUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/main/java/org/kie/pmml/models/clustering/compiler/factories/KiePMMLClusteringConversionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/main/java/org/kie/pmml/models/clustering/compiler/factories/KiePMMLClusteringModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/main/java/org/kie/pmml/models/clustering/compiler/factories/KiePMMLClusteringModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/java/org/kie/pmml/models/clustering/compiler/executor/ClusteringModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/java/org/kie/pmml/models/clustering/compiler/executor/ClusteringModelImplementationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/java/org/kie/pmml/models/clustering/compiler/factories/KiePMMLClusteringModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/src/test/java/org/kie/pmml/models/clustering/compiler/factories/KiePMMLClusteringModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/src/main/java/org/kie/pmml/models/clustering/evaluator/PMMLClusteringModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/src/main/java/org/kie/pmml/models/clustering/evaluator/PMMLClusteringModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/src/test/java/org/kie/pmml/models/clustering/evaluator/PMMLClusteringModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/src/test/java/org/kie/pmml/models/clustering/evaluator/PMMLClusteringModelEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLAggregateFunction.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLAggregateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLCluster.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLCluster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringField.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLCompareFunction.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLCompareFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLComparisonMeasure.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLComparisonMeasure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLMissingValueWeights.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLMissingValueWeights.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/test/java/org/kie/pmml/models/clustering/model/KiePMMLAggregateFunctionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/test/java/org/kie/pmml/models/clustering/model/KiePMMLAggregateFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/test/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/test/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/test/java/org/kie/pmml/models/clustering/model/KiePMMLCompareFunctionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/test/java/org/kie/pmml/models/clustering/model/KiePMMLCompareFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/ClusterWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/ClusterWithTransformationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/EuclideanDistanceTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/EuclideanDistanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/MultipleClustersSameClassTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/MultipleClustersSameClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/SingleIrisKMeansClusteringIdTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/SingleIrisKMeansClusteringIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/SingleIrisKMeansClusteringTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/SingleIrisKMeansClusteringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/KiePMMLDroolsAST.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/KiePMMLDroolsAST.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/KiePMMLDroolsRule.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/KiePMMLDroolsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/KiePMMLDroolsType.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/KiePMMLDroolsType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/KiePMMLFieldOperatorValue.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/KiePMMLFieldOperatorValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLAbstractModelASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLAbstractModelASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLAbstractPredicateASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLAbstractPredicateASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateWithAccumulationASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateWithAccumulationASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateWithResultASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateWithResultASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDerivedFieldASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDerivedFieldASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLPredicateASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLPredicateASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateWithAccumulationASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateWithAccumulationASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateWithResultASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateWithResultASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateWithAccumulationASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateWithAccumulationASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateWithResultASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateWithResultASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateWithAccumulationASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateWithAccumulationASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateWithResultASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateWithResultASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/PredicateASTFactoryData.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/PredicateASTFactoryData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrLhsFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrLhsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRhsFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRhsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRulesFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRulesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrTypesFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrTypesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/model/EfestoRedirectOutputPMMLDrl.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/model/EfestoRedirectOutputPMMLDrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelWithSources.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelWithSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/utils/KiePMMLDroolsModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/utils/KiePMMLDroolsModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/dto/DroolsCompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/dto/DroolsCompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/executor/DroolsModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/executor/DroolsModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/executor/KiePMMLStatusHolder.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/executor/KiePMMLStatusHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLOperatorValue.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLOperatorValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLOriginalTypeGeneratedType.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLOriginalTypeGeneratedType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLReasonCodeAndValue.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLReasonCodeAndValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLAgendaListenerUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLAgendaListenerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/KiePMMLFieldOperatorValueTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/KiePMMLFieldOperatorValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDerivedFieldASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDerivedFieldASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrLhsFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrLhsFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRhsFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRhsFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRulesFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrRulesFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrTypesFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/factories/KiePMMLDescrTypesFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/provider/DroolsModelProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/provider/DroolsModelProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/tuples/KiePMMLOperatorValueTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/tuples/KiePMMLOperatorValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelCharacteristicASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelCharacteristicASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelCharacteristicASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelCharacteristicASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/main/java/org/kie/pmml/models/drools/scorecard/evaluator/PMMLScorecardModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/main/java/org/kie/pmml/models/drools/scorecard/evaluator/PMMLScorecardModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/test/java/org/kie/pmml/models/drools/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/test/java/org/kie/pmml/models/drools/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/src/main/java/org/kie/pmml/models/drools/scorecard/model/KiePMMLScorecardModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/src/main/java/org/kie/pmml/models/drools/scorecard/model/KiePMMLScorecardModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/AirconditioningScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/AirconditioningScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/BasicComplexPartialScoreTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/BasicComplexPartialScoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/CompoundNestedPredicateScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/CompoundNestedPredicateScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/CompoundPredicateScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/CompoundPredicateScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/MultipleAirconditioningScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/MultipleAirconditioningScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/MultipleCompoundNestedPredicateScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/MultipleCompoundNestedPredicateScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/NestedComplexPartialScoreTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/NestedComplexPartialScoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardCategoricalTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardCategoricalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardMixedVariablesTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardMixedVariablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardWithTransformationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/main/java/org/kie/pmml/models/drools/tree/evaluator/PMMLTreeModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/main/java/org/kie/pmml/models/drools/tree/evaluator/PMMLTreeModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/java/org/kie/pmml/models/drools/tree/evaluator/PMMLTreeModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/java/org/kie/pmml/models/drools/tree/evaluator/PMMLTreeModelEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/src/main/java/org/kie/pmml/models/drools/tree/model/KiePMMLTreeModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/src/main/java/org/kie/pmml/models/drools/tree/model/KiePMMLTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/BostonHousingDataTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/BostonHousingDataTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/CompoundPredicateTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/CompoundPredicateTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/IrisDataTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/IrisDataTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/PlanActivityTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/PlanActivityTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/ReturnLastPredictionStrategyTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/ReturnLastPredictionStrategyTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelWithTransformationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SimpleClassificationTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SimpleClassificationTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SimpleSetPredicateTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SimpleSetPredicateTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/dto/MiningModelCompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/dto/MiningModelCompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/dto/SegmentCompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/dto/SegmentCompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/executor/MiningModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/executor/MiningModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentationFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/executor/MiningModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/executor/MiningModelImplementationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/AbstractKiePMMLFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/AbstractKiePMMLFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentationFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLSegmentationFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/main/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/main/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/main/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelStep.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/main/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/test/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/src/test/java/org/kie/pmml/models/mining/evaluator/PMMLMiningModelEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/KiePMMLMiningModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/KiePMMLMiningModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/KiePMMLMiningModelWithSources.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/KiePMMLMiningModelWithSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/enums/MULTIPLE_MODEL_METHOD.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/enums/MULTIPLE_MODEL_METHOD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/enums/MultipleModelMethodFunctions.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/enums/MultipleModelMethodFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegment.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentation.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/AbstractKiePMMLMiningModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/AbstractKiePMMLMiningModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/KiePMMLMiningModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/KiePMMLMiningModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/enums/MULTIPLE_MODEL_METHODTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/enums/MULTIPLE_MODEL_METHODTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentationTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/test/java/org/kie/pmml/models/mining/model/segmentation/KiePMMLSegmentationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningListenerTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningModelChainTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningModelChainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningModelSummedTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningModelSummedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningWithNestedRefersTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MiningWithNestedRefersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MixedMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MixedMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MultipleMixedMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MultipleMixedMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MultiplePredicatesMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MultiplePredicatesMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/PredicatesMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/PredicatesMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/RandomForestClassifierMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/RandomForestClassifierMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationClassificationSelectFirstTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationClassificationSelectFirstTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMajorityVoteMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMajorityVoteMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMaxMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMaxMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMeanMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMeanMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMedian2MiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMedian2MiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMedianMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationMedianMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationSelectFirstMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationSelectFirstMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationSumMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/SegmentationSumMiningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/dto/RegressionCompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/dto/RegressionCompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLClassificationTableFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLClassificationTableFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/AbstractKiePMMLRegressionTableRegressionFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/AbstractKiePMMLRegressionTableRegressionFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLClassificationTableFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLClassificationTableFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/src/main/java/org/kie/pmml/models/regression/evaluator/PMMLRegressionModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/src/main/java/org/kie/pmml/models/regression/evaluator/PMMLRegressionModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/src/test/java/org/kie/pmml/models/regression/evaluator/PMMLRegressionModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/src/test/java/org/kie/pmml/models/regression/evaluator/PMMLRegressionModelEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/AbstractKiePMMLTable.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/AbstractKiePMMLTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLClassificationTable.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLClassificationTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTable.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/enums/MODEL_TYPE.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/enums/MODEL_TYPE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/enums/REGRESSION_NORMALIZATION_METHOD.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/enums/REGRESSION_NORMALIZATION_METHOD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/tuples/KiePMMLTableSourceCategory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/tuples/KiePMMLTableSourceCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLClassificationTableTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLClassificationTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTableTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/CategoricalVariablesRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/CategoricalVariablesRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionIrisDataTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionIrisDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionNoneNormalizationTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionNoneNormalizationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionSimplemaxNormalizationTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionSimplemaxNormalizationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionSoftmaxNormalizationTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionSoftmaxNormalizationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LogisticRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/MissingDataRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/MissingDataRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/MixedVariablesRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/MixedVariablesRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/MultipleCategoricalVariablesRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/MultipleCategoricalVariablesRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/MultipleLogisticRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/MultipleLogisticRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/NumericVariablesDecimalAndNegativeCoefsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/NumericVariablesDecimalAndNegativeCoefsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/NumericVariablesLinearRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/NumericVariablesLinearRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/NumericVariablesPolynomialRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/NumericVariablesPolynomialRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/OrderApprovalRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/OrderApprovalRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/PredictorTermRegressionTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/PredictorTermRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/RegressionNormalizationExpTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/RegressionNormalizationExpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/RegressionNormalizationLogitTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/RegressionNormalizationLogitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/RegressionNormalizationSoftmaxTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/RegressionNormalizationSoftmaxTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/ScorecardCompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/ScorecardCompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLAttributeFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLAttributeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicsFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLComplexPartialScoreFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLComplexPartialScoreFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/main/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLAttributeFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLAttributeFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicsFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLCharacteristicsFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLComplexPartialScoreFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLComplexPartialScoreFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/src/test/java/org/kie/pmml/models/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/src/main/java/org/kie/pmml/models/scorecard/evaluator/PMMLScorecardModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/src/main/java/org/kie/pmml/models/scorecard/evaluator/PMMLScorecardModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/src/test/java/org/kie/pmml/models/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/src/test/java/org/kie/pmml/models/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLAttribute.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristic.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristics.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLComplexPartialScore.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLComplexPartialScore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLScorecardModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLScorecardModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLAttributeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLAttributeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristicTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristicsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLCharacteristicsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLComplexPartialScoreTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLComplexPartialScoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLScorecardModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/test/java/org/kie/pmml/models/scorecard/model/KiePMMLScorecardModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/AirconditioningScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/AirconditioningScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/BasicComplexPartialScoreTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/BasicComplexPartialScoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/CompoundNestedPredicateScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/CompoundNestedPredicateScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/CompoundPredicateScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/CompoundPredicateScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/MultipleAirconditioningScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/MultipleAirconditioningScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/MultipleCompoundNestedPredicateScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/MultipleCompoundNestedPredicateScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/NestedComplexPartialScoreTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/NestedComplexPartialScoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardCategoricalTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardCategoricalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardMixedVariablesTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardMixedVariablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardWithTransformationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/test/java/org/kie/pmml/models/tests/AbstractPMMLTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/test/java/org/kie/pmml/models/tests/AbstractPMMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/dto/TreeCompilationDTO.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/dto/TreeCompilationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/executor/TreeModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/executor/TreeModelImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLNodeFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLTreeModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLTreeModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/utils/KiePMMLTreeModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/utils/KiePMMLTreeModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/executor/TreeModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/executor/TreeModelImplementationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLNodeFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLNodeFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/src/main/java/org/kie/pmml/models/tree/evaluator/PMMLTreeModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/src/main/java/org/kie/pmml/models/tree/evaluator/PMMLTreeModelEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/src/test/java/org/kie/pmml/models/tree/evaluator/PMMLTreeModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/src/test/java/org/kie/pmml/models/tree/evaluator/PMMLTreeModelEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLNode.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLNodeResult.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLNodeResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLScoreDistribution.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLScoreDistribution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLTreeModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLNodeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLTreeTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLTreeTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/BostonHousingDataTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/BostonHousingDataTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/CompoundPredicateTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/CompoundPredicateTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/IrisDataTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/IrisDataTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/ReturnLastPredictionStrategyTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/ReturnLastPredictionStrategyTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelWithTransformationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SimpleClassificationTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SimpleClassificationTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SimpleSetPredicateTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SimpleSetPredicateTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/TestTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/TestTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/StaticMethodTestHelper.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/StaticMethodTestHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/TestStatusListener.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/TestStatusListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/db/CloseSafeMemoryContextFactory.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/db/CloseSafeMemoryContextFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/db/DataSourceFactory.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/db/DataSourceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/db/PersistenceUtil.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/db/PersistenceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/db/PoolingDataSourceWrapper.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/db/PoolingDataSourceWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/db/internal/DatabaseProvider.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/db/internal/DatabaseProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/db/internal/PoolingDataSourceFactory.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/db/internal/PoolingDataSourceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/db/internal/PoolingDataSourceWrapperImpl.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/db/internal/PoolingDataSourceWrapperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/logging/LoggingPrintStream.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/logging/LoggingPrintStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/main/java/org/kie/test/util/network/AvailablePortFinder.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/network/AvailablePortFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-test-util/src/test/java/org/kie/test/util/StaticMethodTestHelperTest.java
+++ b/kie-test-util/src/test/java/org/kie/test/util/StaticMethodTestHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/Aether.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/Aether.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/ArtifactResolver.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/ArtifactResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/DefaultArtifactResolver.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/DefaultArtifactResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/DependencyDescriptor.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/DependencyDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/InJarArtifactResolver.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/InJarArtifactResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/IoUtils.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/IoUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/MavenPomModelGenerator.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/MavenPomModelGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/MavenRepository.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/MavenRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/MavenRepositoryConfiguration.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/MavenRepositoryConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/PomParser.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/PomParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/ComponentProvider.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/ComponentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/EmbeddedPomParser.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/EmbeddedPomParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenEmbedder.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenEmbedder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenEmbedderException.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenEmbedderException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenEmbedderUtils.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenEmbedderUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenProjectLoader.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenProjectLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenRequest.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenSettings.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/MavenSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/PlexusComponentProvider.java
+++ b/kie-util/kie-util-maven-integration/src/main/java/org/kie/maven/integration/embedder/PlexusComponentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/DependencyFilter.java
+++ b/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/DependencyFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/MinimalPomParser.java
+++ b/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/MinimalPomParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/PomModel.java
+++ b/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/PomModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/PomModelGenerator.java
+++ b/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/PomModelGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/ReleaseIdImpl.java
+++ b/kie-util/kie-util-maven-support/src/main/java/org/kie/util/maven/support/ReleaseIdImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/AnyAnnotationTypePermission.java
+++ b/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/AnyAnnotationTypePermission.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/LocalDateTimeXStreamConverter.java
+++ b/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/LocalDateTimeXStreamConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/LocalDateXStreamConverter.java
+++ b/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/LocalDateXStreamConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/LocalTimeXStreamConverter.java
+++ b/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/LocalTimeXStreamConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/OffsetDateTimeXStreamConverter.java
+++ b/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/OffsetDateTimeXStreamConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/XStreamUtils.java
+++ b/kie-util/kie-util-xml/src/main/java/org/kie/utll/xml/XStreamUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
This PR standardizes license headers by converting Javadoc-style block comments (/**) to regular block comments (/*) across multiple source and test files.

Changed the opening comment delimiter from /** to /* in license headers.