### PR TITLE
Move YARD into KIE repositories incubator-kie-issues#2044

### DIFF
--- a/kie-yard/kie-yard-api/pom.xml
+++ b/kie-yard/kie-yard-api/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-yard</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>kie-yard-api</artifactId>
+
+  <name>KIE :: Yard - API</name>
+  <description>KIE Yard API module - Core interfaces and models for YAML Rules DSL</description>
+
+  <properties>
+    <java.module.name>org.kie.yard.api</java.module.name>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/DecisionLogic.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/DecisionLogic.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = DecisionTable.class, name = "DecisionTable"),
+    @JsonSubTypes.Type(value = LiteralExpression.class, name = "LiteralExpression")
+})
+public interface DecisionLogic {
+
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/DecisionTable.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/DecisionTable.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+@JsonPropertyOrder({"inputs", "hitPolicy", "outputComponents", "rules"})
+public class DecisionTable implements DecisionLogic {
+
+    @JsonProperty("inputs")
+    private List<String> inputs;
+    
+    @JsonProperty("hitPolicy")
+    private String hitPolicy = "ANY";
+    
+    @Deprecated
+    @JsonProperty("outputComponents")
+    private List<String> outputComponents;
+    
+    @JsonProperty("rules")
+    @JsonDeserialize(using = RuleListDeserializer.class)
+    private List<Rule> rules;
+
+    public void setInputs(List<String> inputs) {
+        this.inputs = inputs;
+    }
+
+    public void setOutputComponents(List<String> outputComponents) {
+        this.outputComponents = outputComponents;
+    }
+
+    public List<String> getInputs() {
+        return inputs;
+    }
+
+    @Deprecated
+    public List<String> getOutputComponents() {
+        return outputComponents;
+    }
+
+    public String getHitPolicy() {
+        return hitPolicy;
+    }
+
+    public void setHitPolicy(String hitPolicy) {
+        this.hitPolicy = hitPolicy;
+    }
+
+    public List<Rule> getRules() {
+        return rules;
+    }
+
+    public void setRules(List<Rule> rules) {
+        this.rules = rules;
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/Element.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/Element.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"name", "type", "requirements", "logic"})
+public class Element {
+
+    @JsonProperty("name")
+    private String name;
+    
+    @JsonProperty("type")
+    private String type;
+    
+    @JsonProperty("requirements")
+    private List<String> requirements;
+    
+    @JsonProperty("logic")
+    private DecisionLogic logic;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setRequirements(List<String> requirements) {
+        this.requirements = requirements;
+    }
+
+    public void setLogic(DecisionLogic logic) {
+        this.logic = logic;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public List<String> getRequirements() {
+        return requirements;
+    }
+
+    public DecisionLogic getLogic() {
+        return logic;
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/InlineRule.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/InlineRule.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+public class InlineRule implements Rule {
+
+    private final int rowNumber;
+    
+    @JsonProperty("def")
+    public List def;
+
+    public InlineRule(int rowNumber, List data) {
+        this.rowNumber = rowNumber;
+        this.def = data;
+    }
+
+    @Override
+    public int getRowNumber() {
+        return rowNumber;
+    }
+
+    public List getDef() {
+        return def;
+    }
+
+    public void setDef(List def) {
+        this.def = def;
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/Input.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/Input.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"name", "type"})
+public class Input {
+
+    @JsonProperty("name")
+    private String name;
+    
+    @JsonProperty("type")
+    private String type;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/LiteralExpression.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/LiteralExpression.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("LiteralExpression")
+public class LiteralExpression implements DecisionLogic {
+
+    @JsonProperty("expression")
+    private String expression;
+
+    public void setExpression(String expression) {
+        this.expression = expression;
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/Operators.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/Operators.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import java.util.Objects;
+
+/**
+ * Interface instead of enum due to possible custom operators.
+ */
+public interface Operators {
+
+    String NOT_EQUALS = "!=";
+    String EQUALS = "=";
+    String GREATER_OR_EQUAL = ">=";
+    String GREATER_THAN = ">";
+    String LESS_OR_EQUAL = "<=";
+    String LESS_THAN = "<";
+
+    String[] ALL = {EQUALS, LESS_OR_EQUAL, LESS_THAN, GREATER_OR_EQUAL, GREATER_THAN, NOT_EQUALS};
+
+    static int compare(final String operator,
+                       final String other) {
+        return getWeight(operator) - getWeight(other);
+    }
+
+    static int getWeight(final String operator) {
+        for (int i = 0; i < ALL.length; i++) {
+            if (Objects.equals(operator, ALL[i])) {
+                return i;
+            }
+        }
+        return 0;
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/Rule.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/Rule.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+public interface Rule {
+
+    int getRowNumber();
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/RuleDeserializer.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/RuleDeserializer.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class RuleDeserializer extends JsonDeserializer<Rule> {
+    
+    private int rowNumber = 1;
+    
+    @Override
+    public Rule deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        JsonNode node = parser.getCodec().readTree(parser);
+        
+        if (node.isArray()) {
+            // This is an InlineRule (array format)
+            List<Object> items = new ArrayList<>();
+            for (JsonNode item : node) {
+                if (item.isTextual()) {
+                    items.add(item.textValue());
+                } else if (item.isNumber()) {
+                    items.add(item.numberValue());
+                } else if (item.isBoolean()) {
+                    items.add(item.booleanValue());
+                } else {
+                    items.add(item.toString());
+                }
+            }
+            return new InlineRule(rowNumber++, items);
+        } else if (node.isObject()) {
+            // This is a WhenThenRule (object format with when/then)
+            if (node.has("when") && node.has("then")) {
+                WhenThenRule rule = new WhenThenRule(rowNumber++);
+                
+                // Process "when" array
+                JsonNode whenNode = node.get("when");
+                List<Object> whenItems = new ArrayList<>();
+                if (whenNode.isArray()) {
+                    for (JsonNode item : whenNode) {
+                        if (item.isTextual()) {
+                            whenItems.add(item.textValue());
+                        } else if (item.isNumber()) {
+                            whenItems.add(item.numberValue());
+                        } else if (item.isBoolean()) {
+                            whenItems.add(item.booleanValue());
+                        } else {
+                            whenItems.add(item.toString());
+                        }
+                    }
+                }
+                rule.setWhen(whenItems);
+                
+                // Process "then" value
+                JsonNode thenNode = node.get("then");
+                if (thenNode.isTextual()) {
+                    rule.setThen(thenNode.textValue());
+                } else if (thenNode.isNumber()) {
+                    rule.setThen(thenNode.numberValue());
+                } else if (thenNode.isBoolean()) {
+                    rule.setThen(thenNode.booleanValue());
+                } else {
+                    rule.setThen(thenNode.toString());
+                }
+                
+                return rule;
+            }
+        }
+        
+        throw new IllegalArgumentException("Unknown rule format: " + node.toString());
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/RuleListDeserializer.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/RuleListDeserializer.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class RuleListDeserializer extends JsonDeserializer<List<Rule>> {
+    
+    private int rowNumber = 1;
+    
+    @Override
+    public List<Rule> deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        JsonNode arrayNode = parser.getCodec().readTree(parser);
+        List<Rule> rules = new ArrayList<>();
+        
+        if (arrayNode.isArray()) {
+            for (JsonNode ruleNode : arrayNode) {
+                Rule rule = deserializeRule(ruleNode);
+                rules.add(rule);
+            }
+        }
+        
+        return rules;
+    }
+    
+    private Rule deserializeRule(JsonNode node) {
+        if (node.isArray()) {
+            // This is an InlineRule (array format)
+            List<Object> items = new ArrayList<>();
+            for (JsonNode item : node) {
+                if (item.isTextual()) {
+                    items.add(item.textValue());
+                } else if (item.isNumber()) {
+                    items.add(new BigDecimal(item.asText()));
+                } else if (item.isBoolean()) {
+                    items.add(item.booleanValue());
+                } else {
+                    items.add(item.toString());
+                }
+            }
+            return new InlineRule(rowNumber++, items);
+        } else if (node.isObject()) {
+            // This is a WhenThenRule (object format with when/then)
+            if (node.has("when") && node.has("then")) {
+                WhenThenRule rule = new WhenThenRule(rowNumber++);
+                
+                // Process "when" array
+                JsonNode whenNode = node.get("when");
+                List<Object> whenItems = new ArrayList<>();
+                if (whenNode.isArray()) {
+                    for (JsonNode item : whenNode) {
+                        if (item.isTextual()) {
+                            whenItems.add(item.textValue());
+                        } else if (item.isNumber()) {
+                            whenItems.add(new BigDecimal(item.asText()));
+                        } else if (item.isBoolean()) {
+                            whenItems.add(item.booleanValue());
+                        } else {
+                            whenItems.add(item.toString());
+                        }
+                    }
+                }
+                rule.setWhen(whenItems);
+                
+                // Process "then" value
+                JsonNode thenNode = node.get("then");
+                if (thenNode.isTextual()) {
+                    rule.setThen(thenNode.textValue());
+                } else if (thenNode.isNumber()) {
+                    rule.setThen(new BigDecimal(thenNode.asText()));
+                } else if (thenNode.isBoolean()) {
+                    rule.setThen(thenNode.booleanValue());
+                } else {
+                    rule.setThen(thenNode.toString());
+                }
+                
+                return rule;
+            }
+        }
+        
+        throw new IllegalArgumentException("Unknown rule format: " + node.toString());
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/WhenThenRule.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/WhenThenRule.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+public class WhenThenRule implements Rule {
+
+    private final int rowNumber;
+    
+    @JsonProperty("when")
+    private List when;
+    
+    @JsonProperty("then")
+    private Object then;
+
+    public WhenThenRule(int rowNumber) {
+        this.rowNumber = rowNumber;
+    }
+
+    @Override
+    public int getRowNumber() {
+        return rowNumber;
+    }
+
+    public List getWhen() {
+        return when;
+    }
+
+    public Object getThen() {
+        return then;
+    }
+
+    public void setWhen(List when) {
+        this.when = when;
+    }
+
+    public void setThen(Object then) {
+        this.then = then;
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/YaRD.java
+++ b/kie-yard/kie-yard-api/src/main/java/org/kie/yard/api/model/YaRD.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.api.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"specVersion", "kind", "name", "expressionLang", "inputs", "elements"})
+public class YaRD {
+
+    @JsonProperty("specVersion")
+    private String specVersion = "alpha";
+    
+    @JsonProperty("kind")
+    private String kind = "YaRD";
+    @JsonProperty("name")
+    private String name;
+    
+    @JsonProperty("expressionLang")
+    private String expressionLang;
+    
+    @JsonProperty("inputs")
+    private List<Input> inputs;
+    
+    @JsonProperty("elements")
+    private List<Element> elements;
+
+    public void setInputs(List<Input> inputs) {
+        this.inputs = inputs;
+    }
+
+    public void setElements(List<Element> elements) {
+        this.elements = elements;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getExpressionLang() {
+        return expressionLang;
+    }
+
+    public void setExpressionLang(String expressionLang) {
+        this.expressionLang = expressionLang;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getSpecVersion() {
+        return specVersion;
+    }
+
+    public void setSpecVersion(String specVersion) {
+        this.specVersion = specVersion;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Input> getInputs() {
+        return inputs;
+    }
+
+    public List<Element> getElements() {
+        return elements;
+    }
+}

--- a/kie-yard/kie-yard-api/src/main/resources/YaRD-schema.json
+++ b/kie-yard/kie-yard-api/src/main/resources/YaRD-schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "DecisionTable-1": {
+      "type": "object",
+      "properties": {
+        "inputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hitPolicy": {
+          "type": "string",
+          "default": "ANY"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/InlineRule"
+              },
+              {
+                "$ref": "#/definitions/WhenThenRule"
+              }
+            ]
+          }
+        },
+        "outputComponents": {
+          "description": "deprecated",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "inputs",
+        "rules"
+      ]
+    },
+    "DecisionTable-2": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DecisionTable-1"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "DecisionTable"
+            }
+          },
+          "required": [
+            "type"
+          ]
+        }
+      ]
+    },
+    "Element": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "logic": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DecisionTable-2"
+            },
+            {
+              "$ref": "#/definitions/LiteralExpression-2"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "logic"
+      ]
+    },
+    "InlineRule": {
+      "type": "array",
+      "items": {}
+    },
+    "Input": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "LiteralExpression-1": {
+      "type": "object",
+      "properties": {
+        "expression": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ]
+    },
+    "LiteralExpression-2": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/LiteralExpression-1"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "LiteralExpression"
+            }
+          },
+          "required": [
+            "type"
+          ]
+        }
+      ]
+    },
+    "WhenThenRule": {
+      "type": "object",
+      "properties": {
+        "when": {
+          "type": "array",
+          "items": {}
+        },
+        "then": {}
+      },
+      "required": [
+        "when",
+        "then"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "specVersion": {
+      "type": "string",
+      "default": "alpha"
+    },
+    "kind": {
+      "type": "string",
+      "default": "YaRD"
+    },
+    "name": {
+      "type": "string",
+      "description": "when not provided explicitly, implementation will attempt to deduce the name from the runtime context; if a name cannot be deduced it is an error."
+    },
+    "expressionLang": {
+      "type": "string",
+      "description": "An implementation is free to assume a default expressionLang if not explicitly set. For the purpose of a User sharing a YaRD definition, is best to valorise this field explicit."
+    },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Input"
+      }
+    },
+    "elements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Element"
+      }
+    }
+  },
+  "required": [
+    "inputs",
+    "elements"
+  ]
+}

