### PR TITLE
[kie-issues#2017] `range()` function shouldn't allow descendant range endpoints

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
@@ -189,7 +189,7 @@ public class RangeFunction extends BaseFEELFunction {
     /**
      * @param leftObject
      * @param rightObject
-     * @return It checks if the leftObject is a greater than rightObject, false otherwise. If one of the endpoints is null,
+     * @return It checks if the leftObject is lower or equals to rightObject, false otherwise. If one of the endpoints is null,
      * the endpoint range is considered to be in ascending order.
      */
     @SuppressWarnings("unchecked")

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
@@ -137,7 +137,7 @@ public class RangeFunction extends BaseFEELFunction {
             return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "from", "endpoints must be of equivalent types"));
         }
 
-        if (!nodesValueRangeAreAscending(left, right)) {
+        if (!nodesValuesRangeAreAscending(left, right)) {
             return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "from", "range endpoints must be in ascending order"));
         }
 
@@ -194,7 +194,7 @@ public class RangeFunction extends BaseFEELFunction {
      * or undefined, the endpoint range is considered as an ascending interval.
      */
     @SuppressWarnings("unchecked")
-    protected boolean nodesValueRangeAreAscending(Object leftValue, Object rightValue) {
+    protected boolean nodesValuesRangeAreAscending(Object leftValue, Object rightValue) {
         boolean atLeastOneEndpointIsNullOrUndefined = leftValue == null || rightValue == null;
         return atLeastOneEndpointIsNullOrUndefined ||
                 ((Comparable<Object>) leftValue).compareTo(rightValue) <= 0;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
@@ -194,7 +194,8 @@ public class RangeFunction extends BaseFEELFunction {
      */
     @SuppressWarnings("unchecked")
     protected boolean nodesValueRangeAreAscending(Object leftObject, Object rightObject) {
-        boolean oneEndpointIsNull = leftObject == null || rightObject == null;
+        boolean oneEndpointIsNull = leftObject == null || rightObject == null
+                || leftObject instanceof NullNode || rightObject instanceof NullNode;
         return oneEndpointIsNull || ((Comparable<Object>) leftObject).compareTo(rightObject) <= 0;
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
@@ -188,15 +188,16 @@ public class RangeFunction extends BaseFEELFunction {
     }
 
     /**
-     * @param leftObject
+     * @param leftValue
      * @param rightValue
      * @return It checks if the leftValueis lower or equals to rightValue, false otherwise. If one of the endpoints is null,
      * or undefined, the endpoint range is considered as an ascending interval.
      */
     @SuppressWarnings("unchecked")
-    protected boolean nodesValueRangeAreAscending(Object leftObject, Object rightValue) {
-        boolean atLeastOneEndpointIsNullOrUndefined = leftObject == null || rightValue == null;
-        return atLeastOneEndpointIsNullOrUndefined || ((Comparable<Object>) leftObject).compareTo(rightValue) <= 0;
+    protected boolean nodesValueRangeAreAscending(Object leftValue, Object rightValue) {
+        boolean atLeastOneEndpointIsNullOrUndefined = leftValue == null || rightValue == null;
+        return atLeastOneEndpointIsNullOrUndefined ||
+                ((Comparable<Object>) leftValue).compareTo(rightValue) <= 0;
     }
 
     protected BaseNode parse(String input) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
@@ -44,7 +44,6 @@ import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
 import org.kie.dmn.feel.lang.ast.NullNode;
 import org.kie.dmn.feel.lang.ast.NumberNode;
 import org.kie.dmn.feel.lang.ast.StringNode;
-import org.kie.dmn.feel.lang.ast.UndefinedValueNode;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
 import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
@@ -68,17 +67,18 @@ public class RangeFunction extends BaseFEELFunction {
             baseNode -> baseNode instanceof AtLiteralNode,
             baseNode -> baseNode instanceof FunctionInvocationNode);
 
-    private static final List<Predicate<Object>> ALLOWED_TYPES = Arrays.asList(Objects::isNull,
-            object -> object instanceof String,
-            object -> object instanceof Number,
-            object -> object instanceof Duration,
-            object -> object instanceof ChronoPeriod,
-            object -> object instanceof ZonedDateTime,
-            object -> object instanceof OffsetDateTime,
-            object -> object instanceof LocalDateTime,
-            object -> object instanceof LocalDate,
-            object -> object instanceof OffsetTime,
-            object -> object instanceof LocalTime);
+    private static final List<Predicate<Object>> ALLOWED_TYPES = Arrays.asList(
+            ChronoPeriod.class::isInstance,
+            Duration.class::isInstance,
+            LocalDate.class::isInstance,
+            LocalDateTime.class::isInstance,
+            LocalTime.class::isInstance,
+            Number.class::isInstance,
+            Objects::isNull,
+            OffsetDateTime.class::isInstance,
+            OffsetTime.class::isInstance,
+            String.class::isInstance,
+            ZonedDateTime.class::isInstance);
 
     private RangeFunction() {
         super("range");
@@ -189,16 +189,14 @@ public class RangeFunction extends BaseFEELFunction {
 
     /**
      * @param leftObject
-     * @param rightObject
-     * @return It checks if the leftObject is lower or equals to rightObject, false otherwise. If one of the endpoints is null,
+     * @param rightValue
+     * @return It checks if the leftValueis lower or equals to rightValue, false otherwise. If one of the endpoints is null,
      * or undefined, the endpoint range is considered as an ascending interval.
      */
     @SuppressWarnings("unchecked")
-    protected boolean nodesValueRangeAreAscending(Object leftObject, Object rightObject) {
-        boolean atLeastOneEndpointIsNullOrUndefined = leftObject == null || rightObject == null
-                || leftObject instanceof NullNode || rightObject instanceof NullNode
-                || leftObject instanceof UndefinedValueNode || rightObject instanceof UndefinedValueNode;
-        return atLeastOneEndpointIsNullOrUndefined || ((Comparable<Object>) leftObject).compareTo(rightObject) <= 0;
+    protected boolean nodesValueRangeAreAscending(Object leftObject, Object rightValue) {
+        boolean atLeastOneEndpointIsNullOrUndefined = leftObject == null || rightValue == null;
+        return atLeastOneEndpointIsNullOrUndefined || ((Comparable<Object>) leftObject).compareTo(rightValue) <= 0;
     }
 
     protected BaseNode parse(String input) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
@@ -135,6 +135,11 @@ public class RangeFunction extends BaseFEELFunction {
         if (!nodesReturnsSameType(left, right)) {
             return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "from", "endpoints must be of equivalent types"));
         }
+
+        if (!nodesValueRangeAreAscending(left, right)) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "from", "range endpoints must be in ascending order"));
+        }
+
         Range toReturn = getReturnedValue(left, right, startBoundary, endBoundary);
         // Boundary values need to be always defined in range string. They can be undefined only in unary test, that
         // represents range, e.g. (<10).
@@ -166,7 +171,7 @@ public class RangeFunction extends BaseFEELFunction {
 
     /**
      * @param leftObject
-     * @param leftObject
+     * @param rightObject
      * @return
      */
     protected boolean nodesReturnsSameType(Object leftObject, Object rightObject) {
@@ -179,6 +184,18 @@ public class RangeFunction extends BaseFEELFunction {
             Class<?> right = rightObject.getClass();
             return left.equals(right) || left.isAssignableFrom(right) || right.isAssignableFrom(left);
         }
+    }
+
+    /**
+     * @param leftObject
+     * @param rightObject
+     * @return It checks if the leftObject is a greater than rightObject, false otherwise. If one of the endpoints is null,
+     * the endpoint range is considered to be in ascending order.
+     */
+    @SuppressWarnings("unchecked")
+    protected boolean nodesValueRangeAreAscending(Object leftObject, Object rightObject) {
+        boolean oneEndpointIsNull = leftObject == null || rightObject == null;
+        return oneEndpointIsNull || ((Comparable<Object>) leftObject).compareTo(rightObject) <= 0;
     }
 
     protected BaseNode parse(String input) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RangeFunction.java
@@ -44,6 +44,7 @@ import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
 import org.kie.dmn.feel.lang.ast.NullNode;
 import org.kie.dmn.feel.lang.ast.NumberNode;
 import org.kie.dmn.feel.lang.ast.StringNode;
+import org.kie.dmn.feel.lang.ast.UndefinedValueNode;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
 import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
@@ -190,13 +191,14 @@ public class RangeFunction extends BaseFEELFunction {
      * @param leftObject
      * @param rightObject
      * @return It checks if the leftObject is lower or equals to rightObject, false otherwise. If one of the endpoints is null,
-     * the endpoint range is considered to be in ascending order.
+     * or undefined, the endpoint range is considered as an ascending interval.
      */
     @SuppressWarnings("unchecked")
     protected boolean nodesValueRangeAreAscending(Object leftObject, Object rightObject) {
-        boolean oneEndpointIsNull = leftObject == null || rightObject == null
-                || leftObject instanceof NullNode || rightObject instanceof NullNode;
-        return oneEndpointIsNull || ((Comparable<Object>) leftObject).compareTo(rightObject) <= 0;
+        boolean atLeastOneEndpointIsNullOrUndefined = leftObject == null || rightObject == null
+                || leftObject instanceof NullNode || rightObject instanceof NullNode
+                || leftObject instanceof UndefinedValueNode || rightObject instanceof UndefinedValueNode;
+        return atLeastOneEndpointIsNullOrUndefined || ((Comparable<Object>) leftObject).compareTo(rightObject) <= 0;
     }
 
     protected BaseNode parse(String input) {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
@@ -30,7 +30,14 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.kie.dmn.feel.lang.ast.*;
+import org.kie.dmn.feel.lang.ast.AtLiteralNode;
+import org.kie.dmn.feel.lang.ast.BaseNode;
+import org.kie.dmn.feel.lang.ast.BooleanNode;
+import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
+import org.kie.dmn.feel.lang.ast.NullNode;
+import org.kie.dmn.feel.lang.ast.NumberNode;
+import org.kie.dmn.feel.lang.ast.StringNode;
+import org.kie.dmn.feel.lang.ast.UndefinedValueNode;
 import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 import org.kie.dmn.feel.runtime.Range;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
@@ -37,7 +37,6 @@ import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
 import org.kie.dmn.feel.lang.ast.NullNode;
 import org.kie.dmn.feel.lang.ast.NumberNode;
 import org.kie.dmn.feel.lang.ast.StringNode;
-import org.kie.dmn.feel.lang.ast.UndefinedValueNode;
 import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 import org.kie.dmn.feel.runtime.Range;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
@@ -332,20 +332,55 @@ class RangeFunctionTest {
 
     @Test
     void nodesEndpointsAscendant_True() {
-        Object left = 1;
-        Object right = 2;
+        Object left = "a";
+        Object right = "y";
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
-                .withFailMessage("1 - 2")
+                .withFailMessage("a - y")
+                .isTrue();
+        left = "m";
+        right = "m";
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("m - m")
+                .isTrue();
+        left = 1;
+        right = 2;
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("1 - 2 (integer)")
                 .isTrue();
         left  = 2;
         right = 2;
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
-                .withFailMessage("2 - 2")
+                .withFailMessage("2 - 2 (integer)")
+                .isTrue();
+        left = new BigDecimal("1");
+        right = new BigDecimal("2");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("1 - 2 (BigDecimal)")
+                .isTrue();
+        left  = new BigDecimal("2");
+        right = new BigDecimal("2");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2 - 2 (BigDecimal)")
                 .isTrue();
         left = DateTimeFormatter.ISO_DATE.parse("1982-10-13", LocalDate::from);
         right = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
                 .withFailMessage("1982-10-13 - 2017-02-18")
+                .isTrue();
+        left = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
+        right = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2017-02-18 - 2017-02-18")
+                .isTrue();
+        left = DateTimeFormatter.ISO_TIME.parse("10:30:10", LocalTime::from);
+        right = DateTimeFormatter.ISO_TIME.parse("10:30:59", LocalTime::from);
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("10:30:10 - 10:30:59")
+                .isTrue();
+        left = DateTimeFormatter.ISO_TIME.parse("10:30:10", LocalTime::from);
+        right = DateTimeFormatter.ISO_TIME.parse("10:30:10", LocalTime::from);
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("10:30:10 - 10:30:10")
                 .isTrue();
         left = LocalDateTime.of(2017, 2, 18, 10, 30, 4, 0);
         right = LocalDateTime.of(2017, 2, 18, 10, 30, 59, 0);
@@ -357,49 +392,49 @@ class RangeFunctionTest {
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
                 .withFailMessage("P2DT20H14M - P2DT20H15M")
                 .isTrue();
-        left = new NullNode("null");
-        right = Duration.parse("P2DT20H15M");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
-                .withFailMessage("null - P2DT20H15M")
-                .isTrue();
-        left  = 2;
-        right = new NullNode("null");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
-                .withFailMessage("2 - null")
-                .isTrue();
-        left  = new NullNode("null");
-        right = new NullNode("null");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
-                .withFailMessage("null - null")
-                .isTrue();
-        left = new UndefinedValueNode();
-        right = Duration.parse("P2DT20H15M");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
-                .withFailMessage("undefined - P2DT20H15M")
-                .isTrue();
-        left  = 2;
-        right = new UndefinedValueNode();
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
-                .withFailMessage("2 - undefined")
-                .isTrue();
         left  = null;
         right = null;
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
                 .withFailMessage("null - null")
                 .isTrue();
+        left = ComparablePeriod.parse("P10M");
+        right = ComparablePeriod.parse("P1Y");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("P10M - P1Y")
+                .isTrue();
+        left = ComparablePeriod.parse("P1Y");
+        right = ComparablePeriod.parse("P1Y");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("P1Y - P1Y")
+                .isTrue();
     }
 
     @Test
     void nodesEndpointsAscendant_False() {
-        Object left = 2;
-        Object right = 1;
+        Object left = "y";
+        Object right = "a";
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("y - a")
+                .isFalse();
+        left = 2;
+        right = 1;
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
                 .withFailMessage("2 - 1")
+                .isFalse();
+        left = new BigDecimal("2");
+        right = new BigDecimal("1");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2- 1 (BigDecimal)")
                 .isFalse();
         left = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
         right = DateTimeFormatter.ISO_DATE.parse("1982-10-13", LocalDate::from);
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
                 .withFailMessage("2017-02-18 - 1982-10-13")
+                .isFalse();
+        left = DateTimeFormatter.ISO_TIME.parse("10:30:59", LocalTime::from);
+        right = DateTimeFormatter.ISO_TIME.parse("10:30:10", LocalTime::from);
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("10:30:59 - 10:30:10")
                 .isFalse();
         left = LocalDateTime.of(2017, 2, 18, 10, 30, 59, 0);
         right = LocalDateTime.of(2017, 2, 18, 10, 30, 4, 0);
@@ -410,6 +445,11 @@ class RangeFunctionTest {
         right = Duration.parse("P2DT20H14M");
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
                 .withFailMessage("P2DT20H15M - P2DT20H14M")
+                .isFalse();
+        left = ComparablePeriod.parse("P1Y");
+        right = ComparablePeriod.parse("P10M");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("P1Y - P10M")
                 .isFalse();
     }
 

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
@@ -30,13 +30,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.kie.dmn.feel.lang.ast.AtLiteralNode;
-import org.kie.dmn.feel.lang.ast.BaseNode;
-import org.kie.dmn.feel.lang.ast.BooleanNode;
-import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
-import org.kie.dmn.feel.lang.ast.NullNode;
-import org.kie.dmn.feel.lang.ast.NumberNode;
-import org.kie.dmn.feel.lang.ast.StringNode;
+import org.kie.dmn.feel.lang.ast.*;
 import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 import org.kie.dmn.feel.runtime.Range;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
@@ -370,6 +364,16 @@ class RangeFunctionTest {
         right = new NullNode("null");
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
                 .withFailMessage("null - null")
+                .isTrue();
+        left = new UndefinedValueNode();
+        right = Duration.parse("P2DT20H15M");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("undefined - P2DT20H15M")
+                .isTrue();
+        left  = 2;
+        right = new UndefinedValueNode();
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2 - undefined")
                 .isTrue();
         left  = null;
         right = null;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
@@ -356,6 +356,26 @@ class RangeFunctionTest {
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
                 .withFailMessage("P2DT20H14M - P2DT20H15M")
                 .isTrue();
+        left = new NullNode("null");
+        right = Duration.parse("P2DT20H15M");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("null - P2DT20H15M")
+                .isTrue();
+        left  = 2;
+        right = new NullNode("null");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2 - null")
+                .isTrue();
+        left  = new NullNode("null");
+        right = new NullNode("null");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("null - null")
+                .isTrue();
+        left  = null;
+        right = null;
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("null - null")
+                .isTrue();
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
@@ -333,77 +333,77 @@ class RangeFunctionTest {
     void nodesEndpointsAscendant_True() {
         Object left = "a";
         Object right = "y";
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("a - y")
                 .isTrue();
         left = "m";
         right = "m";
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("m - m")
                 .isTrue();
         left = 1;
         right = 2;
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("1 - 2 (integer)")
                 .isTrue();
         left  = 2;
         right = 2;
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("2 - 2 (integer)")
                 .isTrue();
         left = new BigDecimal("1");
         right = new BigDecimal("2");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("1 - 2 (BigDecimal)")
                 .isTrue();
         left  = new BigDecimal("2");
         right = new BigDecimal("2");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("2 - 2 (BigDecimal)")
                 .isTrue();
         left = DateTimeFormatter.ISO_DATE.parse("1982-10-13", LocalDate::from);
         right = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("1982-10-13 - 2017-02-18")
                 .isTrue();
         left = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
         right = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("2017-02-18 - 2017-02-18")
                 .isTrue();
         left = DateTimeFormatter.ISO_TIME.parse("10:30:10", LocalTime::from);
         right = DateTimeFormatter.ISO_TIME.parse("10:30:59", LocalTime::from);
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("10:30:10 - 10:30:59")
                 .isTrue();
         left = DateTimeFormatter.ISO_TIME.parse("10:30:10", LocalTime::from);
         right = DateTimeFormatter.ISO_TIME.parse("10:30:10", LocalTime::from);
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("10:30:10 - 10:30:10")
                 .isTrue();
         left = LocalDateTime.of(2017, 2, 18, 10, 30, 4, 0);
         right = LocalDateTime.of(2017, 2, 18, 10, 30, 59, 0);
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("2017-02-18T10:30:04 - 2017-02-18T10:30:59")
                 .isTrue();
         left = Duration.parse("P2DT20H14M");
         right = Duration.parse("P2DT20H15M");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("P2DT20H14M - P2DT20H15M")
                 .isTrue();
         left  = null;
         right = null;
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("null - null")
                 .isTrue();
         left = ComparablePeriod.parse("P10M");
         right = ComparablePeriod.parse("P1Y");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("P10M - P1Y")
                 .isTrue();
         left = ComparablePeriod.parse("P1Y");
         right = ComparablePeriod.parse("P1Y");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("P1Y - P1Y")
                 .isTrue();
     }
@@ -412,42 +412,42 @@ class RangeFunctionTest {
     void nodesEndpointsAscendant_False() {
         Object left = "y";
         Object right = "a";
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("y - a")
                 .isFalse();
         left = 2;
         right = 1;
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("2 - 1")
                 .isFalse();
         left = new BigDecimal("2");
         right = new BigDecimal("1");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("2- 1 (BigDecimal)")
                 .isFalse();
         left = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
         right = DateTimeFormatter.ISO_DATE.parse("1982-10-13", LocalDate::from);
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("2017-02-18 - 1982-10-13")
                 .isFalse();
         left = DateTimeFormatter.ISO_TIME.parse("10:30:59", LocalTime::from);
         right = DateTimeFormatter.ISO_TIME.parse("10:30:10", LocalTime::from);
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("10:30:59 - 10:30:10")
                 .isFalse();
         left = LocalDateTime.of(2017, 2, 18, 10, 30, 59, 0);
         right = LocalDateTime.of(2017, 2, 18, 10, 30, 4, 0);
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("2017-02-18T10:30:59 - 2017-02-18T10:30:04")
                 .isFalse();
         left = Duration.parse("P2DT20H15M");
         right = Duration.parse("P2DT20H14M");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("P2DT20H15M - P2DT20H14M")
                 .isFalse();
         left = ComparablePeriod.parse("P1Y");
         right = ComparablePeriod.parse("P10M");
-        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+        assertThat(rangeFunction.nodesValuesRangeAreAscending(left, right))
                 .withFailMessage("P1Y - P10M")
                 .isFalse();
     }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
@@ -198,9 +198,9 @@ class RangeFunctionTest {
                                       new RangeImpl(Range.RangeBoundary.CLOSED, BigDecimal.ONE, BigDecimal.valueOf(2)
                                               , Range.RangeBoundary.CLOSED),
                                       from);
-        from = "[2..1]";
+        from = "[1..2]";
         FunctionTestUtil.assertResult(rangeFunction.invoke(from),
-                                      new RangeImpl(Range.RangeBoundary.CLOSED, BigDecimal.valueOf(2), BigDecimal.ONE
+                                      new RangeImpl(Range.RangeBoundary.CLOSED, BigDecimal.ONE, BigDecimal.valueOf(2)
                                               , Range.RangeBoundary.CLOSED),
                                       from);
         from = "[\"a\"..\"z\"]";
@@ -326,6 +326,59 @@ class RangeFunctionTest {
     void nodesReturnsSameType_False() {
         assertThat(rangeFunction.nodesReturnsSameType("1", 1))
                 .withFailMessage("\"1\" - 1")
+                .isFalse();
+    }
+
+    @Test
+    void nodesDescendant_True() {
+        Object left = 1;
+        Object right = 2;
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("1 - 2")
+                .isTrue();
+        left  = 2;
+        right = 2;
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2 - 2")
+                .isTrue();
+        left = DateTimeFormatter.ISO_DATE.parse("1982-10-13", LocalDate::from);
+        right = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("1982-10-13 - 2017-02-18")
+                .isTrue();
+        left = LocalDateTime.of(2017, 2, 18, 10, 30, 4, 0);
+        right = LocalDateTime.of(2017, 2, 18, 10, 30, 59, 0);
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2017-02-18T10:30:04 - 2017-02-18T10:30:59")
+                .isTrue();
+        left = Duration.parse("P2DT20H14M");
+        right = Duration.parse("P2DT20H15M");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("P2DT20H14M - P2DT20H15M")
+                .isTrue();
+    }
+
+    @Test
+    void nodesDescendant_False() {
+        Object left = 2;
+        Object right = 1;
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2 - 1")
+                .isFalse();
+        left = DateTimeFormatter.ISO_DATE.parse("2017-02-18", LocalDate::from);
+        right = DateTimeFormatter.ISO_DATE.parse("1982-10-13", LocalDate::from);
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2017-02-18 - 1982-10-13")
+                .isFalse();
+        left = LocalDateTime.of(2017, 2, 18, 10, 30, 59, 0);
+        right = LocalDateTime.of(2017, 2, 18, 10, 30, 4, 0);
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("2017-02-18T10:30:59 - 2017-02-18T10:30:04")
+                .isFalse();
+        left = Duration.parse("P2DT20H15M");
+        right = Duration.parse("P2DT20H14M");
+        assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
+                .withFailMessage("P2DT20H15M - P2DT20H14M")
                 .isFalse();
     }
 

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RangeFunctionTest.java
@@ -330,7 +330,7 @@ class RangeFunctionTest {
     }
 
     @Test
-    void nodesDescendant_True() {
+    void nodesEndpointsAscendant_True() {
         Object left = 1;
         Object right = 2;
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))
@@ -359,7 +359,7 @@ class RangeFunctionTest {
     }
 
     @Test
-    void nodesDescendant_False() {
+    void nodesEndpointsAscendant_False() {
         Object left = 2;
         Object right = 1;
         assertThat(rangeFunction.nodesValueRangeAreAscending(left, right))


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2017

According to the specs:

> Ranges
>   FEEL supports a compact syntax for a range of values, useful in decision table test cells and elsewhere. Ranges can
>   be syntactically represented either:
>   a) as a comparison operator and a single endpoint (grammar rule 7.a.)
>   b) or a pair of endpoints and endpoint inclusivity flags that indicate whether one or both endpoints are
>   included in the range (grammar rule 7.b.); on this case, endpoints must be of equivalent types (see section
>   10.3.2.9.1for the definition of type equivalence) and **the endpoints must be ordered such that range start
>   <= range end**

Ranges endpoints should be ascendant (i.e range start <= range end)

TCK Tests status after applying the change.
`[ERROR] Tests run: 6765, Failures: 0, Errors: 15, Skipped: 0`

