### PR TITLE
[NO-ISSUE] Upgrade kafka-clients to 3.9.1.

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -77,6 +77,7 @@
     <version.io.netty>4.1.122.Final</version.io.netty>
     <version.io.smallrye.openapi.core>4.0.10</version.io.smallrye.openapi.core>
     <version.io.smallrye.config.core>3.11.4</version.io.smallrye.config.core>
+    <version.org.apache.kafka>3.9.1</version.org.apache.kafka>
 
     <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
     <version.junit>4.13.2</version.junit>
@@ -1221,6 +1222,12 @@
         <artifactId>archunit-junit5</artifactId>
         <version>${version.archunit.junit5}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${version.org.apache.kafka}</version>
       </dependency>
     </dependencies>
 

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/pom.xml
@@ -48,6 +48,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-messaging-kafka</artifactId>
+      <exclusions>
+        <!-- Overriding kafka-clients to fix a vulnerability.
+             This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/resources/application.properties
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/src/main/resources/application.properties
@@ -33,3 +33,4 @@ mp.messaging.incoming.events.value.deserializer=org.drools.quarkus.ruleunit.exam
 mp.messaging.outgoing.alerts.connector=smallrye-kafka
 mp.messaging.outgoing.alerts.topic=alerts
 mp.messaging.outgoing.alerts.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
+org.apache.kafka.sasl.oauthbearer.allowed.urls=


### PR DESCRIPTION
This PR upgrades kafka-clients to 3.9.1 due to vulnerabilities. 

Related PRs:
kogito-runtimes: https://github.com/apache/incubator-kie-kogito-runtimes/pull/3985
kogito-apps: https://github.com/apache/incubator-kie-kogito-apps/pull/2243