--- a/kie-yard/kie-yard-core/README.md
+++ b/kie-yard/kie-yard-core/README.md
@@ -1,0 +1,306 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
+**YaRD - Yet another Rule Definition**
+
+A simple way to describe declarative *Decisions* and *Rules* in YAML.
+
+This exploration effort proposes a simple YAML notation to describe Decisions, Rules, and Declarative Logic in general.
+
+YaRD is designed from the ground-up to be usable standalone, or in a cloud-native based solution.<br/>
+YaRD is also designed to be usable standalone in a Knative solution, and/or alongside the standard CNCF Serverless Workflow potentially to complement the logic required before a Switch, or required to be evaluated before another State, and/or to complement potentially any Managed Service, any Knative service equivalently.
+<p align="center">
+<img src="docs/img/image8.png">
+<br />
+(videos coming soon)
+</p>
+
+This is currently a research effort, to explore this space. Not a supported capability.<br/>
+If you find this content interesting and you would like to contribute, feel free to contact us and reach out!
+
+# Simple example
+
+To introduce the idea of YaRD, let's consider a basic example where we want to decide what is the **Base price** of a service, given a couple of inputs, accordingly to the following decision table:
+
+|  Age   | Previous incidents?   | Base price   |
+|:------:|:---------------------:|:------------:|
+| ` <21` |        `false`        |    ` 800`    |
+| ` <21` |        ` true`        |    `1000`    |
+| `>=21` |        `false`        |    ` 500`    |
+| `>=21` |        ` true`        |    ` 600`    |
+
+The above decision table could be easily represented with a simple YAML as follows:
+
+```yaml
+specVersion: alpha
+kind: YaRD
+name: 'MyDecision'
+…
+elements:
+- name: 'Base price'
+  type: Decision
+  logic:
+    type: DecisionTable
+    inputs: ['Age', 'Previous incidents?']
+    rules:
+     - ['<21' , false,  800]
+     - ['<21' ,  true, 1000]
+     - ['>=21', false,  500]
+     - ['>=21',  true,  600]
+```
+
+This YaRD, which can be thought of as a pure function `base_price(Age, Previous_Incidents_bool)` , could be invoked via CloudEvents on Ingress+Sink on a Knative environment. We will see that in more detail with more complete example cases below. 
+
+## Executing locally
+
+As an executable example, one could think of this YaRD capability to be accessible on the command line too, in this case focusing directly on the content of the CloudEvent’s Data payload coming as input (eg: Knative Source) and reflected as CloudEvent’s Data payload for output (eg: Knative Sink).
+
+For the scope of a simple demo, below using a provisionally defined alias `kiesd` as a command line utility, showing how the input JSON is handled into the YaRD engine, the decision logic of the decision table executed, and how this is reflected in the output JSON. 
+
+![](docs/img/image6.png)
+
+## Development and Testing
+
+As an example of developing with the YaRD capability, a small application is presented which allows to edit the definition file, and quickly play with it using a guided forms (instead of the command line utility):
+
+![](docs/img/image9.png)
+
+## Deployment
+
+Below is presented a working example of deployment: based on the YAML content of the YaRD definition, a REST service can be provided automatically on K8s. For the purpose of this demo, the working use-case is presented on top of the [Developer Sandbox for Red Hat OpenShift](https://developers.redhat.com/developer-sandbox):
+
+![](docs/img/image4.png)
+
+Similarly we can think having this as a capability in Knative Service; that makes it autoscale-to-zero when not in operations, here the  depicted a few times after having invoked the service:
+
+![](docs/img/image2.png)
+
+Similarly we can also think having this capability as part of an Event Mesh architecture comprising a Knative Broker, to consume CloudEvent and produce new events with the results of the YaRD:
+
+![](docs/img/image3.png)
+
+In the next sections, we will describe some of the capabilities offered by YaRD.
+
+# Key Elements
+
+This section discusses some of the concepts which we want to be represented in this YaRD format, along with some provisional design and definitions. You can skip to the next sections for an overview of more complete examples.
+
+## An extensible YAML markup for Decision and Rules
+
+Providing support for multiple types of Decision and Rules.
+
+Providing support of user-preferred expression language.
+
+Example:
+```yaml
+specVersion: alpha
+kind: YaRD
+name: 'Traffic Violation'
+expressionLang: alpha
+…
+elements:
+- name: 'Fine'
+  type: Decision
+  logic:
+    type: DecisionTable
+    inputs: ['Violation.type', 'Violation.Actual Speed - Violation.Speed Limit']
+    rules:
+     - ['="speed"', '[10..30)', {'Amount': 500, 'Points': 3}]
+     …
+- name: 'Should the driver be suspended?'
+  type: Decision
+  logic:
+    type: LiteralExpression
+    expression: 'if Driver.Points + Fine.Points >= 20 then "Yes" else "No"'
+```
+
+## Plug-in mechanism for multiple expression languages
+
+The expression language can be selected by the end-User / Modeler, as the YaRD provides a plug-in mechanism for it (see extensibility point above).
+
+Same base price example, but using `JQ` expression language also used by CNCF:
+```yaml
+specVersion: alpha
+kind: YaRD
+name: 'BasePrice'
+expressionLang: 'jq'
+inputs:
+- name: 'Age'
+ type: 'http://myapi.org/jsonSchema.json#Age'
+- name: 'Previous incidents?'
+ type: boolean
+elements:
+- name: 'Base price'
+ type: Decision
+ logic:
+   type: DecisionTable
+   inputs: ['.Age', '."Previous incidents?"']
+   rules:
+   - when: [. < 21, . == false]
+     then: 800
+   - when: [. < 21, . == true]
+     then: 1000
+   - when: [. >= 21, . == false]
+     then: 500
+   - when: [. >= 21, . == true]
+     then: 600
+```
+
+## Described in YAML, but compatible with JSON too
+
+This document adopts YAML as the preferred serialization.
+
+However, we will strive not to use any YAML-specific feature which might compromise having an equivalent serialization in JSON too.
+<!--(ref old comment).-->
+
+## Explicitly stateless
+
+A specific section describes the input parameters; the decision logic and rules have its own dedicated section. This allows the user to clearly express the logic intent.
+
+Example:
+```yaml
+…
+inputs:
+- name: 'Driver'
+  type: 'http://myapi.org/jsonSchema.json#Driver'
+- name: 'Violation'
+  type: 'http://myapi.org/jsonSchema.json#Violation'
+elements:
+- name: 'Fine'
+  type: Decision
+  …
+- name: 'Should the driver be suspended?'
+  type: Decision
+  logic:
+  …
+```
+
+## Support for Decision Tables
+Decision tables are a very common and important type of logic, as they naturally capture complex Rules, which otherwise would be described with a very messy nesting of if/else. 
+
+Currently under discussion the canonical form.
+
+### Candidate decision table form A example:
+Example:
+```yaml
+elements:
+- name: 'Base price'
+  type: Decision
+  logic:
+    type: DecisionTable
+    inputs: ['Age', 'Previous incidents?']
+    rules:
+     - ['<21', false, 800]
+     - ['<21', true, 1000]
+     - ['>=21', false, 500]
+     - ['>=21', true, 600]
+```
+
+### Candidate decision table form B example:
+
+Example:
+```yaml
+elements:
+- name: 'Base price'
+  type: Decision
+  logic:
+    type: DecisionTable
+    inputs: ['Age', 'Previous incidents?']
+    rules:
+     - when: ['<21', false]
+       then: 800
+     - when: ['<21', true]
+       then: 1000
+     - when: ['>=21', false]
+       then: 500
+     - when: ['>=21', true]
+       then: 600
+```
+
+## Potential layering of rules in this format
+Decision table and Expression are naturally not the only type of declarative logic which is potentially a good use-case for this format; this section describes traditional rules in a layered approach, that borrow inspiration of rules expressed in yaml by other initiatives, but in a generalized manner.
+
+The actual form for the rules is open for discussion.
+
+Example:
+```yaml
+specVersion: alpha
+kind: YaRD
+name: 'Using moc Rules with Decisions'
+expressionLang: alpha
+inputs:
+ - name: 'Driver'
+   type: 'http://myapi.org/jsonSchema.json#Driver'
+ - name: 'Violation'
+   type: 'http://myapi.org/jsonSchema.json#Violation'
+elements:
+ - name: 'Fine'
+   type: Decision
+   logic:
+     type: DecisionTable
+     inputs: ['Violation.type', 'Violation.Actual Speed - Violation.Speed Limit']
+     rules:
+     - ['="speed"', '[10..30)', {'Amount': 500, 'Points': 3}]
+     - ['="speed"', '>= 30', {'Amount': 1000, 'Points': 7}]
+     - ['="parking"', '-', {'Amount': 100, 'Points': 1}]
+     - ['="driving under the influence"', '-', {'Amount': 1000, 'Points': 5}]
+ - name: 'Should the driver be sanctioned?'
+   type: moc Rules
+   schemas: http://myapi.org/jsonSchema.json
+   host_rules:
+     - name: R1
+       condition:
+         all:
+         - $f: /Fine[ Points > 0 ]
+         - $d: /Driver
+       action:
+         assert_fact:
+           sum of points: $f.Points + $d.Points
+           total due: $f.Amount
+     - name: R2
+       condition: /Balance[ sum of points > 20 ]
+       action:
+         send_event: 'Suspend driver'
+     - name: R3
+       condition: /Balance[ total due >= 1000 ]
+       action:
+         send_event: 'Issue money collection priority slip'
+```
+
+# FAQ
+
+**Q: Why YAML?**<br/>
+A: We believe it is a pragmatic, current-day approach to express declaratively logic (such as rules, decision, workflows, etc) but not only limited to that! With reference to the most common examples out there, the way YAML is used in K8s, YAML is used to declaratively describe some desired “state” of the infrastructure or system. So we are providing examples in YAML as that is a natural and pragmatic fit for YaRD.
+Also, [from earlier in this doc] we will strive not to use any YAML-specific feature which might compromise having an equivalent serialization in JSON too.
+<!-- (ref old comment). -->
+We’re also open to other formats, provided rationale and +1s.
+
+**Q: What type of semantics are supported?**<br/>
+A: At this stage we’re mainly focusing on (simple) Decision Tables and generalized Literal Expressions; from experience in the *decision automation* space, those are the most common, basic, easy-to-understand types of decision logic needed to support the majority of simple use-cases.
+We’re of course open to consider other types of declarative decision/rule formalisms as we progress!
+
+**Q: Which Expression Language is supported?**<br/>
+A: We’re striving to provide open-support to any expression language (EL) that supports predicate logic and structural-type or plays well with JSON-like structures in general. That’s why we are focusing on the semantics of the Decision Tables and Literal Expressions type of decision logic.
+At the time of writing this faq-entry (2022-02-22), the expression language is marked “alpha” as we’re using some provisional one to bootstrap the (code-)infrastructure needed. We’re currently considering both FEEL, an open-standard expression language which proved simple to pick up in the *decision automation* space, **and** the [JQ](https://stedolan.github.io/jq/) expression language, a de-facto standard very popular in the CNCF community(ies), as *first-class* support, but this is NOT decided yet and is open to discussion and +1s. We’re open to consider onboarding and dropping as needed/requested.
+Important considerations in the area of support-able ELs are *also*: ease of use in writing the rules/decisions, license, ease of integration with JVM platform, etc.
+We might consider providing first-class support to selected expression languages, as we progress on this specification.
+Early experiments show for instance JavaScript (precisely tested with both V6 as supported by JEP 292, *and*  ECMAScript 2021) fit these points nicely, and could likely be a supported EL but also directly as a “first-class support”! We have also conducted early experiments with other *surprising* ELs too, such as [PowerFX](https://github.com/microsoft/Power-Fx)! The results motivate us to investigate further into this plug-in architecture.
+
+**Q: I couldn’t find my question here?**<br/>
+A: Don’t hesitate to leave a comment, write us an email or drop in chat!

--- a/kie-yard/kie-yard-core/pom.xml
+++ b/kie-yard/kie-yard-core/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-yard</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kie-yard-core</artifactId>
+
+    <name>KIE :: Yard - Core</name>
+    <description>KIE Yard Core module - Implementation and runtime for YAML Rules DSL engine</description>
+
+    <properties>
+        <java.module.name>org.kie.yard.core</java.module.name>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-yard-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-ruleunits-dsl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.obermuhlner</groupId>
+            <artifactId>jshell-scriptengine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mvel</groupId>
+            <artifactId>mvel2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+        </plugins>
+    </build>
+</project>

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/DTableUnitBuilder.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/DTableUnitBuilder.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.drools.model.Index;
+import org.drools.ruleunits.api.SingletonStore;
+import org.drools.ruleunits.dsl.SyntheticRuleUnit;
+import org.drools.ruleunits.dsl.SyntheticRuleUnitBuilder;
+import org.kie.yard.api.model.InlineRule;
+import org.kie.yard.api.model.Rule;
+import org.kie.yard.api.model.WhenThenRule;
+
+public class DTableUnitBuilder {
+
+    private final YaRDDefinitions definitions;
+    private final String name;
+    private final OnExecute executionAction;
+    private final List<Rule> rules;
+    private final List<String> inputs;
+    private final JsonMapper jsonMapper = JsonMapper.builder().build();
+
+    public DTableUnitBuilder(
+            final YaRDDefinitions definitions,
+            final String name,
+            final org.kie.yard.api.model.DecisionTable dtableDefinition) {
+        this.inputs = dtableDefinition.getInputs();
+        if (inputs.isEmpty()) {
+            throw new IllegalStateException("Empty decision table?");
+        }
+        this.definitions = definitions;
+        this.name = name;
+        this.rules = dtableDefinition.getRules();
+        this.executionAction = getExecutionAction(dtableDefinition.getHitPolicy());
+    }
+
+    public SyntheticRuleUnit build() {
+
+        final SyntheticRuleUnitBuilder unit = SyntheticRuleUnitBuilder.build(name);
+        for (Map.Entry<String, SingletonStore<Object>> e : definitions.inputs().entrySet()) {
+            unit.registerDataSource(e.getKey(), e.getValue(), Object.class);
+        }
+        final StoreHandle<Object> result = StoreHandle.empty(Object.class);
+        unit.registerGlobal(name, result);
+        definitions.outputs().put(name, result);
+        return unit.defineRules(rulesFactory -> {
+            for (Rule ruleDefinition : rules) {
+                var rule = rulesFactory.rule();
+                for (int idx = 0; idx < inputs.size(); idx++) {
+                    final RuleCell ruleCell = parseGenericRuleCell(ruleDefinition, idx);
+                    if (ruleCell.value != null) {
+                        final SingletonStore<Object> dataSource = definitions.inputs().get(inputs.get(idx));
+
+                        rule.on(dataSource).filter(ruleCell.idxtype, ruleCell.value);
+                    }
+                }
+                rule.execute(result, storeHandle -> executionAction.onExecute(ruleDefinition, storeHandle));
+            }
+        });
+    }
+
+    private OnExecute getExecutionAction(String hitPolicy) {
+        if (hitPolicy == null || Objects.equals("ANY", hitPolicy)) {
+            return (ruleDefinition, storeHandle) -> {
+                final RuleCell rc = parseGenericRuleThen(ruleDefinition);
+                Object value = resolveValue(rc.value);
+                storeHandle.set(value);
+            };
+        } else if (Objects.equals("FIRST", hitPolicy)) {
+            return (ruleDefinition, storeHandle) -> {
+                if (!storeHandle.isValuePresent()) {
+                    final RuleCell rc = parseGenericRuleThen(ruleDefinition);
+                    storeHandle.set(resolveValue(rc.value));
+                }
+            };
+        } else if (Objects.equals("COLLECT", hitPolicy)) {
+            return (ruleDefinition, storeHandle) -> {
+                if (!storeHandle.isValuePresent()) {
+                    storeHandle.set(new ArrayList<>());
+                }
+                final RuleCell rc = parseGenericRuleThen(ruleDefinition);
+
+                if (storeHandle.get() instanceof List list) {
+                    list.add(resolveValue(rc.value));
+                }
+            };
+        } else {
+            throw new UnsupportedOperationException("Not implemented ");
+        }
+    }
+
+    private Object resolveValue(Object value) {
+        try {
+            if (value instanceof String text) {
+                return jsonMapper.readValue(text, Map.class);
+            }
+        } catch (JsonProcessingException ignored) {
+        }
+        return value;
+    }
+
+    private RuleCell parseGenericRuleThen(Rule rule) {
+        if (rule instanceof InlineRule inlineRule) {
+            return parseRuleCell(inlineRule.getDef().get(inlineRule.getDef().size() - 1));
+        } else if (rule instanceof WhenThenRule whenThenRule) {
+            return parseRuleCell((whenThenRule).getThen());
+        } else {
+            throw new IllegalStateException("Unknown or unmanaged rule instance type?");
+        }
+    }
+
+    private RuleCell parseGenericRuleCell(Rule rule, int i) {
+        if (rule instanceof InlineRule inlineRule) {
+            return parseRuleCell((inlineRule).getDef().get(i));
+        } else if (rule instanceof WhenThenRule whenThenRule) {
+            return parseRuleCell((whenThenRule).getWhen().get(i));
+        } else {
+            throw new IllegalStateException("Unknown or unmanaged rule instance type?");
+        }
+    }
+
+    private RuleCell parseRuleCell(Object object) {
+        if (object instanceof Boolean) {
+            return new RuleCell(Index.ConstraintType.EQUAL, object);
+        } else if (object instanceof Number) {
+            return new RuleCell(Index.ConstraintType.EQUAL, object);
+        } else if (object instanceof String valueString) {
+            if (valueString.startsWith("<=")) { // pay attention to ordering when not using a parser like in this case.
+                return new RuleCell(Index.ConstraintType.LESS_OR_EQUAL, parseConstrainedCellString(valueString.substring(2)));
+            } else if (valueString.startsWith(">=")) {
+                return new RuleCell(Index.ConstraintType.GREATER_OR_EQUAL, parseConstrainedCellString(valueString.substring(2)));
+            } else if (valueString.startsWith("<")) {
+                return new RuleCell(Index.ConstraintType.LESS_THAN, parseConstrainedCellString(valueString.substring(1)));
+            } else if (valueString.startsWith(">")) {
+                return new RuleCell(Index.ConstraintType.GREATER_THAN, parseConstrainedCellString(valueString.substring(1)));
+            } else {
+                return new RuleCell(Index.ConstraintType.EQUAL, parseConstrainedCellString(valueString));
+            }
+        } else {
+            throw new IllegalStateException("Unmanaged case, please report!");
+        }
+    }
+
+    private Object parseConstrainedCellString(String substring) {
+        if (Objects.equals("true", substring.trim().toLowerCase())) {
+            return true;
+        }
+        if (Objects.equals("false", substring.trim().toLowerCase())) {
+            return false;
+        }
+        try {
+            return Integer.parseInt(substring.trim());
+        } catch (Exception e) {
+
+        }
+        try {
+            return Long.parseLong(substring.trim());
+        } catch (Exception e) {
+
+        }
+        if (Objects.equals("-", substring.trim())) {
+            return null;
+        }
+        return substring;
+    }
+
+    private interface OnExecute {
+
+        void onExecute(Rule ruleDefinition, StoreHandle<Object> storeHandle);
+    }
+
+    public static record RuleCell(Index.ConstraintType idxtype, Object value) {
+
+    }
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/Firable.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/Firable.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.util.Map;
+
+public interface Firable {
+
+    int fire(Map<String, Object> context, YaRDDefinitions units);
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/JShellLiteralExpressionInterpreter.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/JShellLiteralExpressionInterpreter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.script.Bindings;
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+public class JShellLiteralExpressionInterpreter implements Firable {
+
+    private final String name;
+    private final QuotedExprParsed quoted;
+    private final ScriptEngine engine;
+    private final CompiledScript compiledScript;
+
+    public JShellLiteralExpressionInterpreter(final String nameString,
+                                              final QuotedExprParsed quotedExprParsed) {
+        this.name = nameString;
+        this.quoted = quotedExprParsed;
+        try {
+            final ScriptEngineManager manager = new ScriptEngineManager();
+            engine = manager.getEngineByName("jshell");
+            final Compilable compiler = (Compilable) engine;
+            compiledScript = compiler.compile(quoted.getRewrittenExpression());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("parse error", e);
+        }
+    }
+
+    @Override
+    public int fire(final Map<String, Object> context,
+                    final YaRDDefinitions units) {
+        final Bindings bindings = engine.createBindings();
+        // deliberately escape all symbols; a normal symbol will
+        // never be in the detected-by-unquoting set, so this
+        // set can't be used to selectively put in scope
+        for (Entry<String, Object> inKV : context.entrySet()) {
+            bindings.put(QuotedExprParsed.escapeIdentifier(inKV.getKey()), inKV.getValue());
+        }
+        for (Entry<String, StoreHandle<Object>> outKV : units.outputs().entrySet()) {
+            if (!outKV.getValue().isValuePresent()) {
+                continue;
+            }
+            bindings.put(QuotedExprParsed.escapeIdentifier(outKV.getKey()), outKV.getValue().get());
+        }
+        try {
+            var result = compiledScript.eval(bindings);
+            units.outputs().get(name).set(result);
+            return 1;
+        } catch (ScriptException e) {
+            throw new RuntimeException("interpretation failed at runtime", e);
+        }
+    }
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/LiteralExpressionBuilder.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/LiteralExpressionBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import org.kie.yard.api.model.LiteralExpression;
+
+import java.util.Objects;
+
+public class LiteralExpressionBuilder {
+
+    private final String expressionLang;
+    private final YaRDDefinitions definitions;
+    private final String name;
+    private final LiteralExpression decisionLogic;
+
+    public LiteralExpressionBuilder(final String expressionLang,
+                                    final YaRDDefinitions definitions,
+                                    final String name,
+                                    final LiteralExpression decisionLogic) {
+        this.expressionLang = expressionLang;
+        this.definitions = definitions;
+        this.name = name;
+        this.decisionLogic = decisionLogic;
+    }
+
+    public Firable build() {
+        final String expr = decisionLogic.getExpression();
+        definitions.outputs().put(name, StoreHandle.empty(Object.class));
+        if(Objects.equals(expressionLang, "jshell")){
+            return new JShellLiteralExpressionInterpreter(name, QuotedExprParsed.from(expr));
+        }
+        else {
+            return new MVELLiteralExpressionInterpreter(name,QuotedExprParsed.from(expr));
+        }
+    }
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/MVELLiteralExpressionInterpreter.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/MVELLiteralExpressionInterpreter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.mvel2.MVEL;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MVELLiteralExpressionInterpreter implements Firable {
+    private final String name;
+    private final QuotedExprParsed expr;
+
+    private final JsonMapper jsonMapper = JsonMapper.builder().build();
+
+    public MVELLiteralExpressionInterpreter(final String name,
+                                            final QuotedExprParsed expr) {
+        this.name = name;
+        this.expr = expr;
+    }
+
+    @Override
+    public int fire(final Map<String, Object> context,
+                    final YaRDDefinitions units) {
+        final Map<String, Object> internalContext = new HashMap<>();
+        internalContext.putAll(context);
+
+        for (Map.Entry<String, StoreHandle<Object>> outKV : units.outputs().entrySet()) {
+            if (!outKV.getValue().isValuePresent()) {
+                continue;
+            }
+            internalContext.put(QuotedExprParsed.escapeIdentifier(outKV.getKey()), outKV.getValue().get());
+        }
+
+        try {
+            String rewrittenExpression = expr.getRewrittenExpression();
+            final Object result = MVEL.eval(rewrittenExpression, internalContext);
+            units.outputs().get(name).set(resolveValue(result));
+            return 1;
+        } catch (Exception e) {
+            throw new RuntimeException("interpretation failed at runtime", e);
+        }
+    }
+
+    private Object resolveValue(Object value) {
+        try {
+            if (value instanceof String text) {
+                return jsonMapper.readValue(text, Map.class);
+            }
+        } catch (JsonProcessingException ignored) {
+        }
+        return value;
+    }
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/QuotedExprParsed.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/QuotedExprParsed.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.PrimitiveIterator.OfInt;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.lang.model.SourceVersion;
+
+public class QuotedExprParsed {
+
+    private static final int ESCAPE_CHAR = "`".codePointAt(0);
+
+    private final Set<String> usedSymbols;
+    private final String rewrittenExpression;
+
+    private QuotedExprParsed(List<String> usedSymbols, String rewrittenExpression) {
+        this.usedSymbols = usedSymbols.stream().collect(Collectors.toUnmodifiableSet());
+        this.rewrittenExpression = rewrittenExpression;
+    }
+
+    public String getRewrittenExpression() {
+        return rewrittenExpression;
+    }
+
+    public Collection<String> getUsedSymbols() {
+        return usedSymbols;
+    }
+
+    public static QuotedExprParsed from(String expr) {
+        StringBuilder rewittenExpr = new StringBuilder();
+        StringBuilder quotedBuffer = new StringBuilder();
+        List<String> usedSymbols = new ArrayList<>();
+        OfInt it = expr.codePoints().iterator();
+        State state = State.UNQUOTED;
+        while (it.hasNext()) {
+            int c = it.nextInt();
+            if (c == ESCAPE_CHAR) {
+                switch (state) {
+                    case UNQUOTED:
+                        state = State.QUOTED;
+                        break;
+                    case QUOTED:
+                        state = State.UNQUOTED;
+                        var originalSymbol = quotedBuffer.toString();
+                        usedSymbols.add(originalSymbol);
+                        var escaped = escapeIdentifier(originalSymbol);
+                        rewittenExpr.append(escaped);
+                        quotedBuffer = new StringBuilder();
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+            } else {
+                switch (state) {
+                    case UNQUOTED:
+                        rewittenExpr.appendCodePoint(c);
+                        break;
+                    case QUOTED:
+                        quotedBuffer.appendCodePoint(c);
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+            }
+        }
+        return new QuotedExprParsed(usedSymbols, rewittenExpr.toString());
+    }
+
+    private static enum State {
+        UNQUOTED,
+        QUOTED
+    }
+
+    public static String escapeIdentifier(String partOfIdentifier) {
+        String id = partOfIdentifier;
+        if (!Character.isJavaIdentifierStart(id.charAt(0))) {
+            id = "_" + id;
+        }
+        id = id.replaceAll("_", "__");
+        if (SourceVersion.isKeyword(id)) {
+            id = "_" + id;
+        }
+        StringBuilder result = new StringBuilder();
+        char[] cs = id.toCharArray();
+        for (char c : cs) {
+            if (Character.isJavaIdentifierPart(c)) {
+                result.append(c);
+            } else {
+                result.append("_" + Integer.valueOf(c));
+            }
+        }
+        return result.toString();
+    }
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/StoreHandle.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/StoreHandle.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import org.drools.ruleunits.api.DataHandle;
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.SingletonStore;
+
+public class StoreHandle<T> {
+
+    private SingletonStore<T> wrapped;
+    private DataHandle datahandle;
+
+    private StoreHandle(T value) {
+        wrapped = DataSource.createSingleton();
+        datahandle = wrapped.set(value);
+    }
+
+    private StoreHandle() {
+        wrapped = DataSource.createSingleton();
+        datahandle = null;
+    }
+
+    public static <T> StoreHandle<T> of(T value) {
+        return new StoreHandle<>(value);
+    }
+
+    public static <T> StoreHandle<T> empty(Class<T> type) {
+        return new StoreHandle<>();
+    }
+
+    public DataHandle set(T value) {
+        datahandle = wrapped.set(value);
+        return datahandle;
+    }
+
+    public void clear() {
+        datahandle = null;
+        wrapped.clear();
+    }
+
+    public boolean isValuePresent() {
+        return !(datahandle == null);
+    }
+
+    public T get() {
+        if (datahandle == null) {
+            throw new IllegalStateException("was never set");
+        }
+        @SuppressWarnings("unchecked")
+        T result = (T) datahandle.getObject();
+        return result;
+    }
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/SyntheticRuleUnitWrapper.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/SyntheticRuleUnitWrapper.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.util.Map;
+
+import org.drools.ruleunits.api.RuleUnitInstance;
+import org.drools.ruleunits.api.RuleUnitProvider;
+import org.drools.ruleunits.dsl.SyntheticRuleUnit;
+
+public class SyntheticRuleUnitWrapper implements Firable {
+
+    private final SyntheticRuleUnit wrapped;
+
+    public SyntheticRuleUnitWrapper(SyntheticRuleUnit wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public int fire(Map<String, Object> context, YaRDDefinitions units) {
+        RuleUnitInstance<SyntheticRuleUnit> unitInstance = RuleUnitProvider.get().createRuleUnitInstance(wrapped);
+        int fire = unitInstance.fire();
+        RuleUnitProvider.get().invalidateRuleUnits(wrapped.getClass());
+        return fire;
+    }
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/YaRDDefinitions.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/YaRDDefinitions.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.drools.ruleunits.api.SingletonStore;
+
+public record YaRDDefinitions(
+        Map<String, SingletonStore<Object>> inputs,
+        List<Firable> units,
+        Map<String, StoreHandle<Object>> outputs) {
+
+    public Map<String, Object> evaluate(Map<String, Object> context) {
+        Map<String, Object> results = new LinkedHashMap<>(context);
+        for (String inputKey : inputs.keySet()) {
+            if (!context.containsKey(inputKey)) {
+                throw new IllegalArgumentException("Missing input key in context: " + inputKey);
+            }
+            Object inputValue = context.get(inputKey);
+            inputs.get(inputKey).set(inputValue);
+        }
+        for (Firable unit : units) {
+            unit.fire(context, this);
+        }
+        for (Entry<String, StoreHandle<Object>> outputSets : outputs.entrySet()) {
+            results.put(outputSets.getKey(), outputSets.getValue().get());
+        }
+        reset();
+        return results;
+    }
+
+    private void reset() {
+        inputs.forEach((k, v) -> v.clear());
+        outputs.forEach((k, v) -> v.clear());
+    }
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/YaRDParser.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/YaRDParser.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import org.drools.ruleunits.api.DataSource;
+import org.kie.yard.api.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class YaRDParser {
+    static YaRDParser fromModel(final YaRD model) throws IOException {
+        return new YaRDParser(model);
+    }
+    static YaRDParser fromYaml(final String yaml) throws IOException {
+        final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+        final YaRD model = yamlMapper.readValue(yaml, YaRD.class);
+        return new YaRDParser(model);
+    }
+
+    static YaRDParser fromYaml(final Reader reader) throws IOException {
+        final String text = read(reader);
+        return fromYaml(text);
+    }
+
+    static YaRDParser fromJson(String json) throws IOException {
+        final ObjectMapper jsonMapper = new ObjectMapper();
+        final YaRD model = jsonMapper.readValue(json, YaRD.class);
+        return new YaRDParser(model);
+    }
+
+    private static String read(Reader reader) throws IOException {
+        final StringBuilder fileData = new StringBuilder(1000);
+        char[] buf = new char[1024];
+        int numRead;
+        while ((numRead = reader.read(buf)) != -1) {
+            String readData = String.valueOf(buf,
+                    0,
+                    numRead);
+            fileData.append(readData);
+            buf = new char[1024];
+        }
+        reader.close();
+        return fileData.toString();
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(YaRDParser.class);
+    private final YaRDDefinitions definitions = new YaRDDefinitions(new HashMap<>(), new ArrayList<>(), new HashMap<>());
+    private final YaRD model;
+
+    private YaRDParser(final YaRD model) {
+        this.model = model;
+        appendInputs();
+        appendUnits();
+    }
+
+    public YaRD getModel() {
+        return model;
+    }
+
+    public YaRDDefinitions getDefinitions() {
+        return definitions;
+    }
+
+    private void appendUnits() {
+        final List<Element> list = model.getElements();
+        final List<String> existingNames = new ArrayList<>();
+        for (Element hi : list) {
+            final String nameString = hi.getName();
+            if (existingNames.contains(nameString)) {
+                throw new IllegalArgumentException("Two element definitions with the same name are not allowed.");
+            } else {
+                existingNames.add(nameString);
+            }
+            LOG.debug("parsing {}", nameString);
+            final Firable decisionLogic = createDecisionLogic(nameString, hi.getLogic());
+            definitions.units().add(decisionLogic);
+        }
+    }
+
+    private Firable createDecisionLogic(String nameString, DecisionLogic decisionLogic) {
+        if (decisionLogic instanceof org.kie.yard.api.model.DecisionTable decisionTable) {
+            return new SyntheticRuleUnitWrapper(new DTableUnitBuilder(definitions, nameString, decisionTable).build());
+        } else if (decisionLogic instanceof org.kie.yard.api.model.LiteralExpression literalExpression) {
+            return new LiteralExpressionBuilder(model.getExpressionLang(), definitions, nameString, literalExpression).build();
+        } else {
+            throw new UnsupportedOperationException("Not implemented.");
+        }
+    }
+
+    private void appendInputs() {
+        final List<Input> list = model.getInputs();
+        for (Input hi : list) {
+            String nameString = hi.getName();
+            @SuppressWarnings("unused")
+            Class<?> typeRef = processType(hi.getType());
+            definitions.inputs().put(nameString, DataSource.createSingleton());
+        }
+    }
+
+    private Class<?> processType(String string) {
+        switch (string) {
+            case "string":
+            case "number":
+            case "boolean":
+            default:
+                return Object.class;
+        }
+    }
+}

--- a/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/YaRDRunner.java
+++ b/kie-yard/kie-yard-core/src/main/java/org/kie/yard/core/YaRDRunner.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.kie.yard.api.model.YaRD;
+
+public class YaRDRunner {
+
+    private final YaRDDefinitions definitions;
+    private final JsonMapper jsonMapper = JsonMapper.builder().build();
+    private final YaRD model;
+
+    public YaRDRunner(final YaRD model) throws IOException {
+        final YaRDParser parser = YaRDParser.fromModel(model);
+        this.model = model;
+        definitions = parser.getDefinitions();
+    }
+
+    public YaRDRunner(final String yaml) throws IOException {
+        final YaRDParser parser = YaRDParser.fromYaml(yaml);
+        model = parser.getModel();
+        definitions = parser.getDefinitions();
+    }
+
+    public YaRDRunner(final Map map) throws IOException {
+        final String json = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(map);
+
+        final YaRDParser parser = YaRDParser.fromJson(json);
+        model = parser.getModel();
+        definitions = parser.getDefinitions();
+    }
+
+    public YaRD getModel() {
+        return model;
+    }
+
+    public Map<String, Object> evaluate(final Map<String, Object> map) {
+        return definitions.evaluate(map);
+    }
+
+    public String evaluate(String jsonInputCxt) throws Exception {
+        final Map<String, Object> inputContext = readJSON(jsonInputCxt);
+        return jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(evaluate(inputContext));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> readJSON(final String json) {
+        try {
+            return jsonMapper.readValue(json, Map.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to read JSON " + json, e);
+        }
+    }
+}

--- a/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/DomesticPackagePricesTest.java
+++ b/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/DomesticPackagePricesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DomesticPackagePricesTest
+        extends TestBase {
+
+    private static final String FILE_NAME = "/domestic-package-prices.yml";
+
+    @Test
+    public void testMPackage() throws Exception {
+        final String CTX = """
+                {
+                    "Height":10,
+                    "Width":10,
+                    "Length": 10,
+                    "Weight":10
+                }
+                """;
+        Map<String, Object> outputJSONasMap = evaluate(CTX, FILE_NAME);
+        assertEquals(6.9, ((Map) outputJSONasMap.get("Package")).get("Cost"));
+        assertEquals("M", ((Map) outputJSONasMap.get("Package")).get("Size"));
+    }
+
+    @Test
+    public void testLPackage() throws Exception {
+        final String CTX = """
+                {
+                    "Height":12,
+                    "Width":10,
+                    "Length": 10,
+                    "Weight":10
+                }
+                """;
+        Map<String, Object> outputJSONasMap = evaluate(CTX, FILE_NAME);
+        assertEquals(8.9, ((Map) outputJSONasMap.get("Package")).get("Cost"));
+        assertEquals("L", ((Map) outputJSONasMap.get("Package")).get("Size"));
+    }
+}

--- a/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/DublicateElementNameTest.java
+++ b/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/DublicateElementNameTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DublicateElementNameTest
+        extends TestBase {
+
+    private static final String FILE_NAME = "/two-elements-with-duplicate-name.yml";
+
+    @Test
+    public void testNoDublicateNames() throws Exception {
+        final String CTX = """
+                {
+                    "Age": 10
+                }
+                """;
+        assertThrows(IllegalArgumentException.class, () ->
+                evaluate(CTX, FILE_NAME)
+        );
+    }
+}

--- a/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/ExtraCostsTest.java
+++ b/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/ExtraCostsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExtraCostsTest
+        extends TestBase {
+
+    private static final String FILE_NAME = "/extra-costs.yml";
+
+    @Test
+    public void testMPackage() throws Exception {
+        final String CTX = """
+                {
+                    "Fragile":true,
+                    "Package Tracking":true,
+                    "Insurance":true,
+                    "Package Type":"M"
+                }
+                """;
+        Map<String, Object> outputJSONasMap = evaluate(CTX, FILE_NAME);
+        assertThat(outputJSONasMap).hasFieldOrPropertyWithValue("Total cost of premiums", 40);
+    }
+}

--- a/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/InsuranceBasePriceTest.java
+++ b/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/InsuranceBasePriceTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InsuranceBasePriceTest
+    extends TestBase {
+
+  private static final String FILE_NAME = "/insurance-base-price.yml";
+
+  @Test
+  public void testScenario1() throws Exception {
+    final String CTX = """
+        {
+          "Age": 47,
+          "Previous incidents?": false
+        }
+        """;
+    Map<String, Object> outputJSONasMap = evaluate(CTX, FILE_NAME);
+    assertThat(outputJSONasMap).hasFieldOrPropertyWithValue("Base price", 500);
+    assertThat(outputJSONasMap).hasFieldOrPropertyWithValue("Downpayment", 50);
+  }
+
+  @Test
+  public void testScenario2() throws Exception {
+    final String CTX = """
+        {
+          "Age": 19,
+          "Previous incidents?": true
+        }
+        """;
+    Map<String, Object> outputJSONasMap = evaluate(CTX, FILE_NAME);
+    assertThat(outputJSONasMap).hasFieldOrPropertyWithValue("Base price", 1000);
+    assertThat(outputJSONasMap).hasFieldOrPropertyWithValue("Downpayment", 70);
+  }
+}

--- a/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/JsonParserTest.java
+++ b/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/JsonParserTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import org.drools.util.IoUtils;
+import org.junit.jupiter.api.Test;
+import org.kie.yard.api.model.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class JsonParserTest {
+
+    @Test
+    public void testWhenThen() throws Exception {
+        String s = new String(IoUtils.readBytesFromInputStream(this.getClass().getResourceAsStream("/insurance-base-price.json"), true));
+        ObjectMapper mapper = new ObjectMapper();
+        YaRD yaRD = mapper.readValue(s, YaRD.class);
+
+        assertEquals("Base price", yaRD.getElements().get(0).getName());
+        final DecisionTable dtable = (DecisionTable) yaRD.getElements().get(0).getLogic();
+        assertEquals(1, dtable.getRules().get(0).getRowNumber());
+        assertEquals(2, dtable.getRules().get(1).getRowNumber());
+        final WhenThenRule rule = (WhenThenRule) dtable.getRules().get(0);
+        assertEquals("<21", rule.getWhen().get(0));
+        assertEquals(new BigDecimal(800), rule.getThen());
+    }
+
+    @Test
+    public void testInlineRule() throws Exception {
+        String s = new String(IoUtils.readBytesFromInputStream(this.getClass().getResourceAsStream("/simplified-ticket-score.json"), true));
+        ObjectMapper mapper = new ObjectMapper();
+        YaRD yaRD = mapper.readValue(s, YaRD.class);
+
+        assertEquals("Level", yaRD.getElements().get(0).getName());
+        DecisionTable dtable = (DecisionTable) yaRD.getElements().get(0).getLogic();
+        assertInstanceOf(InlineRule.class, dtable.getRules().get(0));
+    }
+
+}

--- a/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/MVELJSONTest.java
+++ b/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/MVELJSONTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MVELJSONTest
+        extends TestBase {
+
+    private static final String FILE_NAME = "/mvel-json-dot-access.yml";
+
+    @Test
+    public void testMVELManagesJSONMaps() throws Exception {
+        final String CTX = """
+                {
+                    "Work Address":true
+                }
+                """;
+        final Map<String, Object> output = evaluate(CTX, FILE_NAME);
+
+        final Map mailingAddress = (Map) output.get("Mailing Address");
+        assertEquals("Work Street", mailingAddress.get("Street"));
+        assertEquals(23, mailingAddress.get("Number"));
+
+        final List deliveryItemNames = (List) output.get("Delivery Item Names");
+        assertEquals(3, deliveryItemNames.size());
+        assertTrue(deliveryItemNames.contains("Work Shoes"));
+        assertTrue(deliveryItemNames.contains("Work Hat"));
+        assertTrue(deliveryItemNames.contains("Work Shirt"));
+
+        final Map JSONTest= (Map) output.get("JSON Test");
+        assertEquals("Best Company LTD", JSONTest.get("Company"));
+
+        final Map mapTest = (Map) output.get("Map Test");
+        assertEquals("Hello", mapTest.get("Map"));
+    }
+}

--- a/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/MVELLiteralExpressionInterpreterTest.java
+++ b/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/MVELLiteralExpressionInterpreterTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MVELLiteralExpressionInterpreterTest {
+
+
+    private MVELLiteralExpressionInterpreter sum;
+    private YaRDDefinitions yardDefinitions;
+
+    void setUp(final String expression) {
+        sum = new MVELLiteralExpressionInterpreter("sum", QuotedExprParsed.from(expression));
+
+        final Map<String, StoreHandle<Object>> outputs = new HashMap<>();
+        outputs.put("C", StoreHandle.of(5));
+        outputs.put("sum", StoreHandle.empty(Object.class));
+        yardDefinitions = new YaRDDefinitions(Collections.emptyMap(), Collections.EMPTY_LIST, outputs);
+
+    }
+
+    @Test
+    public void testSum() {
+
+        setUp("1+1");
+
+        final int fire = sum.fire(Collections.emptyMap(), yardDefinitions);
+
+        assertEquals(1, fire);
+        assertEquals(2, yardDefinitions.outputs().get("sum").get());
+    }
+
+    @Test
+    public void testOutputVar() {
+
+        setUp("Math.max(C, 1)");
+
+        final int fire = sum.fire(Collections.emptyMap(), yardDefinitions);
+
+        assertEquals(1, fire);
+        assertEquals(5, yardDefinitions.outputs().get("sum").get());
+    }
+
+    @Test
+    public void testContext() {
+
+        setUp("A+B");
+
+        final Map<String, Object> context = new HashMap<>();
+        context.put("A", 1);
+        context.put("B", 2);
+        final int fire = sum.fire(context, yardDefinitions);
+
+        assertEquals(1, fire);
+        assertEquals(3, yardDefinitions.outputs().get("sum").get());
+    }
+
+    @Test
+    public void testMaps() {
+
+        setUp("person.address.street + ' ' + person.address.number");
+
+        final Map<String, Object> context = new HashMap<>();
+        final Map<String, Object> person = new HashMap<>();
+        final Map<String, Object> address = new HashMap<>();
+        address.put("street", "My Street");
+        address.put("number", 12);
+        person.put("address", address);
+        context.put("person", person);
+        final int fire = sum.fire(context, yardDefinitions);
+
+        assertEquals(1, fire);
+        assertEquals("My Street 12", yardDefinitions.outputs().get("sum").get());
+    }
+}

--- a/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/TestBase.java
+++ b/kie-yard/kie-yard-core/src/test/java/org/kie/yard/core/TestBase.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.yard.core;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.drools.util.IoUtils;
+
+public class TestBase {
+
+    private JsonMapper jsonMapper = JsonMapper.builder().build();
+
+    protected Map<String, Object> evaluate(String jsonInputCxt, String file) throws Exception {
+        final String yamlDecision = read(file);
+        final String OUTPUT_JSON = new YaRDRunner(yamlDecision).evaluate(jsonInputCxt);
+        return readJSON(OUTPUT_JSON);
+    }
+
+    private String read(String file) throws IOException {
+        return new String(IoUtils.readBytesFromInputStream(this.getClass().getResourceAsStream(file), true));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> readJSON(final String CONTEXT) throws JsonProcessingException {
+        return jsonMapper.readValue(CONTEXT, Map.class);
+    }
+}

--- a/kie-yard/kie-yard-core/src/test/resources/domestic-package-prices.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/domestic-package-prices.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Traffic Violation"
+inputs:
+  - name: "Length"
+    type: integer
+  - name: "Width"
+    type: number
+  - name: "Height"
+    type: number
+  - name: "Weight"
+    type: number
+elements:
+  - name: Package
+    type: Decision
+    logic:
+      type: DecisionTable
+      # First matching result will be picked
+      hitPolicy: FIRST
+      inputs: [ "Height", "Width", "Length", "Weight" ]
+      rules:
+        - when: [ '<= 3', '<= 25','<= 35', '<= 2' ]
+          then: '{ "Size": "S", "Cost": 5.90 }'
+        - when: [ '<= 11','<= 32','<= 42', '<=25' ]
+          then: '{ "Size": "M", "Cost": 6.90 }'
+        - when: [ '<= 19', '<= 36', '<= 60', '<= 25' ]
+          then: '{ "Size": "L", "Cost": 8.90 }'
+        - when: [ '<= 37', '<= 36', '<= 60', '<= 25' ]
+          then: '{ "Size": "XL", "Cost": 10.90}'

--- a/kie-yard/kie-yard-core/src/test/resources/extra-costs.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/extra-costs.yml
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Traffic Violation"
+expressionLang: jshell
+inputs:
+  - name: Fragile
+    type: boolean
+  - name: Package Tracking
+    type: boolean
+  - name: Insurance
+    type: boolean
+  - name: Package Type
+    type: string
+elements:
+  - name: Selected premiums
+    type: Decision
+    logic:
+      type: DecisionTable
+      # Collect all costs
+      hitPolicy: COLLECT
+      inputs: [ Package Type, Fragile, Package Tracking, Insurance ]
+      rules:
+        # Insurance for all packages, based on size and if the content is fragile
+        - when: [ 'S', true, "-", true ]
+          then: '{ "Name": "Fragile insurance cost", "Price": 10}'
+        - when: [ 'M', true, "-", true ]
+          then: '{ "Name": "Fragile insurance cost", "Price": 20}'
+        - when: [ 'L', true, "-", true ]
+          then: '{ "Name": "Fragile insurance cost", "Price": 30}'
+        - when: [ 'XL', true, "-", true ]
+          then: '{ "Name": "Fragile insurance cost", "Price": 40}'
+        - when: [ "-", false, "-", true ]
+          then: '{ "Name": "Regular insurance cost", "Price": 5}'
+        # Tracking cost is same for all sizes
+        - when: [ "-", "-", true, "-" ]
+          then: '{ "Name": "Tracking cost", "Price": 5}'
+        # Fragile package extra care cost
+        - when: [ "-", true, "-", "-" ]
+          then: '{ "Name": "Fragile package shipping cost", "Price": 15}'
+  - name: "Total cost of premiums"
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        ((java.util.List<java.util.Map<String,Integer>>)`Selected premiums`).stream().map(m -> m.get("Price")).mapToInt(Integer::valueOf).sum();
+#      Feels filthy compared to FEEL below
+#      expression: 'sum( for item in Selected premiums return item.Price )'

--- a/kie-yard/kie-yard-core/src/test/resources/insurance-base-price.json
+++ b/kie-yard/kie-yard-core/src/test/resources/insurance-base-price.json
@@ -1,0 +1,66 @@
+{
+  "specVersion": "alpha",
+  "kind": "YaRD",
+  "name": "BasePrice",
+  "inputs": [
+    {
+      "name": "Age",
+      "type": "number"
+    },
+    {
+      "name": "Previous incidents?",
+      "type": "boolean"
+    }
+  ],
+  "elements": [
+    {
+      "name": "Base price",
+      "type": "Decision",
+      "logic": {
+        "type": "DecisionTable",
+        "inputs": [
+          "Age",
+          "Previous incidents?"
+        ],
+        "rules": [
+          {
+            "when": [
+              "<21",
+              false
+            ],
+            "then": 800
+          },
+          {
+            "when": [
+              "<21",
+              true
+            ],
+            "then": 1000
+          },
+          {
+            "when": [
+              ">=21",
+              false
+            ],
+            "then": 500
+          },
+          {
+            "when": [
+              ">=21",
+              true
+            ],
+            "then": 600
+          }
+        ]
+      }
+    },
+    {
+      "name": "Downpayment",
+      "type": "Decision",
+      "logic": {
+        "type": "LiteralExpression",
+        "expression": "Math.max(`Base price` * 0.07, 50)\n"
+      }
+    }
+  ]
+}

--- a/kie-yard/kie-yard-core/src/test/resources/insurance-base-price.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/insurance-base-price.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: 'BasePrice'
+inputs:
+  - name: 'Age'
+    type: number
+  - name: 'Previous incidents?'
+    type: boolean
+elements:
+  - name: 'Base price'
+    type: Decision
+    logic:
+      type: DecisionTable
+      inputs: [ 'Age', 'Previous incidents?' ]
+      rules:
+        - when: [ '<21', false ]
+          then: 800
+        - when: [ '<21', true ]
+          then: 1000
+        - when: [ '>=21', false ]
+          then: 500
+        - when: [ '>=21', true ]
+          then: 600
+  - name: 'Downpayment'
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        Math.max(`Base price` * 0.07, 50)

--- a/kie-yard/kie-yard-core/src/test/resources/mvel-json-dot-access.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/mvel-json-dot-access.yml
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Testing MVEL"
+inputs:
+  - name: Work Address
+    type: boolean
+elements:
+  - name: JSON Test
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        '{ "Company": "Best Company LTD" }'
+  - name: Map Test
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        [ "Map": "Hello" ]
+  - name: Delivery Items
+    type: Decision
+    logic:
+      type: DecisionTable
+      hitPolicy: COLLECT
+      inputs: [ 'Work Address']
+      rules:
+        - when: [ true ]
+          then: '{ "Item": { "Name": "Work Shoes" } }'
+        - when: [ true ]
+          then: '{ "Item": { "Name": "Work Hat" } }'
+        - when: [ true ]
+          then: '{ "Item": { "Name": "Work Shirt" } }'
+        - when: [ false ]
+          then: '{ "Item": { "Name": "Holiday Hat" } }'
+  - name: Customer
+    type: Decision
+    logic:
+      type: DecisionTable
+      hitPolicy: ANY
+      inputs: [ 'Work Address']
+      rules:
+        - when: [ true ]
+          then: '{ "Address": { "Street": "Work Street", "Number": 23 } }'
+        - when: [ false ]
+          then: '{ "Address": { "Street": "Free Time Path", "Number": 123 } }'
+  - name: Mailing Address
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        Customer.Address
+  - name: Delivery Item Names
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        ( Item.Name in `Delivery Items` )

--- a/kie-yard/kie-yard-core/src/test/resources/scorecards/README-health-card.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/scorecards/README-health-card.yml
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Git Repository Completeness"
+expressionLang: jshell
+inputs:
+  - name: "README"
+    type: string
+  - name: "Web Page Link"
+    type: string
+  - name: "Documentation Link"
+    type: string
+elements:
+  - name: Has README.md file
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `README` != null
+  - name: README has link to web page
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `README`.contains( `Web Page Link` )
+  - name: README has a link to documentation
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `README`.contains( `Documentation Link` )
+  - name: README has a title for 'How to contribute'
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `README`.contains( "#How to contribute" )
+  - name: Score
+    type: Decision
+    logic:
+      type: DecisionTable
+      hitPolicy: COLLECT COUNT
+      inputs: [ "true == {0}" ]
+      rules:
+        - [ "Has README.md file" ]
+        - [ "README has link to web page" ]
+        - [ "README has a link to documentation" ]
+        - [ "README has a title for 'How to contribute'" ]

--- a/kie-yard/kie-yard-core/src/test/resources/scorecards/README.md
+++ b/kie-yard/kie-yard-core/src/test/resources/scorecards/README.md
@@ -1,0 +1,27 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
+Not used by any tests at this point. Used as drafts for upcoming features.
+
+Each YaRD yml file is a scorecard and has to return a value "Score".
+Depending on the draft:
+
+* The Score is either a % between 0 and 100.
+* The Score is calculated from previous expressions, each expression has to return true or it is considered a failure
+

--- a/kie-yard/kie-yard-core/src/test/resources/scorecards/branch-responsibilities.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/scorecards/branch-responsibilities.yml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Branch responsibilities"
+expressionLang: jshell
+inputs:
+  - name: "Main POM"
+    type: 'http://myapi.org/jsonSchema.json#POM'
+  - name: "Latest Tag POM"
+    type: 'http://myapi.org/jsonSchema.json#POM'
+elements:
+  - name: Main is set on SNAPSHOT
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Main POM`.version.endsWith("-SNAPSHOT")
+  - name: Main version is higher than latest Tag
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Main POM`.version > `Latest Tag POM`.version
+  - name: Tag is not on SNAPSHOT
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        !`Latest Tag POM`.version.endWith("-SNAPSHOT")
+  - name: Score
+    type: Decision
+    logic:
+      type: DecisionTable
+      hitPolicy: COLLECT COUNT
+      inputs: [ "true == {0}" ] # this is not in the current spec, neither is inserting the values below
+      rules:
+        - [ 'Main is set on SNAPSHOT' ]
+        - [ 'Main version is higher than latest Tag' ]
+        - [ 'Tag is not on SNAPSHOT' ]

--- a/kie-yard/kie-yard-core/src/test/resources/scorecards/drafts/branch-blocked-card.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/scorecards/drafts/branch-blocked-card.yml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Main broken"
+expressionLang: jshell
+inputs:
+  - name: "Creator"
+    type: string
+  - name: "Created"
+    type: datetime
+  - name: "Closed"
+    type: datetime
+  - name: "Severity"
+# How long was branch broken
+# Was the correct protocol followed, what ever that is
+elements:
+  - name: Time Taken to Ack
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Reported` -`Acked`

--- a/kie-yard/kie-yard-core/src/test/resources/scorecards/drafts/closed-prs-card.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/scorecards/drafts/closed-prs-card.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Closed PRs"
+expressionLang: jshell
+inputs:
+  - name: "Creator"
+    type: string
+  - name: "Created"
+    type: datetime
+  - name: "Closed"
+    type: datetime
+  - name: "Severity"
+# Another one for closed PRs?
+# Gap check
+# Reviewers acked
+# Code smells and so on were in check
+elements:
+  - name: Time Taken to Ack
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Reported` -`Acked`

--- a/kie-yard/kie-yard-core/src/test/resources/scorecards/drafts/open-prs-card.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/scorecards/drafts/open-prs-card.yml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Open PRs"
+expressionLang: jshell
+inputs:
+  - name: "Creator"
+    type: string
+  - name: "Created"
+    type: datetime
+  - name: "Closed"
+    type: datetime
+  - name: "Severity"
+# Check they have 2 reviewers set, open - close gap is scored based on length
+# Tests are ran, code smells minimal
+elements:
+  - name: Time Taken to Ack
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Reported` -`Acked`

--- a/kie-yard/kie-yard-core/src/test/resources/scorecards/drafts/weekly-branch-health-card.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/scorecards/drafts/weekly-branch-health-card.yml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Main broken"
+expressionLang: jshell
+inputs:
+  - name: "Creator"
+    type: string
+  - name: "Created"
+    type: datetime
+  - name: "Closed"
+    type: datetime
+  - name: "Severity"
+# Times the nightlies failed
+# Amount of test failures
+# Build failures
+elements:
+  - name: Time Taken to Ack
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Reported` -`Acked`

--- a/kie-yard/kie-yard-core/src/test/resources/scorecards/git-repository-health-card.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/scorecards/git-repository-health-card.yml
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Git Repository Completeness"
+expressionLang: jshell
+inputs:
+  - name: "Repository Data"
+    type: 'http://myapi.org/jsonSchema.json#GitRepositoryData'
+elements:
+  - name: Has Owners
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Git Data`.owners.size > 0
+  - name: Has Description
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        !`Git Data`.description.trim.isEmpty()
+  - name: Code of Conduct is Set
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Git Data`.codeOfConduct != null
+        && !`Git Data`.codeOfConduct.trim.isEmpty()
+  - name: Security Information is Set
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Git Data`.securityInformation != null
+        && !`Git Data`.securityInformation.trim.isEmpty()
+  - name: Weighted Score
+    type: Decision
+    logic:
+      type: DecisionTable
+      hitPolicy: COLLECT
+      inputs: [ "true == {0}" ]
+      outputComponents: [ "Line Score" ]
+      rules:
+        - when: [ 'Has Owners' ]
+          then: 4
+        - when: [ 'Has Description' ]
+          then: 1
+        - when: [ 'Code of Conduct is Set' ]
+          then: 4
+        - when: [ 'Security Information is Set' ]
+          then: 2
+  - name: Score
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        `Weighted Score`.stream.mapToInt(Integer::intValue).sum();

--- a/kie-yard/kie-yard-core/src/test/resources/scorecards/resource-limits-card.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/scorecards/resource-limits-card.yml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Resource Limits"
+expressionLang: jshell
+inputs:
+  - name: "CPU Count"
+    type: number
+  - name: "Memory Use"
+    type: number
+  - name: "Run Started"
+    type: datetime
+  - name: "Run Ended"
+    type: datetime
+elements:
+  - name: Run Time
+    type: Decision
+    logic:
+      type: LiteralExpression
+      # With JShell this does not work, but this can be done with a Java oneliner
+      expression: |
+        `Run Started` -`Run Ended`
+  - name: Fitting profiles
+    type: Decision
+    logic:
+      type: DecisionTable
+      hitPolicy: COLLECT
+      inputs: [ "Run Time", "Memory Use", "CPU Count" ]
+      # This assumes there are set profiles that include the above parameters
+      # How well we meet them is visualized in the score
+      rules:
+        - when: [ '<=30m', '<=20', '<=1' ] # Low profile
+          then: 4
+        - when: [ '<=3h00m', '<=40', '<=1' ] # Medium
+          then: 3
+        - when: [ '<=4h00m', '<=50', '<=1' ] # High
+          then: 2
+        - when: [ '<=2h30m', '<=60', '<=1' ] # Ultra
+          then: 1
+        - when: [ '-', '-', '-' ] # Unacceptable
+          then: 0

--- a/kie-yard/kie-yard-core/src/test/resources/simplified-ticket-score.json
+++ b/kie-yard/kie-yard-core/src/test/resources/simplified-ticket-score.json
@@ -1,0 +1,57 @@
+{
+  "specVersion": "alpha",
+  "kind": "YaRD",
+  "name": "Traffic Violation",
+  "inputs": [
+    {
+      "name": "Bronze Complete",
+      "type": "boolean"
+    },
+    {
+      "name": "Silver Complete",
+      "type": "boolean"
+    },
+    {
+      "name": "Gold Complete",
+      "type": "boolean"
+    }
+  ],
+  "elements": [
+    {
+      "name": "Level",
+      "type": "Decision",
+      "logic": {
+        "type": "DecisionTable",
+        "hitPolicy": "ANY",
+        "inputs": [
+          "Bronze Complete",
+          "Silver Complete",
+          "Gold Complete"
+        ],
+        "outputComponents": [
+          "Level"
+        ],
+        "rules": [
+          [
+            true,
+            true,
+            true,
+            "Gold"
+          ],
+          [
+            true,
+            true,
+            false,
+            "Silver"
+          ],
+          [
+            true,
+            false,
+            false,
+            "Bronze"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/kie-yard/kie-yard-core/src/test/resources/ticket-score-cards.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/ticket-score-cards.yml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: "Level Score"
+inputs:
+  - name: "Bronze Complete"
+    type: boolean
+  - name: "Silver Complete"
+    type: boolean
+  - name: "Gold Complete"
+    type: boolean
+elements:
+  - name: Score
+    type: Decision
+    logic:
+      type: DecisionTable
+      hitPolicy: ANY
+      inputs: [ "Bronze Complete", "Silver Complete", "Gold Complete" ]
+      outputComponents: [ "Score" ]
+      rules:
+        - [ true, true,  true,  10 ]
+        - [ true, true,  false, 20 ]
+        - [ true, false, false, 30 ]

--- a/kie-yard/kie-yard-core/src/test/resources/two-elements-with-duplicate-name.yml
+++ b/kie-yard/kie-yard-core/src/test/resources/two-elements-with-duplicate-name.yml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+specVersion: alpha
+kind: YaRD
+name: 'BasePrice'
+inputs:
+  - name: Age
+    type: number
+elements:
+  - name: Ten
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        10
+  - name: Ten
+    type: Decision
+    logic:
+      type: LiteralExpression
+      expression: |
+        5 + 5 

--- a/kie-yard/pom.xml
+++ b/kie-yard/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.kie</groupId>
+        <artifactId>drools-build-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../build-parent</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-yard</artifactId>
+    <version>999-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>KIE :: Yard - YAML Rules DSL</name>
+    <description>Yet another Rules DSL (YaRD) - A YAML-based domain-specific language for defining business rules</description>
+
+    <url>http://drools.org</url>
+    <inceptionYear>2022</inceptionYear>
+    <organization>
+        <name>JBoss by Red Hat</name>
+        <url>http://www.jboss.org/</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:https://github.com/kiegroup/yard.git</connection>
+        <developerConnection>scm:git:git@github.com:kiegroup/yard.git</developerConnection>
+        <url>https://github.com/kiegroup/yard</url>
+    </scm>
+
+    <developers>
+        <developer>
+            <name>All developers are listed in the KIE GitHub organization</name>
+            <url>https://github.com/orgs/kiegroup/people</url>
+        </developer>
+    </developers>
+
+    <properties>
+
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <version.org.drools>8.44.0.Final</version.org.drools>
+        <version.jackson>2.15.2</version.jackson>
+        <version.jshell>1.1.0</version.jshell>
+        <version.org.glassfish.jakarta.json>2.0.1</version.org.glassfish.jakarta.json>
+    </properties>
+
+    <!-- distributionManagement section -->
+    <distributionManagement>
+        <repository>
+            <id>jboss-releases-repository</id>
+            <name>JBoss Releases Repository</name>
+            <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>jboss-snapshots-repository</id>
+            <name>JBoss Snapshot Repository</name>
+            <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${version.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>${version.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kie</groupId>
+                <artifactId>kie-yard-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-ruleunits-dsl</artifactId>
+                <version>${version.org.drools}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.obermuhlner</groupId>
+                <artifactId>jshell-scriptengine</artifactId>
+                <version>${version.jshell}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>kie-yard-api</module>
+        <module>kie-yard-core</module>
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
     <module>drools-quarkus-extension</module>
     <module>drools-reliability</module>
     <module>drools-drlonyaml-parent</module>
+    <module>kie-yard</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
https://github.com/apache/incubator-kie-issues/issues/2044

Adds in YARD. We need to at least temporally add this into the source codes, since YARD is owned by KIE and this was not moved into the Apache KIE repositories during the move.