### PR TITLE
[incubator-kie-issues#2083] Fix correct overrides of expressionLanguage

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
@@ -890,9 +890,10 @@ public class DMNEvaluatorCompiler implements DMNDecisionLogicCompiler {
      * @return
      */
     static FEEL getFEELDialectAdaptedFEEL(DMNCompilerContext ctx, LiteralExpression expression, String expressionLanguage) {
-        if (expressionLanguage == null ||
-                expressionLanguage.equals(expression.getURIFEEL())) {
+        if (expressionLanguage == null) {
             return ctx.getFeelHelper().newFEELInstance();
+        } else if (expressionLanguage.equals(expression.getURIFEEL())) {
+            return ctx.getFeelHelper().newFEELInstance(FEELDialect.FEEL);
         } else if (expressionLanguage.equals(FEELDialect.BFEEL.getNamespace())) {
             return ctx.getFeelHelper().newFEELInstance(FEELDialect.BFEEL);
         } else {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeBFEELTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeBFEELTest.java
@@ -18,21 +18,60 @@
  */
 package org.kie.dmn.core;
 
+import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collections;
 
+import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.impl.DMNModelImpl;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.feel.lang.FEELDialect;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
+import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
 
 public class DMNInputRuntimeBFEELTest extends BaseInterpretedVsCompiledTest {
+
+
+    @ParameterizedTest
+    @MethodSource("params")
+    void expressionLanguageOverridesBFEEL(boolean useExecModelCompiler) {
+        init(useExecModelCompiler);
+        final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("invalid_models/DMNv1_6/B-FEEL/bfeel-global-feel-local.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("https://kie.org/dmn/_3A640A4E-08C2-4B09-BAAF-866504DC8750", "DMN_1D8875EF-E77F-4A89-9495-113D22A02DBA");
+        assertThat(dmnModel).isNotNull();
+        assertThat(dmnModel.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnModel.getMessages())).isFalse();
+
+        final DMNContext context = DMNFactory.newContext();
+        context.set("Person", mapOf(entry("Age", 30)));
+
+        final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
+        assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
+        List<DMNMessage> errors = dmnResult.getMessages(DMNMessage.Severity.ERROR);
+        List<String> expectedErrors = Arrays.asList("Wrong Sum List", "Wrong Boolean",
+                                                    "Wrong decision based on Wrong Boolean");
+        List<String> unwantedErrors = Arrays.asList("Right Sum List", "Right Boolean",
+                                                    "Right decision based on Wrong Boolean");
+        assertThat(errors)
+                .anyMatch(message -> expectedErrors.stream().anyMatch(toTest -> message.getText().contains(toTest)))
+                .noneMatch(message -> unwantedErrors.stream().anyMatch(toTest -> message.getText().contains(toTest)));
+
+        final DMNContext result = dmnResult.getContext();
+
+        assertThat(result.get("Right Sum List")).isEqualTo(new BigDecimal("34"));
+        assertThat(result.get("Right Boolean")).isEqualTo(false);
+        assertThat(result.get("Right decision based on Wrong Boolean")).isEqualTo(true);
+
+    }
 
     @ParameterizedTest
     @MethodSource("params")

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/DMNEvaluatorCompilerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/DMNEvaluatorCompilerTest.java
@@ -88,6 +88,25 @@ class DMNEvaluatorCompilerTest {
     }
 
     @Test
+    void getFEELDialectAdaptedFEELNoExpressionLanguageDefault() {
+        String expressionLanguage = null;
+        LiteralExpression expression = getLiteralExpression(expressionLanguage);
+        FEEL retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(DEFAULT_DMN_COMPILER_CONTEXT, expression, expressionLanguage);
+        assertThat(retrieved).isNotNull().isInstanceOf(FEELImpl.class);
+        assertThat(((FEELImpl) retrieved).getFeelDialect()).isEqualTo(DEFAULT_FEEL_DIALECT);
+    }
+
+    @Test
+    void getFEELDialectAdaptedFEELNoExpressionLanguageBFEEL() {
+        String expressionLanguage = null;
+        LiteralExpression expression = getLiteralExpression(expressionLanguage);
+        FEEL retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(B_FEEL_DMN_COMPILER_CONTEXT, expression, expressionLanguage);
+        assertThat(retrieved).isNotNull().isInstanceOf(FEELImpl.class);
+        assertThat(((FEELImpl) retrieved).getFeelDialect()).isEqualTo(B_FEEL_DIALECT);
+    }
+
+
+    @Test
     void getFEELDialectAdaptedFEELFEELURIExpressionLanguage() {
         LiteralExpression expression = getLiteralExpression(null);
         String expressionLanguage = expression.getURIFEEL();

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/DMNEvaluatorCompilerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/DMNEvaluatorCompilerTest.java
@@ -54,18 +54,22 @@ import static org.kie.dmn.core.compiler.DMNEvaluatorCompiler.getEvaluatorIdentif
 class DMNEvaluatorCompilerTest {
 
     private static final FEELDialect DEFAULT_FEEL_DIALECT = FEELDialect.FEEL;
+    private static final FEELDialect B_FEEL_DIALECT = FEELDialect.BFEEL;
     private static final String IF_ELEMENT_ID = "IF_ELEMENT_ID";
     private static final String THEN_ELEMENT_ID = "THEN_ELEMENT_ID";
     private static final String ELSE_ELEMENT_ID = "ELSE_ELEMENT_ID";
-    private static DMNCompilerContext DMN_COMPILER_CONTEXT;
+    private static DMNCompilerContext DEFAULT_DMN_COMPILER_CONTEXT;
+    private static DMNCompilerContext B_FEEL_DMN_COMPILER_CONTEXT;
     private static DMNEvaluatorCompiler dmnEvaluatorCompiler;
-    private static DMNFEELHelper DMN_FEEL_HELPER;
+    private static DMNFEELHelper DEFAULT_DMN_FEEL_HELPER;
+    private static DMNFEELHelper B_FEEL_DMN_FEEL_HELPER;
 
     @BeforeAll
     static void setUp() {
-        DMN_FEEL_HELPER = new DMNFEELHelper(Collections.emptyList(), DEFAULT_FEEL_DIALECT, DMNVersion.getLatest());
-        DMN_COMPILER_CONTEXT = new DMNCompilerContext(DMN_FEEL_HELPER);
-
+        DEFAULT_DMN_FEEL_HELPER = new DMNFEELHelper(Collections.emptyList(), DEFAULT_FEEL_DIALECT, DMNVersion.getLatest());
+        DEFAULT_DMN_COMPILER_CONTEXT = new DMNCompilerContext(DEFAULT_DMN_FEEL_HELPER);
+        B_FEEL_DMN_FEEL_HELPER = new DMNFEELHelper(Collections.emptyList(), B_FEEL_DIALECT, DMNVersion.getLatest());
+        B_FEEL_DMN_COMPILER_CONTEXT = new DMNCompilerContext(B_FEEL_DMN_FEEL_HELPER);
         DMNCompilerImpl compiler = new DMNCompilerImpl();
         dmnEvaluatorCompiler = new DMNEvaluatorCompiler(compiler);
     }
@@ -74,16 +78,20 @@ class DMNEvaluatorCompilerTest {
     void getFEELDialectAdaptedFEELNoExpressionLanguage() {
         String expressionLanguage = null;
         LiteralExpression expression = getLiteralExpression(expressionLanguage);
-        FEEL retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(DMN_COMPILER_CONTEXT, expression, expressionLanguage);
+        FEEL retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(DEFAULT_DMN_COMPILER_CONTEXT, expression, expressionLanguage);
         assertThat(retrieved).isNotNull().isInstanceOf(FEELImpl.class);
         assertThat(((FEELImpl) retrieved).getFeelDialect()).isEqualTo(DEFAULT_FEEL_DIALECT);
+        //
+        retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(B_FEEL_DMN_COMPILER_CONTEXT, expression, expressionLanguage);
+        assertThat(retrieved).isNotNull().isInstanceOf(FEELImpl.class);
+        assertThat(((FEELImpl) retrieved).getFeelDialect()).isEqualTo(B_FEEL_DIALECT);
     }
 
     @Test
     void getFEELDialectAdaptedFEELFEELURIExpressionLanguage() {
         LiteralExpression expression = getLiteralExpression(null);
         String expressionLanguage = expression.getURIFEEL();
-        FEEL retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(DMN_COMPILER_CONTEXT, expression, expressionLanguage);
+        FEEL retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(DEFAULT_DMN_COMPILER_CONTEXT, expression, expressionLanguage);
         assertThat(retrieved).isNotNull().isInstanceOf(FEELImpl.class);
         assertThat(((FEELImpl) retrieved).getFeelDialect()).isEqualTo(DEFAULT_FEEL_DIALECT);
     }
@@ -92,9 +100,18 @@ class DMNEvaluatorCompilerTest {
     void getFEELDialectAdaptedFEELBFEELExpressionLanguage() {
         String expressionLanguage = FEELDialect.BFEEL.getNamespace();
         LiteralExpression expression = getLiteralExpression(expressionLanguage);
-        FEEL retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(DMN_COMPILER_CONTEXT, expression, expressionLanguage);
+        FEEL retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(DEFAULT_DMN_COMPILER_CONTEXT, expression, expressionLanguage);
         assertThat(retrieved).isNotNull().isInstanceOf(FEELImpl.class);
         assertThat(((FEELImpl) retrieved).getFeelDialect()).isEqualTo(FEELDialect.BFEEL);
+    }
+
+    @Test
+    void getFEELDialectAdaptedFEELSFEELExpressionLanguage() {
+        String expressionLanguage = "https://www.omg.org/spec/DMN/20230324/FEEL/";
+        LiteralExpression expression = getLiteralExpression(expressionLanguage);
+        FEEL retrieved = DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(B_FEEL_DMN_COMPILER_CONTEXT, expression, expressionLanguage);
+        assertThat(retrieved).isNotNull().isInstanceOf(FEELImpl.class);
+        assertThat(((FEELImpl) retrieved).getFeelDialect()).isEqualTo(FEELDialect.FEEL);
     }
 
     @Test
@@ -102,7 +119,7 @@ class DMNEvaluatorCompilerTest {
         String expressionLanguage = "something-else";
         LiteralExpression expression = getLiteralExpression(expressionLanguage);
         String expectedMessage = String.format("Unsupported FEEL language '%s'; allowed values are `null`, %s, %s", expressionLanguage, expression.getURIFEEL(), FEELDialect.BFEEL.getNamespace());
-        assertThatThrownBy(() -> DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(DMN_COMPILER_CONTEXT, expression, expressionLanguage))
+        assertThatThrownBy(() -> DMNEvaluatorCompiler.getFEELDialectAdaptedFEEL(DEFAULT_DMN_COMPILER_CONTEXT, expression, expressionLanguage))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(expectedMessage);
     }
@@ -129,7 +146,7 @@ class DMNEvaluatorCompilerTest {
         Conditional expr = (Conditional) retrieved;
         DMNBaseNode dmnBaseNode = getNodeByName(dmnModel, "B");
         DMNType numType = dmnBaseNode.getType();
-        DMNCompilerContext compilerContext = new DMNCompilerContext(DMN_FEEL_HELPER);;
+        DMNCompilerContext compilerContext = new DMNCompilerContext(DEFAULT_DMN_FEEL_HELPER);;
         compilerContext.setVariable("num", numType);
         DMNExpressionEvaluator ifEvaluator = dmnEvaluatorCompiler.compileExpression(compilerContext, (DMNModelImpl) dmnModel, dmnBaseNode, ifExprName, expr.getIf().getExpression());
         DMNExpressionEvaluator thenEvaluator = dmnEvaluatorCompiler.compileExpression(compilerContext, (DMNModelImpl) dmnModel, dmnBaseNode, thenExprName, expr.getThen().getExpression());
@@ -171,7 +188,7 @@ class DMNEvaluatorCompilerTest {
         assertThat(retrieved).isNotNull();
         DMNBaseNode dmnBaseNode = getNodeByName(dmnModel, "B");
         DMNType numType = dmnBaseNode.getType();
-        DMNCompilerContext compilerContext = new DMNCompilerContext(DMN_FEEL_HELPER);
+        DMNCompilerContext compilerContext = new DMNCompilerContext(DEFAULT_DMN_FEEL_HELPER);
         compilerContext.setVariable("num", numType);
         DMNExpressionEvaluator result = dmnEvaluatorCompiler.compileConditional(compilerContext, (DMNModelImpl) dmnModel, dmnBaseNode, exprName, (Conditional) retrieved);
         assertThat(result).isNotNull();

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/DMNModelInstrumentedBase.java
@@ -52,6 +52,11 @@ public interface DMNModelInstrumentedBase {
 
     String getIdentifierString();
 
+    /**
+     * Returns the FEEL namespace mapped to the DMN version of the current <code>DMNModelInstrumentedBase</code>,
+     * e.g. any v1.6 concrete class will return the FEEL namespace used by DMN 1.6
+     * @return
+     */
     String getURIFEEL();
 
     void setLocation(Location location);

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Definitions.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Definitions.java
@@ -25,7 +25,7 @@ import javax.xml.namespace.QName;
 
 import org.kie.dmn.model.api.dmndi.DMNDI;
 
-public interface Definitions extends NamedElement {
+public interface Definitions extends NamedElement, HasExpressionLanguage {
 
     List<Import> getImport();
 
@@ -55,10 +55,6 @@ public interface Definitions extends NamedElement {
             processQNameURIs(itemDefinition, this.getNamespace());
         }
     }
-
-    String getExpressionLanguage();
-
-    void setExpressionLanguage(String value);
 
     String getTypeLanguage();
 

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/HasExpressionLanguage.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/HasExpressionLanguage.java
@@ -18,10 +18,14 @@
  */
 package org.kie.dmn.model.api;
 
-public interface ImportedValues extends Import, HasExpressionLanguage {
+public interface HasExpressionLanguage {
 
-    String getImportedElement();
+    /**
+     * This is the <b>expressionLanguage</b> attribute
+     * @return
+     */
+    String getExpressionLanguage();
 
-    void setImportedElement(String value);
+    void setExpressionLanguage(String value);
 
 }

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/LiteralExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/LiteralExpression.java
@@ -18,7 +18,7 @@
  */
 package org.kie.dmn.model.api;
 
-public interface LiteralExpression extends Expression {
+public interface LiteralExpression extends Expression, HasExpressionLanguage {
 
     String getText();
 
@@ -27,9 +27,5 @@ public interface LiteralExpression extends Expression {
     ImportedValues getImportedValues();
 
     void setImportedValues(ImportedValues value);
-
-    String getExpressionLanguage();
-
-    void setExpressionLanguage(String value);
 
 }

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/UnaryTests.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/UnaryTests.java
@@ -20,15 +20,11 @@ package org.kie.dmn.model.api;
 
 import javax.xml.namespace.QName;
 
-public interface UnaryTests extends Expression {
+public interface UnaryTests extends Expression, HasExpressionLanguage {
 
     String getText();
 
     void setText(String value);
-
-    String getExpressionLanguage();
-
-    void setExpressionLanguage(String value);
 
     @Override
     default QName getTypeRef() {

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/invalid_models/DMNv1_6/B-FEEL/bfeel-global-feel-local.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/invalid_models/DMNv1_6/B-FEEL/bfeel-global-feel-local.dmn
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+<definitions xmlns="https://www.omg.org/spec/DMN/20240513/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="https://kie.org/dmn/extensions/1.0"
+             expressionLanguage="https://www.omg.org/spec/DMN/20240513/B-FEEL/" namespace="https://kie.org/dmn/_3A640A4E-08C2-4B09-BAAF-866504DC8750" id="_95F556A6-B5F3-466F-9C55-63440FAC8AEE"
+             name="DMN_1D8875EF-E77F-4A89-9495-113D22A02DBA">
+  <itemDefinition id="_6265833E-19AD-40FA-9053-8C766C1FE415" name="tPerson" isCollection="false" typeLanguage="https://www.omg.org/spec/DMN/20240513/FEEL/">
+    <itemComponent id="_7DA957A9-8F14-4940-A61E-403A94BF546D" name="Age" isCollection="false" typeLanguage="https://www.omg.org/spec/DMN/20240513/FEEL/">
+      <typeRef>number</typeRef>
+    </itemComponent>
+  </itemDefinition>
+  <decision name="Wrong Sum List" id="_D44300BE-2FE4-435C-B6FF-5236589EC0C2">
+    <variable id="_704A66D6-E45E-4D22-A183-0F3D1DB4A129" name="Wrong Sum List" typeRef="number" />
+    <informationRequirement id="_9AECBCC6-8333-47A9-BD06-47DA41D07FB4">
+      <requiredInput href="#_2A8EFAB9-E782-4993-9982-9D8D3E918EF8" />
+    </informationRequirement>
+    <literalExpression id="_40AA06F1-3ABD-4AEC-8F48-B7488181E33D" typeRef="number" label="Wrong Sum List" expressionLanguage="https://www.omg.org/spec/DMN/20240513/FEEL/">
+      <text>sum([Person.Age, &quot;1&quot;, 4])</text>
+    </literalExpression>
+  </decision>
+  <decision name="Wrong Boolean" id="_D44300BE-2FE4-435C-B6FF-5236589EC0C3">
+    <variable id="_704A66D6-E45E-4D22-A183-0F3D1DB4A130" name="Wrong Boolean" typeRef="boolean" />
+    <literalExpression id="_40AA06F1-3ABD-4AEC-8F48-B7488181E33E" typeRef="boolean" label="Wrong Boolean" expressionLanguage="https://www.omg.org/spec/DMN/20240513/FEEL/">
+      <text>"a" = 1</text>
+    </literalExpression>
+  </decision>
+
+  <decision name="Right Sum List" id="_D44300BE-2FE4-435C-B6FF-5236589EC0C4">
+    <variable id="_704A66D6-E45E-4D22-A183-0F3D1DB4A131" name="Right Sum List" typeRef="number" />
+    <informationRequirement id="_9AECBCC6-8333-47A9-BD06-47DA41D07FB6">
+      <requiredInput href="#_2A8EFAB9-E782-4993-9982-9D8D3E918EF8" />
+    </informationRequirement>
+    <literalExpression id="_40AA06F1-3ABD-4AEC-8F48-B7488181E33F" typeRef="number" label="Right Sum List">
+      <text>sum([Person.Age, &quot;1&quot;, 4])</text>
+    </literalExpression>
+  </decision>
+
+  <decision name="Right Boolean" id="_D44300BE-2FE4-435C-B6FF-5236589EC0C5">
+    <variable id="_704A66D6-E45E-4D22-A183-0F3D1DB4A132" name="Right Boolean" typeRef="boolean" />
+    <literalExpression id="_40AA06F1-3ABD-4AEC-8F48-B7488181E33G" typeRef="boolean" label="Right Boolean">
+      <text>"a" = 1</text>
+    </literalExpression>
+  </decision>
+
+  <decision id="_fc1bff6c-b1ca-4a10-ba9a-23b8f5e86e6a" name="Wrong decision based on Wrong Boolean">
+    <variable name="Wrong decision based on Wrong Boolean" id="_2e323310-3d83-4c51-a256-3082e0ccacea" typeRef="boolean"/>
+    <informationRequirement id="_e848f84a-25ef-432b-b944-2848f11ea91c" >
+      <requiredDecision href="_D44300BE-2FE4-435C-B6FF-5236589EC0C3"/>
+    </informationRequirement>
+    <literalExpression id="_05fab753-c3c4-41a9-8984-e078f4aabe32" typeRef="boolean"   expressionLanguage="https://www.omg.org/spec/DMN/20240513/FEEL/" >
+      <text>is(Wrong Boolean) = true</text>
+    </literalExpression>
+  </decision>
+
+  <decision id="_fc1bff6c-b1ca-4a10-ba9a-23b8f5e86e6b" name="Right decision based on Wrong Boolean">
+    <variable name="Right decision based on Wrong Boolean" id="_2e323310-3d83-4c51-a256-3082e0ccaceb" typeRef="boolean"/>
+    <informationRequirement id="_e848f84a-25ef-432b-b944-2848f11ea91d" >
+      <requiredDecision href="_D44300BE-2FE4-435C-B6FF-5236589EC0C3"/>
+    </informationRequirement>
+    <literalExpression id="_05fab753-c3c4-41a9-8984-e078f4aabe33" typeRef="boolean" >
+      <text>is(Wrong Boolean) = false</text>
+    </literalExpression>
+  </decision>
+
+  <inputData name="Person" id="_2A8EFAB9-E782-4993-9982-9D8D3E918EF8">
+    <variable name="Person" id="_D8CC72F8-D10C-4A8B-B7AC-C74CA66D4272" typeRef="tPerson" />
+  </inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_D3BA90EC-79E4-45E9-9F9E-540E47C4AE6B" name="Default DRD" useAlternativeInputDataShape="false">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_40AA06F1-3ABD-4AEC-8F48-B7488181E33D">
+            <kie:width>190</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="_4E15F28B-2232-4F1E-8546-DAC813B4D4D2" dmnElementRef="_2A8EFAB9-E782-4993-9982-9D8D3E918EF8" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="140" y="120" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_0AB4DFDB-8B2F-4D4B-ACAA-53C987D1725E" dmnElementRef="_D44300BE-2FE4-435C-B6FF-5236589EC0C2" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="380" y="120" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="_787BC3EE-6C29-415A-9534-FC3A49F68B92-AUTO-TARGET" dmnElementRef="_9AECBCC6-8333-47A9-BD06-47DA41D07FB4" sourceElement="_4E15F28B-2232-4F1E-8546-DAC813B4D4D2" targetElement="_0AB4DFDB-8B2F-4D4B-ACAA-53C987D1725E">
+        <di:waypoint x="220" y="160" />
+        <di:waypoint x="460" y="160" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2083

This PR:

1. fix the FEEL language setting on dynamically instantiated (nested) Context
2. add minor refactoring to inheritance tree to remove duplicated code
3. add unit test to cover the core modification
4. add integration tests on specially-crafted dmn to verify correct behavior under different scenarios

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
