### PR TITLE
[incubator-kie-issues#2064] Fixing usage of duplicated Input Data nodes with inherited decisions

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -465,9 +465,10 @@ public class DMNCompilerImpl implements DMNCompiler {
                                            model,
                                            null,
                                            null,
-                                           Msg.REQ_INPUT_NOT_FOUND_FOR_NODE,
+                                           Msg.DETAILED_REQ_INPUT_NOT_FOUND_FOR_NODE,
                                            id,
-                                           node.getName() );
+                                           node.getName(),
+                                           node.getModelNamespace());
                 }
             } else if ( ir.getRequiredDecision() != null ) {
                 String id = getId( ir.getRequiredDecision() );

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/UnnamedImportUtils.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/UnnamedImportUtils.java
@@ -45,31 +45,32 @@ public class UnnamedImportUtils {
         return false;
     }
 
-    public static void processMergedModel(DMNModelImpl parentModel, DMNModelImpl mergedModel) {
+    public static void processMergedModel(DMNModelImpl importingModel, DMNModelImpl importedModel) {
         // incubator-kie-issues#852: The idea is to not treat the anonymous models as import, but to "merge" them with original opne,
         // Here we try to put all the definitions from the "imported" model inside the parent one
-        Definitions parentDefinitions = parentModel.getDefinitions();
-        Definitions mergedDefinitions = mergedModel.getDefinitions();
+        Definitions importingDefinitions = importingModel.getDefinitions();
+        Definitions importedDefinitions = importedModel.getDefinitions();
 
-        mergeDefinitions(parentDefinitions, mergedDefinitions);
+        mergeDefinitions(importingDefinitions, importedDefinitions);
 
-        mergedModel.getTypeRegistry().getTypes().forEach((s, stringDMNTypeMap) ->
+        importedModel.getTypeRegistry().getTypes().forEach((s, stringDMNTypeMap) ->
                                                                  stringDMNTypeMap.values().
-                                                                         forEach(dmnType -> parentModel.getTypeRegistry().registerType(dmnType)));
-        mergedModel.getDecisions().forEach(parentModel::addDecision);
-        mergedModel.getImportAliasesForNS().forEach((s, qName) -> parentModel.setImportAliasForNS(s, qName.getNamespaceURI(), qName.getLocalPart()));
+                                                                         forEach(dmnType -> importingModel.getTypeRegistry().registerType(dmnType)));
+        importedModel.getDecisions().forEach(importingModel::addDecision);
+        importedModel.getInputs().forEach(importingModel::addInput);
+        importedModel.getImportAliasesForNS().forEach((s, qName) -> importingModel.setImportAliasForNS(s, qName.getNamespaceURI(), qName.getLocalPart()));
     }
 
-    public static void mergeDefinitions(Definitions parentDefinitions, Definitions mergedDefinitions) {
+    public static void mergeDefinitions(Definitions importingDefinitions, Definitions importedDefinitions) {
         // incubator-kie-issues#852: The idea is to not treat the anonymous models as import, but to "merge" them with original one,
         // Here we try to put all the definitions from the "imported" model inside the parent one
-        parentDefinitions.getArtifact().addAll(mergedDefinitions.getArtifact());
-        addIfNotPresent(parentDefinitions.getDecisionService(), mergedDefinitions.getDecisionService(), DecisionService.class);
-        addIfNotPresent(parentDefinitions.getBusinessContextElement(), mergedDefinitions.getBusinessContextElement(), BusinessContextElement.class);
-        addIfNotPresent(parentDefinitions.getDrgElement(), mergedDefinitions.getDrgElement(), DRGElement.class);
-        addIfNotPresent(parentDefinitions.getImport(), mergedDefinitions.getImport(), Import.class);
-        addIfNotPresent(parentDefinitions.getItemDefinition(), mergedDefinitions.getItemDefinition(), ItemDefinition.class);
-        mergedDefinitions.getChildren().forEach(parentDefinitions::addChildren);
+        importingDefinitions.getArtifact().addAll(importedDefinitions.getArtifact());
+        addIfNotPresent(importingDefinitions.getDecisionService(), importedDefinitions.getDecisionService(), DecisionService.class);
+        addIfNotPresent(importingDefinitions.getBusinessContextElement(), importedDefinitions.getBusinessContextElement(), BusinessContextElement.class);
+        addIfNotPresent(importingDefinitions.getDrgElement(), importedDefinitions.getDrgElement(), DRGElement.class);
+        addIfNotPresent(importingDefinitions.getImport(), importedDefinitions.getImport(), Import.class);
+        addIfNotPresent(importingDefinitions.getItemDefinition(), importedDefinitions.getItemDefinition(), ItemDefinition.class);
+        importedDefinitions.getChildren().forEach(importingDefinitions::addChildren);
     }
 
     static <T extends NamedElement> void addIfNotPresent(Collection<T> target, Collection<T> source, Class expectedClass) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNModelImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNModelImpl.java
@@ -264,7 +264,7 @@ public class DMNModelImpl
     }
 
     private List<String> computeDRGElementModelLocalId(DMNNode node) {
-        // incubator-kie-issues#852: The idea is to not treat the anonymous models as import, but to "merge" them with original opne,
+        // incubator-kie-issues#852: The idea is to not treat the anonymous models as import, but to "merge" them with original one,
         // Here, if the node comes from an unnamed imported model, then it is stored only with its id, to be looked for
         // as if defined in the model itself
         if (node.getModelNamespace().equals(definitions.getNamespace())) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
@@ -31,6 +31,7 @@ public final class Msg {
     public static final Message2 REQ_INPUT_NOT_FOUND_FOR_DS                          = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required input '%s' not found for Decision Service '%s', invoking using null.");
     public static final Message2 REFERENCE_NOT_FOUND_FOR_DS                          = new Message2( DMNMessageType.REQ_NOT_FOUND, "Element reference '%s' not resolved for Decision Service '%s'.");
     public static final Message2 REQ_INPUT_NOT_FOUND_FOR_NODE                        = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required input '%s' not found on node '%s'" );
+    public static final Message3 DETAILED_REQ_INPUT_NOT_FOUND_FOR_NODE               = new Message3( DMNMessageType.REQ_NOT_FOUND, "Required input '%s' not found for node '%s' from model with namespace '%s'" );
     public static final Message3 OUTPUT_NOT_FOUND_FOR_DS                             = new Message3( DMNMessageType.REQ_NOT_FOUND, "Decision service '%s' does not define any output decisions in top segment (outputDecision count: %s, encapsulatedDecision count: %s)" );
     public static final Message2 REQ_DECISION_NOT_FOUND_FOR_NODE                     = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required Decision '%s' not found on node '%s'" );
     public static final Message2 REQ_BKM_NOT_FOUND_FOR_NODE                          = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required Business Knowledge Model '%s' not found on node '%s'" );

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/imports/two-input-data-same-name/ImportedModel.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/imports/two-input-data-same-name/ImportedModel.dmn
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
 <definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
              xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="https://kie.org/dmn/extensions/1.0"
              expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/" namespace="https://kie.org/dmn/_6B0AD797-1CA7-45BD-8942-791F36526A89" id="_1F39D6DF-8CA8-4EE7-847A-2DC1AD057145"

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/imports/two-input-data-same-name/ImportedModel.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/imports/two-input-data-same-name/ImportedModel.dmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="https://kie.org/dmn/extensions/1.0"
+             expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/" namespace="https://kie.org/dmn/_6B0AD797-1CA7-45BD-8942-791F36526A89" id="_1F39D6DF-8CA8-4EE7-847A-2DC1AD057145"
+             name="DMN_CA451E6C-14B2-4CA6-B8C4-C5BBCBD2FB40">
+  <decision name="a decision" id="_6A0ACE83-A371-4BB1-A7D3-92524A14183E">
+    <variable name="a decision" id="_E48D22A2-FCC4-422D-B2A4-7EE24028BD7A" typeRef="number" />
+    <informationRequirement id="_80E3807D-E1C7-4258-B7DC-678CC0635B07">
+      <requiredInput href="#_0D2BA05B-1392-455A-865B-F02BAC981EB9" />
+    </informationRequirement>
+    <literalExpression id="_BC27FD0A-A1D3-4E11-A79D-51C64311E47F" typeRef="number" label="a decision">
+      <text>a input</text>
+    </literalExpression>
+  </decision>
+  <inputData name="a input" id="_0D2BA05B-1392-455A-865B-F02BAC981EB9">
+    <variable name="a input" id="_1CACC471-D5EA-43F7-A9A2-F21E62FE797A" typeRef="number" />
+  </inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_2DFB8915-F5F1-4DE0-A374-E60473A00616" name="Default DRD" useAlternativeInputDataShape="false">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths />
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="_51D6A636-7A68-478A-B8C0-AA693668312B" dmnElementRef="_6A0ACE83-A371-4BB1-A7D3-92524A14183E" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="540" y="60" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_5F408C40-D04E-4B99-96BA-C34010FEE69C" dmnElementRef="_0D2BA05B-1392-455A-865B-F02BAC981EB9" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="280" y="60" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="_4066B0BD-EE5A-4E55-8589-80FE5A701208" dmnElementRef="_80E3807D-E1C7-4258-B7DC-678CC0635B07" sourceElement="_5F408C40-D04E-4B99-96BA-C34010FEE69C" targetElement="_51D6A636-7A68-478A-B8C0-AA693668312B">
+        <di:waypoint x="360" y="100" />
+        <di:waypoint x="540" y="100" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/imports/two-input-data-same-name/ImportingModel.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/imports/two-input-data-same-name/ImportingModel.dmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="https://kie.org/dmn/extensions/1.0"
+             expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/"
+             namespace="https://kie.org/dmn/_7CBF2741-CA67-4979-A383-49D787FB3642" id="_BCC46F98-A5D0-4CBA-AD35-BA91EC453664" name="DMN_5AE0999E-35B2-45C1-9B02-B9413CA3442C" xmlns:included0="https://kie.org/dmn/_6B0AD797-1CA7-45BD-8942-791F36526A89">
+  <import id="_23C3A6BD-C36F-4C16-AD9F-AD6D666011E0" name="" importType="https://www.omg.org/spec/DMN/20240513/MODEL/" namespace="https://kie.org/dmn/_6B0AD797-1CA7-45BD-8942-791F36526A89" locationURI="./ImportedModel.dmn" />
+  <decision name="a decision2" id="_430E2045-651C-4921-94EB-A1DCFE642B1C">
+    <variable name="a decision2" id="_C68ACE62-8B51-4795-B305-54E99620380B" typeRef="number" />
+    <informationRequirement id="_F3D8BE91-64C2-4E7C-96F9-7E42902FBEE2">
+      <requiredDecision href="https://kie.org/dmn/_6B0AD797-1CA7-45BD-8942-791F36526A89#_6A0ACE83-A371-4BB1-A7D3-92524A14183E" />
+    </informationRequirement>
+    <informationRequirement id="_2FC4FB35-AC0F-440A-BDD8-3E597F90F48A">
+      <requiredInput href="#_B63E3399-D6C7-4C82-9D21-876A0206D067" />
+    </informationRequirement>
+    <literalExpression id="_BC27FD0A-A1D3-4E11-A79D-51C64311E47E" typeRef="number" label="a decision2">
+      <text>a input + a decision</text>
+    </literalExpression>
+  </decision>
+  <inputData name="a input" id="_B63E3399-D6C7-4C82-9D21-876A0206D067">
+    <variable name="a input" id="_03EE467E-B0CC-400D-B506-84060E97D30A" typeRef="number" />
+  </inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_0CD18BAA-5314-4D91-B2BB-672CFD6AE270" name="Default DRD" useAlternativeInputDataShape="false">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_BC27FD0A-A1D3-4E11-A79D-51C64311E47E">
+            <kie:width>190</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="_4D27D2B5-A69A-46FB-9482-9B912681F674" dmnElementRef="_430E2045-651C-4921-94EB-A1DCFE642B1C" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="460" y="-20" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_61FBA3EE-F070-42E9-8234-AC83E0E2CC35" dmnElementRef="_B63E3399-D6C7-4C82-9D21-876A0206D067" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="340" y="140" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_85564DD0-BA58-4F26-B470-9C343F76994C" dmnElementRef="included0:_6A0ACE83-A371-4BB1-A7D3-92524A14183E">
+        <dc:Bounds x="580" y="140" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_E54F28ED-9C08-4C8A-A7D1-B5A192E09EA0" dmnElementRef="included0:_0D2BA05B-1392-455A-865B-F02BAC981EB9">
+        <dc:Bounds x="580" y="280" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="_D9B64536-F1A1-4AB8-AE4E-E0B1C3FA4EE4" dmnElementRef="_F3D8BE91-64C2-4E7C-96F9-7E42902FBEE2" sourceElement="_85564DD0-BA58-4F26-B470-9C343F76994C" targetElement="_4D27D2B5-A69A-46FB-9482-9B912681F674">
+        <di:waypoint x="660" y="180" />
+        <di:waypoint x="540" y="60" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="_E8FEC5D5-6148-4FBF-AAD7-681749278E74" dmnElementRef="_2FC4FB35-AC0F-440A-BDD8-3E597F90F48A" sourceElement="_61FBA3EE-F070-42E9-8234-AC83E0E2CC35" targetElement="_4D27D2B5-A69A-46FB-9482-9B912681F674">
+        <di:waypoint x="420" y="180" />
+        <di:waypoint x="540" y="60" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/imports/two-input-data-same-name/ImportingModel.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/imports/two-input-data-same-name/ImportingModel.dmn
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
 <definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
              xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="https://kie.org/dmn/extensions/1.0"
              expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/"


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2064

This PR:

1. add InputData from imported models inside importing ones, as per Decisions
2. create ad-hoc models and tests
3. improve message in case of missing inputdata at compile time

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
