### PR TITLE
[incubator-kie-drools-6037] exec-model doesn't populate metadata of declared type

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/TypeMetaData.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/TypeMetaData.java
@@ -18,9 +18,19 @@
  */
 package org.drools.model;
 
+import java.util.List;
 import java.util.Map;
 
 public interface TypeMetaData extends NamedModelItem {
     Class<?> getType();
     Map<String, AnnotationValue[]> getAnnotations();
+
+    List<FieldMetaData> getFields();
+
+    interface FieldMetaData {
+
+        String getFieldName();
+
+        Map<String, AnnotationValue[]> getAnnotations();
+    }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/TypeMetaDataImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/TypeMetaDataImpl.java
@@ -19,8 +19,10 @@
 package org.drools.model.impl;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.drools.model.AnnotationValue;
@@ -34,6 +36,7 @@ public class TypeMetaDataImpl implements TypeMetaData, ModelComponent {
     private final String pkg;
     private final String name;
     private final Map<String, AnnotationValue[]> annotations = new HashMap<>();
+    private final Map<String, FieldMetaData> fields = new HashMap<>();
 
     public TypeMetaDataImpl( Class<?> type ) {
         this.type = type;
@@ -61,10 +64,36 @@ public class TypeMetaDataImpl implements TypeMetaData, ModelComponent {
         return annotations;
     }
 
+    @Override
+    public List<FieldMetaData> getFields() {
+        return new ArrayList<>(fields.values());
+    }
+
     public TypeMetaDataImpl addAnnotation( String name, AnnotationValue... values) {
         annotations.put(name, values);
         return this;
     }
+
+    public TypeMetaDataImpl addField(String fieldName) {
+        fields.computeIfAbsent(fieldName, FieldMetaDataImpl::new);
+        return this;
+    }
+
+    public TypeMetaDataImpl addFieldAnnotation(String fieldName, String annotationName, AnnotationValue... values) {
+        FieldMetaDataImpl fieldMetaData = (FieldMetaDataImpl) fields.computeIfAbsent(fieldName, FieldMetaDataImpl::new);
+        fieldMetaData.addAnnotation(annotationName, values);
+        return this;
+    }
+
+    // DSL-style instance methods for fluent API
+    public TypeMetaDataImpl withField(String fieldName) {
+        return addField(fieldName);
+    }
+
+    public TypeMetaDataImpl withFieldAnnotation(String fieldName, String annotationName, AnnotationValue... values) {
+        return addFieldAnnotation(fieldName, annotationName, values);
+    }
+
 
     @Override
     public boolean isEqualTo( ModelComponent o ) {
@@ -91,5 +120,29 @@ public class TypeMetaDataImpl implements TypeMetaData, ModelComponent {
         }
 
         return true;
+    }
+
+    public static class FieldMetaDataImpl implements FieldMetaData {
+        private final String fieldName;
+        private final Map<String, AnnotationValue[]> annotations = new HashMap<>();
+
+        public FieldMetaDataImpl(String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        @Override
+        public Map<String, AnnotationValue[]> getAnnotations() {
+            return annotations;
+        }
+
+        public FieldMetaDataImpl addAnnotation(String name, AnnotationValue... values) {
+            annotations.put(name, values);
+            return this;
+        }
     }
 }

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrAnnotationDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrAnnotationDefinition.java
@@ -42,6 +42,8 @@ import static org.drools.model.codegen.execmodel.generator.declaredtype.POJOGene
 
 public class DescrAnnotationDefinition implements AnnotationDefinition {
 
+    public static final String BUILTIN_ANNOTATION_PACKAGE = "org.kie.api.definition.type.";
+
     static final String VALUE = "value";
 
     private static final Map<String, Class<?>> annotationMapping = new HashMap<>();

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrFieldDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrFieldDefinition.java
@@ -40,6 +40,7 @@ public class DescrFieldDefinition implements FieldDefinition {
     private boolean isOverride = false;
 
     private final Map<String, AnnotationDefinition> annotations = new HashMap<>();
+    private final Map<String, Object> fieldMetaData = new HashMap<>();
 
     public DescrFieldDefinition(String fieldName, String objectType, String initExpr) {
         this.fieldName = fieldName;
@@ -135,6 +136,14 @@ public class DescrFieldDefinition implements FieldDefinition {
     public DescrFieldDefinition setOverride( boolean override ) {
         isOverride = override;
         return this;
+    }
+
+    public Map<String, Object> getFieldMetaData() {
+        return fieldMetaData;
+    }
+
+    public void addFieldMetaData(String key, Object value) {
+        fieldMetaData.put(key, value);
     }
 
     @Override

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrTypeDefinition.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/declaredtype/DescrTypeDefinition.java
@@ -115,7 +115,7 @@ public class DescrTypeDefinition implements TypeDefinition {
                 annotations.add(DescrAnnotationDefinition.fromDescr(typeResolver, ann));
             } catch (UnkownAnnotationClassException e) {
                 // Store non-defined custom annotations as metadata
-                // class level built-in annotations are not added here. Rather added in TypeDeclarationUtil at the later phase
+                // Class level built-in annotations are not added here; they are added in TypeDeclarationUtil at a later phase.
                 classMetaData.put(ann.getName(), ann.getSingleValue());
             } catch (UnknownKeysInAnnotation e) {
                 // Add build errors for unknown annotation properties

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
@@ -34,18 +33,20 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.drools.base.rule.IndexableConstraint;
+import org.drools.base.rule.constraint.AlphaNodeFieldConstraint;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.AlphaNode;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
-import org.drools.base.rule.IndexableConstraint;
-import org.drools.base.rule.constraint.AlphaNodeFieldConstraint;
 import org.drools.model.codegen.execmodel.domain.Address;
 import org.drools.model.codegen.execmodel.domain.Person;
 import org.drools.model.codegen.execmodel.domain.Result;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
+import org.kie.api.builder.Message;
+import org.kie.api.builder.Results;
 import org.kie.api.definition.type.FactField;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
@@ -600,14 +601,14 @@ public class DeclaredTypesTest extends BaseModelTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testNonDefinedCustomAnnotation(RUN_TYPE runType) {
+    void testNonDefinedCustomAnnotation(RUN_TYPE runType) {
         String str = "package org.example.custom; \n" +
                 "import " + Date.class.getCanonicalName() + ";\n" +
                 "import " + Address.class.getCanonicalName() + ";\n" +
                 "\n" +
                 "declare Person\n" +
                 "    @xxxAuthor( Bob )\n" +
-                "    @xxxDateOfCreation( 01-Feb-2009 )\n" +
+                "    @role(event)\n" + // @role is a built-in annotation
                 "\n" +
                 "    name : String @key @xxxMaxLength( 30 )\n" + // @key is a built-in annotation
                 "    dateOfBirth : Date\n" +
@@ -620,24 +621,22 @@ public class DeclaredTypesTest extends BaseModelTest {
         FactType person = kBase.getFactType( "org.example.custom", "Person" );
 
         Map<String, Object> classMetaData = person.getMetaData();
-        System.out.println("== Class Meta Data ==");
-        System.out.println(classMetaData);
         assertThat(classMetaData).isNotNull();
         assertThat(classMetaData.get("xxxAuthor")).isEqualTo("Bob");
-        assertThat(classMetaData.get("xxxDateOfCreation")).isEqualTo("01-Feb-2009");
+        assertThat(classMetaData.containsKey("role")).isTrue();
+        assertThat(classMetaData.get("event")).isNull();
 
         FactField field = person.getField("name" );
         Map<String, Object> fieldMetaData = field.getMetaData();
-        System.out.println("== Field Meta Data ==");
-        System.out.println(fieldMetaData);
         assertThat(fieldMetaData).isNotNull();
         assertThat(fieldMetaData.get("xxxMaxLength")).isEqualTo("30");
+        assertThat(fieldMetaData.containsKey("key")).isTrue();
         assertThat(fieldMetaData.get("key")).isNull();
     }
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testDefinedCustomAnnotation(RUN_TYPE runType) throws Exception {
+    void testDefinedCustomAnnotation(RUN_TYPE runType) throws Exception {
         String str = "package org.example.custom; \n" +
                 "import " + Date.class.getCanonicalName() + ";\n" +
                 "import " + Address.class.getCanonicalName() + ";\n" +
@@ -658,22 +657,21 @@ public class DeclaredTypesTest extends BaseModelTest {
         FactType person = kBase.getFactType( "org.example.custom", "Person" );
 
         Class<?> factClass = person.getFactClass();
-        System.out.println("== Person Fact Class ==");
-        System.out.println(factClass.getName());
-        System.out.println(Arrays.stream(factClass.getAnnotations()).toList());
+        MyAuthor classAnnotation = factClass.getAnnotation(MyAuthor.class);
+        assertThat(classAnnotation).isNotNull();
+        assertThat(classAnnotation.value()).isEqualTo("Bob");
+
         Field factField = factClass.getDeclaredField("name");
-        System.out.println("  name : " + Arrays.toString(factField.getAnnotations()));
+        MyMaxLength fieldAnnotation = factField.getAnnotation(MyMaxLength.class);
+        assertThat(fieldAnnotation).isNotNull();
+        assertThat(fieldAnnotation.value()).isEqualTo(30);
 
         Map<String, Object> classMetaData = person.getMetaData();
-        System.out.println("== Class Meta Data ==");
-        System.out.println(classMetaData);
-        assertThat(classMetaData).as("Defined Annotation should not be stored in metaData").isNull();
+        assertThat(classMetaData).as("Defined custom annotation should not be stored in metaData").isNull();
 
         FactField field = person.getField("name" );
         Map<String, Object> fieldMetaData = field.getMetaData();
-        System.out.println("== Field Meta Data ==");
-        System.out.println(fieldMetaData);
-        assertThat(fieldMetaData).as("Defined Annotation should not be stored in metaData").isNull();
+        assertThat(fieldMetaData).as("Defined custom annotation should not be stored in metaData").isNull();
     }
 
     @Retention(RetentionPolicy.RUNTIME)
@@ -686,5 +684,31 @@ public class DeclaredTypesTest extends BaseModelTest {
     @Target({ElementType.FIELD})
     public @interface MyMaxLength {
         int value();
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void testDefinedCustomAnnotationWithUnknownProperty(RUN_TYPE runType) {
+        String str = "package org.example.custom; \n" +
+                "import " + Date.class.getCanonicalName() + ";\n" +
+                "import " + Address.class.getCanonicalName() + ";\n" +
+                "import " + MyAuthor.class.getCanonicalName() + ";\n" +
+                "import " + MyMaxLength.class.getCanonicalName() + ";\n" +
+                "\n" +
+                "declare Person\n" +
+                "    @MyAuthor( yyy = \"Bob\" )\n" +
+                "\n" +
+                "    name : String @MyMaxLength( zzz = 30 )\n" +
+                "    dateOfBirth : Date\n" +
+                "    address : Address\n" +
+                "end";
+
+        Results results = createKieBuilder(runType, str).getResults();
+
+        assertThat(results.getMessages(Message.Level.ERROR))
+                .hasSize(2)
+                .extracting(Message::getText)
+                .containsExactlyInAnyOrder("Unknown annotation property yyy",
+                                           "Unknown annotation property zzz");
     }
 }

--- a/drools-model/drools-model-codegen/src/test/resources/logback-test.xml
+++ b/drools-model/drools-model-codegen/src/test/resources/logback-test.xml
@@ -34,7 +34,7 @@
   <logger name="org.kie" level="warn"/>
   <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
   <!--<logger name="org.drools.model.codegen.execmodel.generator.expressiontyper" level="debug"/>-->
-    <logger name="org.drools.model.codegen.execmodel" level="debug"/>
+<!--    <logger name="org.drools.model.codegen.execmodel" level="debug"/>-->
   <logger name="org.drools.ancompiler" level="info"/>
 <!--  <logger name="org.drools.drl.parser.DrlParser" level="debug"/>-->
 

--- a/drools-model/drools-model-codegen/src/test/resources/logback-test.xml
+++ b/drools-model/drools-model-codegen/src/test/resources/logback-test.xml
@@ -34,7 +34,7 @@
   <logger name="org.kie" level="warn"/>
   <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
   <!--<logger name="org.drools.model.codegen.execmodel.generator.expressiontyper" level="debug"/>-->
-<!--    <logger name="org.drools.model.codegen.execmodel" level="debug"/>-->
+    <logger name="org.drools.model.codegen.execmodel" level="debug"/>
   <logger name="org.drools.ancompiler" level="info"/>
 <!--  <logger name="org.drools.drl.parser.DrlParser" level="debug"/>-->
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/TypeDeclarationUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/TypeDeclarationUtil.java
@@ -65,9 +65,14 @@ public class TypeDeclarationUtil {
     }
 
     private static void wireMetaTypeAnnotations( TypeMetaData metaType, TypeDeclaration typeDeclaration ) {
+        ClassDefinition classDef = typeDeclaration.getTypeClassDef();
         for (Map.Entry<String, AnnotationValue[]> ann : metaType.getAnnotations().entrySet()) {
-            switch (ann.getKey()) {
+            String annotationName = ann.getKey();
+            boolean isKnownAnnotation = false;
+            
+            switch (annotationName) {
                 case "role":
+                    isKnownAnnotation = true;
                     for (AnnotationValue annVal : ann.getValue()) {
                         if (annVal.getKey().equals( "value" ) && annVal.getValue().equals( "event" )) {
                             typeDeclaration.setRole( Role.Type.EVENT );
@@ -75,6 +80,7 @@ public class TypeDeclarationUtil {
                     }
                     break;
                 case "duration":
+                    isKnownAnnotation = true;
                     for (AnnotationValue annVal : ann.getValue()) {
                         if (annVal.getKey().equals( "value" )) {
                             wireDurationAccessor( annVal.getValue().toString(), typeDeclaration );
@@ -82,6 +88,7 @@ public class TypeDeclarationUtil {
                     }
                     break;
                 case "timestamp":
+                    isKnownAnnotation = true;
                     for (AnnotationValue annVal : ann.getValue()) {
                         if (annVal.getKey().equals( "value" )) {
                             wireTimestampAccessor( annVal.getValue().toString(), typeDeclaration );
@@ -89,6 +96,7 @@ public class TypeDeclarationUtil {
                     }
                     break;
                 case "expires":
+                    isKnownAnnotation = true;
                     for (AnnotationValue annVal : ann.getValue()) {
                         if (annVal.getKey().equals( "value" )) {
                             long offset = TimeIntervalParser.parseSingle( annVal.getValue().toString() );
@@ -100,11 +108,26 @@ public class TypeDeclarationUtil {
                     }
                     break;
                 case "propertyReactive":
+                    isKnownAnnotation = true;
                     typeDeclaration.setPropertyReactive( true );
                     break;
                 case "classReactive":
+                    isKnownAnnotation = true;
                     typeDeclaration.setPropertyReactive( false );
                     break;
+            }
+            
+            // For non-defined custom annotations, add them as metadata to the ClassDefinition
+            if (!isKnownAnnotation && classDef != null) {
+                // Get the value from the annotation values
+                Object value = null;
+                for (AnnotationValue annVal : ann.getValue()) {
+                    if (annVal.getKey().equals("value")) {
+                        value = annVal.getValue();
+                        break;
+                    }
+                }
+                classDef.addMetaData(annotationName, value);
             }
         }
     }


### PR DESCRIPTION
- https://github.com/apache/incubator-kie-drools/issues/6037

Sequence:
  
1. `DescrTypeDefinition` : Reads `TypeDeclarationDescr.getAnnotations()` and `TypeFieldDescr.getAnnotations()`. Stores the information to `DescrTypeDefinition.classMetaData` and `DescrFieldDefinition.fieldMetaData`
2. `POJOGenerator` : Writes `TypeMetaData` expressions via DSL calls in the generated Model source code.
3. `TypeDeclarationUtil` : On package build, reads `TypeMetaData` and populate metaData of `ClassDefinition` and `FieldDefinition`