### PR TITLE
[NO ISSUE] Remove getknowledgebase usages

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/AgendaFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaFactory.java
@@ -18,8 +18,9 @@
  */
 package org.drools.core.common;
 
+import org.drools.core.impl.InternalRuleBase;
 
 public interface AgendaFactory {
 
-    InternalAgenda createAgenda(InternalWorkingMemory workingMemory);
+    InternalAgenda createAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory);
 }

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
@@ -256,21 +256,15 @@ public interface AgendaGroupsManager extends Externalizable {
             this.kieBase = kieBase;
             // stacked agenda groups are supported only for InternalWorkingMemory
             this.workingMemory = workingMemory;
-            if (this.mainAgendaGroup == null) {
-                initMainAgendaGroup(kieBase);
-            }
+            this.mainAgendaGroup = agendaGroupFactory.createAgendaGroup( InternalAgendaGroup.MAIN, kieBase);
+			this.agendaGroups.put( InternalAgendaGroup.MAIN, this.mainAgendaGroup );
+			this.focusStack.add( this.mainAgendaGroup );
             this.mainAgendaGroup.setReteEvaluator( workingMemory );
         }
 
         @Override
         public InternalAgendaGroup getMainAgendaGroup() {
             return mainAgendaGroup;
-        }
-
-        private void initMainAgendaGroup(InternalRuleBase kieBase) {
-            this.mainAgendaGroup = agendaGroupFactory.createAgendaGroup( InternalAgendaGroup.MAIN, kieBase);
-            this.agendaGroups.put( InternalAgendaGroup.MAIN, this.mainAgendaGroup );
-            this.focusStack.add( this.mainAgendaGroup );
         }
 
         private boolean isEmpty() {

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
@@ -256,9 +256,11 @@ public interface AgendaGroupsManager extends Externalizable {
             this.kieBase = kieBase;
             // stacked agenda groups are supported only for InternalWorkingMemory
             this.workingMemory = workingMemory;
-            this.mainAgendaGroup = agendaGroupFactory.createAgendaGroup( InternalAgendaGroup.MAIN, kieBase);
-			this.agendaGroups.put( InternalAgendaGroup.MAIN, this.mainAgendaGroup );
-			this.focusStack.add( this.mainAgendaGroup );
+            if (this.mainAgendaGroup == null) {
+                this.mainAgendaGroup = agendaGroupFactory.createAgendaGroup( InternalAgendaGroup.MAIN, kieBase);
+				this.agendaGroups.put( InternalAgendaGroup.MAIN, this.mainAgendaGroup );
+				this.focusStack.add( this.mainAgendaGroup );
+            }
             this.mainAgendaGroup.setReteEvaluator( workingMemory );
         }
 

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
@@ -79,9 +79,8 @@ public interface AgendaGroupsManager extends Externalizable {
 
     InternalAgendaGroup getMainAgendaGroup();
 
-    static AgendaGroupsManager create(InternalWorkingMemory workingMemory) {
-        InternalRuleBase kBase = workingMemory.getKnowledgeBase();
-        return kBase.hasMultipleAgendaGroups() || !kBase.getProcesses().isEmpty() ? new StackedAgendaGroupsManager(workingMemory) : new SimpleAgendaGroupsManager(workingMemory);
+    static AgendaGroupsManager create(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
+        return kieBase.hasMultipleAgendaGroups() || !kieBase.getProcesses().isEmpty() ? new StackedAgendaGroupsManager(kieBase, workingMemory) : new SimpleAgendaGroupsManager(kieBase, workingMemory);
     }
 
     class SimpleAgendaGroupsManager implements AgendaGroupsManager {
@@ -90,9 +89,9 @@ public interface AgendaGroupsManager extends Externalizable {
 
         public SimpleAgendaGroupsManager() { }
 
-        public SimpleAgendaGroupsManager(ReteEvaluator reteEvaluator) {
+        public SimpleAgendaGroupsManager(InternalRuleBase kieBase, ReteEvaluator reteEvaluator) {
             this.reteEvaluator = reteEvaluator;
-            this.mainAgendaGroup = RuntimeComponentFactory.get().getAgendaGroupFactory().createAgendaGroup(InternalAgendaGroup.MAIN, reteEvaluator.getKnowledgeBase());
+            this.mainAgendaGroup = RuntimeComponentFactory.get().getAgendaGroupFactory().createAgendaGroup(InternalAgendaGroup.MAIN, kieBase);
             this.mainAgendaGroup.setReteEvaluator(reteEvaluator);
         }
 
@@ -248,15 +247,17 @@ public interface AgendaGroupsManager extends Externalizable {
         private Deque<InternalAgendaGroup> focusStack = new ArrayDeque<>();
         private InternalAgendaGroup mainAgendaGroup;
         private InternalWorkingMemory workingMemory;
+		private InternalRuleBase kieBase;
 
         public StackedAgendaGroupsManager() { }
 
-        public StackedAgendaGroupsManager(InternalWorkingMemory workingMemory) {
+        public StackedAgendaGroupsManager(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
             this.agendaGroupFactory = RuntimeComponentFactory.get().getAgendaGroupFactory();
+            this.kieBase = kieBase;
             // stacked agenda groups are supported only for InternalWorkingMemory
             this.workingMemory = workingMemory;
             if (this.mainAgendaGroup == null) {
-                initMainAgendaGroup(workingMemory.getKnowledgeBase());
+                initMainAgendaGroup(kieBase);
             }
             this.mainAgendaGroup.setReteEvaluator( workingMemory );
         }
@@ -266,8 +267,8 @@ public interface AgendaGroupsManager extends Externalizable {
             return mainAgendaGroup;
         }
 
-        private void initMainAgendaGroup(InternalRuleBase kBase) {
-            this.mainAgendaGroup = agendaGroupFactory.createAgendaGroup( InternalAgendaGroup.MAIN, kBase);
+        private void initMainAgendaGroup(InternalRuleBase kieBase) {
+            this.mainAgendaGroup = agendaGroupFactory.createAgendaGroup( InternalAgendaGroup.MAIN, kieBase);
             this.agendaGroups.put( InternalAgendaGroup.MAIN, this.mainAgendaGroup );
             this.focusStack.add( this.mainAgendaGroup );
         }
@@ -401,7 +402,7 @@ public interface AgendaGroupsManager extends Externalizable {
 
         @Override
         public InternalAgendaGroup getAgendaGroup(final String name) {
-            return getAgendaGroup( name, workingMemory == null ? null : workingMemory.getKnowledgeBase() );
+            return getAgendaGroup( name, workingMemory == null ? null : kieBase);
         }
 
         @Override

--- a/drools-core/src/main/java/org/drools/core/common/EntryPointFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/EntryPointFactory.java
@@ -20,11 +20,12 @@ package org.drools.core.common;
 
 import org.drools.base.rule.EntryPointId;
 import org.drools.core.EntryPointsManager;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
 
 public interface EntryPointFactory {
 
-    InternalWorkingMemoryEntryPoint createEntryPoint(EntryPointNode addedNode, EntryPointId id, ReteEvaluator reteEvaluator);
+    InternalWorkingMemoryEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, EntryPointId id, EntryPointNode addedNode);
 
-    EntryPointsManager createEntryPointsManager(ReteEvaluator reteEvaluator);
+    EntryPointsManager createEntryPointsManager(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator);
 }

--- a/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
@@ -114,9 +114,7 @@ public interface ReteEvaluator extends ValueResolver {
 
     SessionClock getSessionClock();
 
-    default boolean isSequential() {
-        return getKnowledgeBase().getRuleBaseConfiguration().isSequential();
-    }
+    boolean isSequential();
 
     default void startOperation(InternalOperationType operationType) { }
     default void endOperation(InternalOperationType operationType) { }

--- a/drools-core/src/main/java/org/drools/core/concurrent/AbstractGroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/AbstractGroupEvaluator.java
@@ -20,6 +20,7 @@ package org.drools.core.concurrent;
 
 import org.drools.core.common.ActivationsManager;
 import org.drools.core.common.InternalAgendaGroup;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.RuleAgendaItem;
 import org.drools.core.rule.consequence.KnowledgeHelper;
 import org.kie.api.runtime.rule.AgendaFilter;
@@ -33,9 +34,12 @@ public abstract class AbstractGroupEvaluator implements GroupEvaluator {
 
     private boolean haltEvaluation;
 
-    public AbstractGroupEvaluator(ActivationsManager activationsManager) {
-        this.activationsManager = activationsManager;
-        this.sequential = activationsManager.getReteEvaluator().getKnowledgeBase().getRuleBaseConfiguration().isSequential();
+	private InternalRuleBase ruleBase;
+
+    public AbstractGroupEvaluator(InternalRuleBase ruleBase, ActivationsManager activationsManager) {
+        this.ruleBase = ruleBase;
+		this.activationsManager = activationsManager;
+        this.sequential = ruleBase.getRuleBaseConfiguration().isSequential();
         this.knowledgeHelper = newKnowledgeHelper();
     }
 

--- a/drools-core/src/main/java/org/drools/core/concurrent/ParallelGroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/ParallelGroupEvaluator.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.core.common.ActivationsManager;
 import org.drools.core.common.InternalAgendaGroup;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.RuleAgendaItem;
 
 import static org.drools.base.common.PartitionsManager.MIN_PARALLEL_THRESHOLD;
@@ -33,8 +34,8 @@ import static org.drools.base.common.PartitionsManager.doOnForkJoinPool;
 
 public class ParallelGroupEvaluator extends AbstractGroupEvaluator {
 
-    public ParallelGroupEvaluator(ActivationsManager activationsManager ) {
-        super(activationsManager);
+    public ParallelGroupEvaluator(InternalRuleBase ruleBase, ActivationsManager activationsManager ) {
+        super(ruleBase, activationsManager);
     }
 
     protected void startEvaluation(InternalAgendaGroup group) {

--- a/drools-core/src/main/java/org/drools/core/concurrent/SequentialGroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/SequentialGroupEvaluator.java
@@ -19,11 +19,12 @@
 package org.drools.core.concurrent;
 
 import org.drools.core.common.ActivationsManager;
+import org.drools.core.impl.InternalRuleBase;
 
 public class SequentialGroupEvaluator extends AbstractGroupEvaluator {
 
-    public SequentialGroupEvaluator(ActivationsManager activationsManager) {
-        super(activationsManager);
+    public SequentialGroupEvaluator(InternalRuleBase ruleBase, ActivationsManager activationsManager) {
+        super(ruleBase, activationsManager);
     }
 }
 

--- a/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
@@ -86,7 +86,7 @@ public class ActivationsManagerImpl implements ActivationsManager {
         this.reteEvaluator = reteEvaluator;
         this.agendaGroupsManager = new AgendaGroupsManager.SimpleAgendaGroupsManager(ruleBase, reteEvaluator);
         this.propagationList = new SynchronizedPropagationList(reteEvaluator);
-        this.groupEvaluator = new SequentialGroupEvaluator( this );
+        this.groupEvaluator = new SequentialGroupEvaluator( ruleBase, this );
         if (ruleBase.getRuleBaseConfiguration().getEventProcessingMode() == EventProcessingOption.STREAM) {
             expirationContexts = new ArrayList<>();
         }

--- a/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
@@ -82,12 +82,12 @@ public class ActivationsManagerImpl implements ActivationsManager {
 
     private List<PropagationContext> expirationContexts;
 
-    public ActivationsManagerImpl(ReteEvaluator reteEvaluator) {
+    public ActivationsManagerImpl(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator) {
         this.reteEvaluator = reteEvaluator;
-        this.agendaGroupsManager = new AgendaGroupsManager.SimpleAgendaGroupsManager(reteEvaluator);
+        this.agendaGroupsManager = new AgendaGroupsManager.SimpleAgendaGroupsManager(ruleBase, reteEvaluator);
         this.propagationList = new SynchronizedPropagationList(reteEvaluator);
         this.groupEvaluator = new SequentialGroupEvaluator( this );
-        if (reteEvaluator.getKnowledgeBase().getRuleBaseConfiguration().getEventProcessingMode() == EventProcessingOption.STREAM) {
+        if (ruleBase.getRuleBaseConfiguration().getEventProcessingMode() == EventProcessingOption.STREAM) {
             expirationContexts = new ArrayList<>();
         }
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -30,6 +30,7 @@ import org.drools.core.common.DefaultEventHandle;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.impl.WorkingMemoryReteExpireAction;
 import org.drools.core.reteoo.ClassObjectTypeConf;
 import org.drools.core.reteoo.CompositePartitionAwareObjectSinkAdapter;
@@ -156,9 +157,11 @@ public interface PropagationEntry {
         private final InternalFactHandle handle;
         private final PropagationContext pCtx;
         private final boolean calledFromRHS;
+		private InternalRuleBase ruleBase;
 
-        public ExecuteQuery(String queryName, DroolsQueryImpl queryObject, InternalFactHandle handle, PropagationContext pCtx, boolean calledFromRHS) {
-            this.queryName = queryName;
+        public ExecuteQuery(InternalRuleBase ruleBase, String queryName, DroolsQueryImpl queryObject, InternalFactHandle handle, PropagationContext pCtx, boolean calledFromRHS) {
+            this.ruleBase = ruleBase;
+			this.queryName = queryName;
             this.queryObject = queryObject;
             this.handle = handle;
             this.pCtx = pCtx;
@@ -167,7 +170,7 @@ public interface PropagationEntry {
 
         @Override
         public void internalExecute(ReteEvaluator reteEvaluator ) {
-            QueryTerminalNode[] tnodes = reteEvaluator.getKnowledgeBase().getReteooBuilder().getTerminalNodesForQuery( queryName );
+            QueryTerminalNode[] tnodes = ruleBase.getReteooBuilder().getTerminalNodesForQuery( queryName );
             if ( tnodes == null ) {
                 throw new RuntimeException( "Query '" + queryName + "' does not exist" );
             }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
@@ -70,11 +70,10 @@ public class CompositeDefaultAgenda implements Externalizable, InternalAgenda {
 
     public CompositeDefaultAgenda() { }
 
-    public CompositeDefaultAgenda(InternalWorkingMemory workingMemory) {
-        InternalRuleBase kBase = workingMemory.getKnowledgeBase();
-        this.agendas = new DefaultAgenda[kBase.getParallelEvaluationSlotsCount()];
+    public CompositeDefaultAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
+        this.agendas = new DefaultAgenda[kieBase.getParallelEvaluationSlotsCount()];
         for ( int i = 0; i < this.agendas.length; i++ ) {
-            agendas[i] = new PartitionedDefaultAgenda(workingMemory, executionStateMachine, i);
+            agendas[i] = new PartitionedDefaultAgenda(kieBase, workingMemory, executionStateMachine, i);
         }
         // this composite agenda and the first partitioned one share the same propagation list
         this.propagationList = agendas[0].getPropagationList();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -159,8 +159,8 @@ public class DefaultAgenda implements InternalAgenda {
 
          // for fully parallel execution the parallelism is implemented at the level of CompositeDefaultAgenda
          this.groupEvaluator = ruleBaseConf.isParallelEvaluation() && !ruleBaseConf.isParallelExecution() ?
-                 new ParallelGroupEvaluator( this ) :
-                 new SequentialGroupEvaluator( this );
+                 new ParallelGroupEvaluator( kieBase, this ) :
+                 new SequentialGroupEvaluator( kieBase, this );
 
         this.propagationList = createPropagationList();
     }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -127,14 +127,14 @@ public class DefaultAgenda implements InternalAgenda {
     // Constructors
     // ------------------------------------------------------------
 
-    public DefaultAgenda(InternalWorkingMemory workingMemory) {
-        this(workingMemory, null);
+    public DefaultAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
+        this(kieBase, workingMemory, null);
     }
 
-    DefaultAgenda(InternalWorkingMemory workingMemory, ExecutionStateMachine executionStateMachine) {
+    DefaultAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, ExecutionStateMachine executionStateMachine) {
 
         this.workingMemory = workingMemory;
-        this.agendaGroupsManager = AgendaGroupsManager.create(workingMemory);
+        this.agendaGroupsManager = AgendaGroupsManager.create(kieBase, workingMemory);
         this.activationGroups = new HashMap<>();
 
         if (executionStateMachine != null) {
@@ -144,9 +144,7 @@ public class DefaultAgenda implements InternalAgenda {
                     new ConcurrentExecutionStateMachine() :
                     new UnsafeExecutionStateMachine();
         }
-
-        InternalRuleBase kBase = workingMemory.getKnowledgeBase();
-        RuleBaseConfiguration ruleBaseConf = kBase.getRuleBaseConfiguration();
+        RuleBaseConfiguration ruleBaseConf = kieBase.getRuleBaseConfiguration();
         Object object = ComponentsFactory.createConsequenceExceptionHandler( ruleBaseConf.getConsequenceExceptionHandler(),
                                                                              ruleBaseConf.getClassLoader() );
         if ( object instanceof ConsequenceExceptionHandler ) {

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgendaFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgendaFactory.java
@@ -22,6 +22,7 @@ package org.drools.kiesession.agenda;
 import org.drools.core.common.AgendaFactory;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.impl.InternalRuleBase;
 
 import java.io.Serializable;
 
@@ -35,9 +36,9 @@ public class DefaultAgendaFactory implements AgendaFactory, Serializable {
 
     private DefaultAgendaFactory() { }
 
-    public InternalAgenda createAgenda(InternalWorkingMemory workingMemory) {
-        return workingMemory.getKnowledgeBase().getRuleBaseConfiguration().isParallelExecution() ?
-                new CompositeDefaultAgenda( workingMemory ) :
-                new DefaultAgenda( workingMemory );
+    public InternalAgenda createAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
+        return kieBase.getRuleBaseConfiguration().isParallelExecution() ?
+                new CompositeDefaultAgenda( kieBase, workingMemory ) :
+                new DefaultAgenda(kieBase, workingMemory );
     }
 }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/PartitionedDefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/PartitionedDefaultAgenda.java
@@ -21,16 +21,18 @@ package org.drools.kiesession.agenda;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.PropagationContext;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.ObjectTypeNode;
 
 public class PartitionedDefaultAgenda extends DefaultAgenda {
 
     private final int partition;
 
-    PartitionedDefaultAgenda(InternalWorkingMemory workingMemory,
+    PartitionedDefaultAgenda(InternalRuleBase kieBase, 
+    		InternalWorkingMemory workingMemory,
                              ExecutionStateMachine executionStateMachine,
                              int partition) {
-        super(workingMemory, executionStateMachine);
+        super(kieBase, workingMemory, executionStateMachine);
         this.partition = partition;
     }
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
@@ -103,13 +103,14 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
         reteEvaluator = null;
     }
 
-    public NamedEntryPoint(EntryPointId entryPoint,
-                           EntryPointNode entryPointNode,
-                           ReteEvaluator reteEvaluator) {
+    public NamedEntryPoint(InternalRuleBase ruleBase, 
+            ReteEvaluator reteEvaluator,
+            EntryPointId entryPoint,
+            EntryPointNode entryPointNode) {
+        this.ruleBase = ruleBase;
+        this.reteEvaluator = reteEvaluator;
         this.entryPoint = entryPoint;
         this.entryPointNode = entryPointNode;
-        this.reteEvaluator = reteEvaluator;
-        this.ruleBase = this.reteEvaluator.getKnowledgeBase();
         this.lock = reteEvaluator.getRuleSessionConfiguration().isThreadSafe() ? new ReentrantLock() : null;
         this.handleFactory = this.reteEvaluator.getFactHandleFactory();
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointFactory.java
@@ -20,17 +20,18 @@ package org.drools.kiesession.entrypoints;
 
 import org.drools.core.common.EntryPointFactory;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.base.rule.EntryPointId;
 
 public class NamedEntryPointFactory implements EntryPointFactory {
 
     @Override
-    public NamedEntryPoint createEntryPoint(EntryPointNode addedNode, EntryPointId id, ReteEvaluator reteEvaluator) {
-        return new NamedEntryPoint(id, addedNode, reteEvaluator);
+    public NamedEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, EntryPointId id, EntryPointNode addedNode) {
+        return new NamedEntryPoint(ruleBase, reteEvaluator, id, addedNode);
     }
 
-    public NamedEntryPointsManager createEntryPointsManager(ReteEvaluator reteEvaluator) {
-        return new NamedEntryPointsManager(reteEvaluator);
+    public NamedEntryPointsManager createEntryPointsManager(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator) {
+        return new NamedEntryPointsManager(ruleBase, reteEvaluator);
     }
 }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointsManager.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointsManager.java
@@ -40,9 +40,9 @@ public class NamedEntryPointsManager implements EntryPointsManager {
 
     private final Map<String, WorkingMemoryEntryPoint> entryPoints = new ConcurrentHashMap<>();
 
-    public NamedEntryPointsManager(ReteEvaluator reteEvaluator) {
+    public NamedEntryPointsManager(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator) {
         this.reteEvaluator = reteEvaluator;
-        this.ruleBase = reteEvaluator.getKnowledgeBase();
+        this.ruleBase = ruleBase;
         initDefaultEntryPoint();
         updateEntryPointsCache();
     }
@@ -60,7 +60,7 @@ public class NamedEntryPointsManager implements EntryPointsManager {
     }
 
     private InternalWorkingMemoryEntryPoint createNamedEntryPoint(EntryPointNode addedNode) {
-        return RuntimeComponentFactory.get().getEntryPointFactory().createEntryPoint(addedNode, addedNode.getEntryPoint(), reteEvaluator);
+        return RuntimeComponentFactory.get().getEntryPointFactory().createEntryPoint(ruleBase, reteEvaluator, addedNode.getEntryPoint(), addedNode);
     }
 
     public void updateEntryPointsCache() {

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -341,7 +341,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         this.agenda = RuntimeComponentFactory.get().getAgendaFactory( config ).createAgenda(kBase, this);
 
-        this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(this);
+        this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(kBase, this);
 
         this.sequential = conf.isSequential();
 
@@ -713,7 +713,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
     }
 
     private QueryTerminalNode[] evalQuery(final String queryName, final DroolsQueryImpl queryObject, final InternalFactHandle handle, final PropagationContext pCtx, final boolean isCalledFromRHS) {
-        PropagationEntry.ExecuteQuery executeQuery = new PropagationEntry.ExecuteQuery( queryName, queryObject, handle, pCtx, isCalledFromRHS);
+        PropagationEntry.ExecuteQuery executeQuery = new PropagationEntry.ExecuteQuery( kBase, queryName, queryObject, handle, pCtx, isCalledFromRHS);
         addPropagation( executeQuery );
         return executeQuery.getResult();
     }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -339,7 +339,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         RuleBaseConfiguration conf = kBase.getRuleBaseConfiguration();
         this.pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
 
-        this.agenda = RuntimeComponentFactory.get().getAgendaFactory( config ).createAgenda(this);
+        this.agenda = RuntimeComponentFactory.get().getAgendaFactory( config ).createAgenda(kBase, this);
 
         this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(this);
 

--- a/drools-mvel/src/main/java/org/drools/mvel/field/ClassFieldImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/field/ClassFieldImpl.java
@@ -66,15 +66,6 @@ public class ClassFieldImpl implements FieldValue, Externalizable {
         return type;
     }
 
-    public Object resolve( InternalWorkingMemory workingMemory ) {
-        try {
-            type = workingMemory.getKnowledgeBase().getRootClassLoader().loadClass( className );
-        } catch (Exception e) {
-
-        }
-        return type;
-    }
-
     @Override
     public int hashCode() {
         return className.hashCode();

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
@@ -20,6 +20,7 @@ package org.drools.reliability.core;
 
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Storage;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.PropagationList;
 import org.drools.kiesession.agenda.DefaultAgenda;
 
@@ -27,8 +28,8 @@ import static org.drools.reliability.core.ReliablePropagationList.PROPAGATION_LI
 
 public class ReliableAgenda extends DefaultAgenda {
 
-    public ReliableAgenda(InternalWorkingMemory workingMemory) {
-        super( workingMemory );
+    public ReliableAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
+        super( kieBase, workingMemory );
     }
 
     @Override

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgendaFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgendaFactory.java
@@ -22,6 +22,7 @@ package org.drools.reliability.core;
 import org.drools.core.common.AgendaFactory;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.impl.InternalRuleBase;
 
 import java.io.Serializable;
 
@@ -35,7 +36,7 @@ public class ReliableAgendaFactory implements AgendaFactory, Serializable {
 
     private ReliableAgendaFactory() { }
 
-    public InternalAgenda createAgenda(InternalWorkingMemory workingMemory) {
-        return new ReliableAgenda( workingMemory );
+    public InternalAgenda createAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
+        return new ReliableAgenda( kieBase, workingMemory );
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
@@ -21,6 +21,7 @@ package org.drools.reliability.core;
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.ObjectStore;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.base.rule.EntryPointId;
 import org.drools.kiesession.entrypoints.NamedEntryPoint;
@@ -28,8 +29,8 @@ import org.kie.api.runtime.conf.PersistedSessionOption;
 
 public class ReliableNamedEntryPoint extends NamedEntryPoint {
 
-    public ReliableNamedEntryPoint(EntryPointId entryPoint, EntryPointNode entryPointNode, ReteEvaluator reteEvaluator) {
-        super(entryPoint, entryPointNode, reteEvaluator);
+    public ReliableNamedEntryPoint(EntryPointId entryPoint, EntryPointNode entryPointNode, InternalRuleBase ruleBase, ReteEvaluator reteEvaluator) {
+        super(ruleBase, reteEvaluator, entryPoint, entryPointNode);
     }
 
     @Override

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPointFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPointFactory.java
@@ -19,6 +19,7 @@
 package org.drools.reliability.core;
 
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.base.rule.EntryPointId;
 import org.drools.kiesession.entrypoints.NamedEntryPoint;
@@ -27,10 +28,10 @@ import org.drools.kiesession.entrypoints.NamedEntryPointFactory;
 public class ReliableNamedEntryPointFactory extends NamedEntryPointFactory {
 
     @Override
-    public NamedEntryPoint createEntryPoint(EntryPointNode addedNode, EntryPointId id, ReteEvaluator reteEvaluator) {
+    public NamedEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, EntryPointId id, EntryPointNode addedNode) {
         if (!reteEvaluator.getSessionConfiguration().hasPersistedSessionOption()) {
-            return super.createEntryPoint(addedNode, id, reteEvaluator);
+            return super.createEntryPoint(ruleBase, reteEvaluator, id, addedNode);
         }
-        return new ReliableNamedEntryPoint(id, addedNode, reteEvaluator);
+        return new ReliableNamedEntryPoint(id, addedNode, ruleBase, reteEvaluator);
     }
 }

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
@@ -131,7 +131,7 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
         this.nodeMemories = new ConcurrentNodeMemories(ruleBase);
 
         this.activationsManager = new ActivationsManagerImpl(ruleBase, this);
-        this.entryPointsManager = RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(this);
+        this.entryPointsManager = RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(ruleBase, this);
         this.timerService = sessionConfiguration.createTimerService();
 
         initInitialFact(ruleBase);
@@ -317,7 +317,7 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
 
         final PropagationContext pCtx = new PhreakPropagationContext(getNextPropagationIdCounter(), PropagationContext.Type.INSERTION, null, null, handle, getDefaultEntryPointId());
 
-        PropagationEntry.ExecuteQuery executeQuery = new PropagationEntry.ExecuteQuery( queryName, queryObject, handle, pCtx, false);
+        PropagationEntry.ExecuteQuery executeQuery = new PropagationEntry.ExecuteQuery( ruleBase, queryName, queryObject, handle, pCtx, false);
         addPropagation( executeQuery );
         TerminalNode[] terminalNodes = executeQuery.getResult();
 
@@ -354,6 +354,11 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
         return tmsEnabled;
     }
 
+	@Override
+	public boolean isSequential() {
+		return ruleBase.getRuleBaseConfiguration().isSequential();
+	}
+    
     @Override
     public KnowledgeHelper createKnowledgeHelper() {
         return new RuleUnitKnowledgeHelper((DefaultKnowledgeHelper) ReteEvaluator.super.createKnowledgeHelper(), this);

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
@@ -130,7 +130,7 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
         this.handleFactory = knowledgeBase.newFactHandleFactory();
         this.nodeMemories = new ConcurrentNodeMemories(ruleBase);
 
-        this.activationsManager = new ActivationsManagerImpl(this);
+        this.activationsManager = new ActivationsManagerImpl(ruleBase, this);
         this.entryPointsManager = RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(this);
         this.timerService = sessionConfiguration.createTimerService();
 

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/FactHandleMarshallingTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/FactHandleMarshallingTest.java
@@ -27,6 +27,7 @@ import org.drools.core.common.DefaultFactHandle;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.QueryElementFactHandle;
 import org.drools.core.impl.EnvironmentFactory;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.impl.RuleBaseFactory;
 import org.drools.core.marshalling.MarshallerReaderContext;
 import org.drools.core.reteoo.CoreComponentFactory;
@@ -70,7 +71,7 @@ public class FactHandleMarshallingTest {
         return KnowledgeBaseFactory.newKnowledgeBase( config );
     }
     
-    private InternalFactHandle createEventFactHandle(StatefulKnowledgeSessionImpl wm, InternalKnowledgeBase kBase) {
+    private InternalFactHandle createEventFactHandle(StatefulKnowledgeSessionImpl wm, InternalRuleBase kBase) {
         // EntryPointNode
         Rete rete = kBase.getRete();
 
@@ -78,7 +79,7 @@ public class FactHandleMarshallingTest {
 
         RuleBasePartitionId partionId = RuleBasePartitionId.MAIN_PARTITION;
         EntryPointNode entryPointNode = nFacotry.buildEntryPointNode(1, partionId, rete , EntryPointId.DEFAULT);
-        WorkingMemoryEntryPoint wmEntryPoint = new NamedEntryPoint( EntryPointId.DEFAULT, entryPointNode, wm);
+        WorkingMemoryEntryPoint wmEntryPoint = new NamedEntryPoint(kBase, wm, EntryPointId.DEFAULT, entryPointNode);
 
         DefaultEventHandle factHandle = new DefaultEventHandle(1, new Person(), 0, (new Date()).getTime(), 0, wmEntryPoint);
         

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
@@ -883,7 +883,7 @@ public class IndexingTest {
         InternalWorkingMemory wm = (InternalWorkingMemory) kbase.newKieSession();
 
         try {
-            final ObjectTypeNode node = KieUtil.getObjectTypeNode(wm.getKnowledgeBase(), Person.class);
+            final ObjectTypeNode node = KieUtil.getObjectTypeNode(kbase, Person.class);
             assertThat(node).isNotNull();
             final LeftInputAdapterNode liaNode = (LeftInputAdapterNode) node.getObjectSinkPropagator().getSinks()[0];
             final JoinNode j2 = (JoinNode) liaNode.getSinkPropagator().getSinks()[0];

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryTest.java
@@ -24,6 +24,7 @@ import org.drools.base.base.ObjectType;
 import org.drools.commands.runtime.FlatQueryResults;
 import org.drools.core.QueryResultsImpl;
 import org.drools.core.common.InternalFactHandle;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.ReteDumper;
@@ -421,7 +422,7 @@ public class QueryTest {
 
         StatefulKnowledgeSessionImpl sessionImpl = (StatefulKnowledgeSessionImpl) ksession;
 
-        Collection<EntryPointNode> entryPointNodes = sessionImpl.getKnowledgeBase().getRete().getEntryPointNodes().values();
+        Collection<EntryPointNode> entryPointNodes = ((InternalRuleBase)kbase).getRete().getEntryPointNodes().values();
 
         EntryPointNode defaultEntryPointNode = null;
         for ( EntryPointNode epNode : entryPointNodes ) {

--- a/drools-traits/src/main/java/org/drools/traits/core/common/TraitEntryPointFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/common/TraitEntryPointFactory.java
@@ -21,6 +21,7 @@ package org.drools.traits.core.common;
 import org.drools.kiesession.entrypoints.NamedEntryPoint;
 import org.drools.core.common.EntryPointFactory;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.base.rule.EntryPointId;
 import org.drools.kiesession.entrypoints.NamedEntryPointFactory;
@@ -28,7 +29,7 @@ import org.drools.kiesession.entrypoints.NamedEntryPointFactory;
 public class TraitEntryPointFactory extends NamedEntryPointFactory implements EntryPointFactory {
 
     @Override
-    public NamedEntryPoint createEntryPoint(EntryPointNode addedNode, EntryPointId id, ReteEvaluator reteEvaluator) {
-        return new TraitNamedEntryPoint(id, addedNode, reteEvaluator);
+    public NamedEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, EntryPointId id, EntryPointNode addedNode) {
+        return new TraitNamedEntryPoint(id, addedNode, ruleBase, reteEvaluator);
     }
 }

--- a/drools-traits/src/main/java/org/drools/traits/core/common/TraitNamedEntryPoint.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/common/TraitNamedEntryPoint.java
@@ -23,6 +23,7 @@ import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemoryActions;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.impl.InternalRuleBase;
 import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.factmodel.traits.TraitableBean;
 import org.drools.core.reteoo.EntryPointNode;
@@ -39,8 +40,9 @@ public class TraitNamedEntryPoint extends NamedEntryPoint {
 
     public TraitNamedEntryPoint(EntryPointId entryPoint,
                                 EntryPointNode entryPointNode,
+                                InternalRuleBase ruleBase, 
                                 ReteEvaluator reteEvaluator) {
-        super(entryPoint, entryPointNode, reteEvaluator);
+        super(ruleBase, reteEvaluator, entryPoint, entryPointNode);
         this.traitHelper = new TraitHelperImpl((InternalWorkingMemoryActions) reteEvaluator, this);
     }
 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

This is another patch related to cleaning and simplifying drools core.

The strategy is always the same - remove excessive reliance on ReteEvaluator as a mother object.  Where possible, split dependency and provide reference directly to the underlying objects.

This patch focuses mostly removing usages of getKnowledgeBase and passing directly the rule base in the constructor.

All tests pass and PR should be straightforward.