### PR TITLE
NO-ISSUE: Removed deps of drools-io from drools-core

### DIFF
--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wiring-api</artifactId>
+      <artifactId>drools-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
@@ -67,11 +67,11 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wiring-static</artifactId>
+      <artifactId>drools-wiring-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-io</artifactId>
+      <artifactId>drools-wiring-static</artifactId>
     </dependency>
 
     <dependency>
@@ -127,12 +127,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/drools-decisiontables/pom.xml
+++ b/drools-decisiontables/pom.xml
@@ -59,6 +59,10 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-xml-support</artifactId>
       <scope>test</scope>
     </dependency>

--- a/drools-drl/drools-drl-parser/pom.xml
+++ b/drools-drl/drools-drl-parser/pom.xml
@@ -56,6 +56,10 @@
             <groupId>org.kie</groupId>
             <artifactId>kie-internal</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-io</artifactId>
+        </dependency>
         <!-- External dependencies -->
         <dependency>
             <groupId>org.antlr</groupId>

--- a/drools-io/pom.xml
+++ b/drools-io/pom.xml
@@ -49,15 +49,20 @@
             <groupId>org.drools</groupId>
             <artifactId>drools-util</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>        
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>        
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
     </dependencies>
 </project>

--- a/drools-io/src/test/java/org/drools/io/ByteArrayResourceSerializationTest.java
+++ b/drools-io/src/test/java/org/drools/io/ByteArrayResourceSerializationTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.drools.core.io.impl;
+package org.drools.io;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -25,7 +25,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
 
-import org.drools.io.ByteArrayResource;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/drools-io/src/test/java/org/drools/io/ByteArrayResourceToStringTest.java
+++ b/drools-io/src/test/java/org/drools/io/ByteArrayResourceToStringTest.java
@@ -16,14 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.drools.core.io.impl;
+package org.drools.io;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.drools.io.ByteArrayResource;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -36,23 +33,23 @@ public class ByteArrayResourceToStringTest {
     public static Stream<Arguments> parameters() {
         List<Arguments> parameters = List.of(
                arguments(
-                        Arrays.asList(new Byte[]{10, 20, 30, 40}),
+                        new byte[]{10, 20, 30, 40},
                         null,
                         "ByteArrayResource[bytes=[10, 20, 30, 40], encoding=null]"
                 ),
                 arguments(
-                        Arrays.asList(new Byte[]{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}),
+                        new byte[]{10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
                         null,
                         "ByteArrayResource[bytes=[10, 20, 30, 40, 50, 60, 70, 80, 90, 100], encoding=null]"
                 ),
                 arguments(
-                        Arrays.asList(new Byte[]{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120}),
+                		new byte[]{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120},
                         null,
                         "ByteArrayResource[bytes=[10, 20, 30, 40, 50, 60, 70, 80, 90, 100, ...], encoding=null]"
                 ),
                 // non-null encoding
                 arguments(
-                        Arrays.asList(new Byte[]{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120}),
+                		new byte[]{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120},
                         "UTF-8",
                         "ByteArrayResource[bytes=[10, 20, 30, 40, 50, 60, 70, 80, 90, 100, ...], encoding=UTF-8]"
                 ));
@@ -64,8 +61,7 @@ public class ByteArrayResourceToStringTest {
 
     @ParameterizedTest(name = "{index}: bytes={0}, encoding={1}")
     @MethodSource("parameters")
-    public void testToString(List<Byte> bytes, String encoding, String expectedString) {
-        byte[] byteArray = ArrayUtils.toPrimitive(bytes.toArray(new Byte[0]));
+    public void testToString(byte[] byteArray, String encoding, String expectedString) {
         ByteArrayResource byteArrayResource = new ByteArrayResource(byteArray, encoding);
         assertThat(byteArrayResource.toString()).isEqualTo(expectedString);
     }

--- a/drools-io/src/test/java/org/drools/io/IoUtilsTest.java
+++ b/drools-io/src/test/java/org/drools/io/IoUtilsTest.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.drools.core.util;
+package org.drools.io;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.IOException;
-import java.io.StringReader;
 
-import org.drools.io.ReaderInputStream;
 import org.drools.util.IoUtils;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +32,8 @@ public class IoUtilsTest {
     @Test
     public void testReadEmptyStream() throws IOException {
         // DROOLS-971
-        byte[] bytes = IoUtils.readBytesFromInputStream( new ReaderInputStream( new StringReader( "" ) ) );
+    	InputStream emptyStream = new ByteArrayInputStream("".getBytes());
+        byte[] bytes = IoUtils.readBytesFromInputStream( emptyStream );
         assertThat(bytes).isEmpty();
     }
 

--- a/drools-io/src/test/java/org/drools/io/ReaderResourceTest.java
+++ b/drools-io/src/test/java/org/drools/io/ReaderResourceTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.drools.core.io.impl;
+package org.drools.io;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -24,7 +24,6 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 
-import org.drools.io.ReaderResource;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
A first work to cleanup dependencies in drools core.

It intends to properly push dependencies where they are needed and not use transitive dependencies among modules.



<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

**Thank you for submitting this pull request**

**NOTE!:** Double-check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

* [link](https://www.example.com)

**Issue**: _(please edit the GitHub Issues link if it exists)_

* [link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
