### PR TITLE
[incubator-kie-drools-6442] Remove uses of getFactHandleFactory

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/AgendaFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaFactory.java
@@ -19,8 +19,9 @@
 package org.drools.core.common;
 
 import org.drools.core.impl.InternalRuleBase;
+import org.drools.core.rule.accessor.FactHandleFactory;
 
 public interface AgendaFactory {
 
-    InternalAgenda createAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory);
+    InternalAgenda createAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, FactHandleFactory factHandleFactory);
 }

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.RuleAgendaItem;
 import org.drools.core.reteoo.RuntimeComponentFactory;
+import org.drools.core.rule.accessor.FactHandleFactory;
 
 public interface AgendaGroupsManager extends Externalizable {
 
@@ -79,18 +80,20 @@ public interface AgendaGroupsManager extends Externalizable {
 
     InternalAgendaGroup getMainAgendaGroup();
 
-    static AgendaGroupsManager create(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
-        return kieBase.hasMultipleAgendaGroups() || !kieBase.getProcesses().isEmpty() ? new StackedAgendaGroupsManager(kieBase, workingMemory) : new SimpleAgendaGroupsManager(kieBase, workingMemory);
+    static AgendaGroupsManager create(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, FactHandleFactory factHandleFactory) {
+        return kieBase.hasMultipleAgendaGroups() || !kieBase.getProcesses().isEmpty() ? new StackedAgendaGroupsManager(kieBase, workingMemory, factHandleFactory) : new SimpleAgendaGroupsManager(kieBase, workingMemory, factHandleFactory);
     }
 
     class SimpleAgendaGroupsManager implements AgendaGroupsManager {
         private InternalAgendaGroup mainAgendaGroup;
         private ReteEvaluator reteEvaluator;
+		private FactHandleFactory factHandleFactory;
 
         public SimpleAgendaGroupsManager() { }
 
-        public SimpleAgendaGroupsManager(InternalRuleBase kieBase, ReteEvaluator reteEvaluator) {
+        public SimpleAgendaGroupsManager(InternalRuleBase kieBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactory) {
             this.reteEvaluator = reteEvaluator;
+			this.factHandleFactory = factHandleFactory;
             this.mainAgendaGroup = RuntimeComponentFactory.get().getAgendaGroupFactory().createAgendaGroup(InternalAgendaGroup.MAIN, kieBase);
             this.mainAgendaGroup.setReteEvaluator(reteEvaluator);
         }
@@ -104,7 +107,7 @@ public interface AgendaGroupsManager extends Externalizable {
         public void reset(boolean clearForRecency) {
             mainAgendaGroup.visited();
             if (clearForRecency) {
-                mainAgendaGroup.setClearedForRecency(this.reteEvaluator.getFactHandleFactory().getRecency());
+                mainAgendaGroup.setClearedForRecency(factHandleFactory.getRecency());
             }
             mainAgendaGroup.reset();
         }
@@ -189,7 +192,7 @@ public interface AgendaGroupsManager extends Externalizable {
             }
             if ( !mainAgendaGroup.isActive() ) {
                 // only update recency, if not already active. It may be active already if the use called setFocus
-                mainAgendaGroup.setActivatedForRecency( this.reteEvaluator.getFactHandleFactory().getRecency() );
+                mainAgendaGroup.setActivatedForRecency(factHandleFactory.getRecency() );
                 mainAgendaGroup.setActive( true );
             }
             return mainAgendaGroup;
@@ -248,14 +251,16 @@ public interface AgendaGroupsManager extends Externalizable {
         private InternalAgendaGroup mainAgendaGroup;
         private InternalWorkingMemory workingMemory;
 		private InternalRuleBase kieBase;
+		private FactHandleFactory factHandleFactory;
 
         public StackedAgendaGroupsManager() { }
 
-        public StackedAgendaGroupsManager(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
-            this.agendaGroupFactory = RuntimeComponentFactory.get().getAgendaGroupFactory();
+        public StackedAgendaGroupsManager(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, FactHandleFactory factHandleFactory) {
+			this.agendaGroupFactory = RuntimeComponentFactory.get().getAgendaGroupFactory();
             this.kieBase = kieBase;
             // stacked agenda groups are supported only for InternalWorkingMemory
             this.workingMemory = workingMemory;
+            this.factHandleFactory = factHandleFactory;
             if (this.mainAgendaGroup == null) {
                 this.mainAgendaGroup = agendaGroupFactory.createAgendaGroup( InternalAgendaGroup.MAIN, kieBase);
 				this.agendaGroups.put( InternalAgendaGroup.MAIN, this.mainAgendaGroup );
@@ -288,7 +293,7 @@ public interface AgendaGroupsManager extends Externalizable {
             for ( InternalAgendaGroup group : this.agendaGroups.values() ) {
                 // preserve lazy items.
                 if (clearForRecency) {
-                    group.setClearedForRecency(this.workingMemory.getFactHandleFactory().getRecency());
+                    group.setClearedForRecency(factHandleFactory.getRecency());
                 }
                 group.reset();
             }
@@ -326,7 +331,7 @@ public interface AgendaGroupsManager extends Externalizable {
 
             final EventSupport eventsupport = this.workingMemory;
 
-            agendaGroup.setClearedForRecency( this.workingMemory.getFactHandleFactory().getRecency() );
+            agendaGroup.setClearedForRecency(factHandleFactory.getRecency() );
 
             // this is thread safe for BinaryHeapQueue
             // Binary Heap locks while it returns the array and reset's it's own internal array. Lock is released afer getAndClear()
@@ -373,7 +378,7 @@ public interface AgendaGroupsManager extends Externalizable {
                 InternalAgendaGroup internalGroup = agendaGroup;
                 this.focusStack.add( internalGroup );
                 internalGroup.setActive( true );
-                internalGroup.setActivatedForRecency( this.workingMemory.getFactHandleFactory().getRecency() );
+                internalGroup.setActivatedForRecency(factHandleFactory.getRecency() );
                 final EventSupport eventsupport = this.workingMemory;
                 eventsupport.getAgendaEventSupport().fireAgendaGroupPushed( agendaGroup, this.workingMemory );
                 return true;
@@ -456,7 +461,7 @@ public interface AgendaGroupsManager extends Externalizable {
 
             if ( agendaGroup != null &&  !agendaGroup.isActive() ) {
                 // only update recency, if not already active. It may be active already if the use called setFocus
-                agendaGroup.setActivatedForRecency( this.workingMemory.getFactHandleFactory().getRecency() );
+                agendaGroup.setActivatedForRecency(factHandleFactory.getRecency() );
                 agendaGroup.setActive( true );
             }
             return agendaGroup;

--- a/drools-core/src/main/java/org/drools/core/common/EntryPointFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/EntryPointFactory.java
@@ -22,10 +22,11 @@ import org.drools.base.rule.EntryPointId;
 import org.drools.core.EntryPointsManager;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
+import org.drools.core.rule.accessor.FactHandleFactory;
 
 public interface EntryPointFactory {
 
-    InternalWorkingMemoryEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, EntryPointId id, EntryPointNode addedNode);
+    InternalWorkingMemoryEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactory, EntryPointId id, EntryPointNode addedNode);
 
-    EntryPointsManager createEntryPointsManager(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator);
+    EntryPointsManager createEntryPointsManager(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactory);
 }

--- a/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
@@ -52,6 +52,7 @@ import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
 import org.drools.core.reteoo.TerminalNode;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.core.rule.consequence.KnowledgeHelper;
 import org.drools.util.StringUtils;
@@ -81,10 +82,12 @@ public class ActivationsManagerImpl implements ActivationsManager {
     private final Map<QueryImpl, RuleAgendaItem> queries = new ConcurrentHashMap<>();
 
     private List<PropagationContext> expirationContexts;
+	private FactHandleFactory factHandleFactory;
 
-    public ActivationsManagerImpl(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator) {
+    public ActivationsManagerImpl(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactory) {
         this.reteEvaluator = reteEvaluator;
-        this.agendaGroupsManager = new AgendaGroupsManager.SimpleAgendaGroupsManager(ruleBase, reteEvaluator);
+		this.factHandleFactory = factHandleFactory;
+        this.agendaGroupsManager = new AgendaGroupsManager.SimpleAgendaGroupsManager(ruleBase, reteEvaluator, factHandleFactory);
         this.propagationList = new SynchronizedPropagationList(reteEvaluator);
         this.groupEvaluator = new SequentialGroupEvaluator( ruleBase, this );
         if (ruleBase.getRuleBaseConfiguration().getEventProcessingMode() == EventProcessingOption.STREAM) {
@@ -156,7 +159,7 @@ public class ActivationsManagerImpl implements ActivationsManager {
 
     @Override
     public void clearAndCancelActivationGroup(final InternalActivationGroup activationGroup) {
-        activationGroup.setTriggeredForRecency( this.reteEvaluator.getFactHandleFactory().getRecency() );
+        activationGroup.setTriggeredForRecency(factHandleFactory.getRecency() );
 
         for (final Iterator it = activationGroup.iterator(); it.hasNext(); ) {
             final ActivationGroupNode node = (ActivationGroupNode) it.next();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
@@ -38,6 +38,7 @@ import org.drools.core.phreak.RuleAgendaItem;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
 import org.drools.core.reteoo.TerminalNode;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.core.rule.consequence.KnowledgeHelper;
 import org.drools.core.util.CompositeIterator;
@@ -70,10 +71,10 @@ public class CompositeDefaultAgenda implements Externalizable, InternalAgenda {
 
     public CompositeDefaultAgenda() { }
 
-    public CompositeDefaultAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
+    public CompositeDefaultAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, FactHandleFactory factHandleFactory) {
         this.agendas = new DefaultAgenda[kieBase.getParallelEvaluationSlotsCount()];
         for ( int i = 0; i < this.agendas.length; i++ ) {
-            agendas[i] = new PartitionedDefaultAgenda(kieBase, workingMemory, executionStateMachine, i);
+            agendas[i] = new PartitionedDefaultAgenda(kieBase, workingMemory, factHandleFactory, executionStateMachine, i);
         }
         // this composite agenda and the first partitioned one share the same propagation list
         this.propagationList = agendas[0].getPropagationList();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -61,6 +61,7 @@ import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
 import org.drools.core.reteoo.TerminalNode;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.core.rule.consequence.ConsequenceExceptionHandler;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.core.rule.consequence.KnowledgeHelper;
@@ -123,18 +124,20 @@ public class DefaultAgenda implements InternalAgenda {
 
     private final AgendaGroupsManager agendaGroupsManager;
 
+	private FactHandleFactory factHandleFactory;
+
     // ------------------------------------------------------------
     // Constructors
     // ------------------------------------------------------------
 
-    public DefaultAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
-        this(kieBase, workingMemory, null);
+    public DefaultAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, FactHandleFactory factHandleFactory) {
+        this(kieBase, workingMemory, factHandleFactory, null);
     }
 
-    DefaultAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, ExecutionStateMachine executionStateMachine) {
-
+    DefaultAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, FactHandleFactory factHandleFactory, ExecutionStateMachine executionStateMachine) {
         this.workingMemory = workingMemory;
-        this.agendaGroupsManager = AgendaGroupsManager.create(kieBase, workingMemory);
+		this.factHandleFactory = factHandleFactory;
+        this.agendaGroupsManager = AgendaGroupsManager.create(kieBase, workingMemory, factHandleFactory);
         this.activationGroups = new HashMap<>();
 
         if (executionStateMachine != null) {
@@ -382,7 +385,7 @@ public class DefaultAgenda implements InternalAgenda {
     }
 
     public void activateRuleFlowGroup(final InternalRuleFlowGroup group, Object processInstanceId, String nodeInstanceId) {
-        this.workingMemory.getAgendaEventSupport().fireBeforeRuleFlowGroupActivated( group, this.workingMemory );
+        workingMemory.getAgendaEventSupport().fireBeforeRuleFlowGroupActivated( group, workingMemory );
         group.setActive( true );
         group.hasRuleFlowListener(true);
         if ( !StringUtils.isEmpty( nodeInstanceId ) ) {
@@ -390,7 +393,7 @@ public class DefaultAgenda implements InternalAgenda {
             group.setActive( true );
         }
         group.setFocus();
-        this.workingMemory.getAgendaEventSupport().fireAfterRuleFlowGroupActivated( group, this.workingMemory );
+        workingMemory.getAgendaEventSupport().fireAfterRuleFlowGroupActivated( group, workingMemory );
         propagationList.notifyWaitOnRest();
     }
 
@@ -400,7 +403,7 @@ public class DefaultAgenda implements InternalAgenda {
 
         // reset all activation groups.
         for ( InternalActivationGroup group : this.activationGroups.values() ) {
-            group.setTriggeredForRecency(this.workingMemory.getFactHandleFactory().getRecency());
+            group.setTriggeredForRecency(factHandleFactory.getRecency());
             group.reset();
         }
         propagationList.reset();
@@ -417,7 +420,7 @@ public class DefaultAgenda implements InternalAgenda {
 
         // reset all activation groups.
         for ( InternalActivationGroup group : this.activationGroups.values() ) {
-            group.setTriggeredForRecency( this.workingMemory.getFactHandleFactory().getRecency() );
+            group.setTriggeredForRecency(factHandleFactory.getRecency() );
             group.reset();
         }
 
@@ -470,7 +473,7 @@ public class DefaultAgenda implements InternalAgenda {
     public void clearAndCancelActivationGroup(final InternalActivationGroup activationGroup) {
         final EventSupport eventsupport = this.workingMemory;
 
-        activationGroup.setTriggeredForRecency( this.workingMemory.getFactHandleFactory().getRecency() );
+        activationGroup.setTriggeredForRecency(factHandleFactory.getRecency() );
 
         for ( final Iterator it = activationGroup.iterator(); it.hasNext(); ) {
             final ActivationGroupNode node = (ActivationGroupNode) it.next();

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgendaFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgendaFactory.java
@@ -23,6 +23,7 @@ import org.drools.core.common.AgendaFactory;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.impl.InternalRuleBase;
+import org.drools.core.rule.accessor.FactHandleFactory;
 
 import java.io.Serializable;
 
@@ -36,9 +37,9 @@ public class DefaultAgendaFactory implements AgendaFactory, Serializable {
 
     private DefaultAgendaFactory() { }
 
-    public InternalAgenda createAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
+    public InternalAgenda createAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, FactHandleFactory factHandleFactory) {
         return kieBase.getRuleBaseConfiguration().isParallelExecution() ?
-                new CompositeDefaultAgenda( kieBase, workingMemory ) :
-                new DefaultAgenda(kieBase, workingMemory );
+                new CompositeDefaultAgenda( kieBase, workingMemory, factHandleFactory ) :
+                new DefaultAgenda(kieBase, workingMemory, factHandleFactory );
     }
 }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/PartitionedDefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/PartitionedDefaultAgenda.java
@@ -23,6 +23,7 @@ import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.ObjectTypeNode;
+import org.drools.core.rule.accessor.FactHandleFactory;
 
 public class PartitionedDefaultAgenda extends DefaultAgenda {
 
@@ -30,9 +31,10 @@ public class PartitionedDefaultAgenda extends DefaultAgenda {
 
     PartitionedDefaultAgenda(InternalRuleBase kieBase, 
     		InternalWorkingMemory workingMemory,
-                             ExecutionStateMachine executionStateMachine,
-                             int partition) {
-        super(kieBase, workingMemory, executionStateMachine);
+    		FactHandleFactory factHandleFactory,
+    		ExecutionStateMachine executionStateMachine,
+    		int partition) {
+        super(kieBase, workingMemory, factHandleFactory, executionStateMachine);
         this.partition = partition;
     }
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPoint.java
@@ -89,7 +89,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
 
     protected ReteEvaluator reteEvaluator;
 
-    protected FactHandleFactory         handleFactory;
+    protected FactHandleFactory         factHandleFactory;
     protected PropagationContextFactory pctxFactory;
 
     protected ReentrantLock lock;
@@ -105,6 +105,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
 
     public NamedEntryPoint(InternalRuleBase ruleBase, 
             ReteEvaluator reteEvaluator,
+            FactHandleFactory factHandleFactory,
             EntryPointId entryPoint,
             EntryPointNode entryPointNode) {
         this.ruleBase = ruleBase;
@@ -112,7 +113,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
         this.entryPoint = entryPoint;
         this.entryPointNode = entryPointNode;
         this.lock = reteEvaluator.getRuleSessionConfiguration().isThreadSafe() ? new ReentrantLock() : null;
-        this.handleFactory = this.reteEvaluator.getFactHandleFactory();
+        this.factHandleFactory = factHandleFactory;
 
         RuleBaseConfiguration conf = this.ruleBase.getRuleBaseConfiguration();
         this.pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
@@ -156,7 +157,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
     }
 
     public FactHandleFactory getHandleFactory() {
-        return handleFactory;
+        return factHandleFactory;
     }
 
     /**
@@ -370,7 +371,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
                     this.objectStore.updateHandle(handle, object);
                 }
 
-                this.handleFactory.increaseFactHandleRecency(handle);
+                this.factHandleFactory.increaseFactHandleRecency(handle);
 
                 final PropagationContext propagationContext = pctxFactory.createPropagationContext(this.reteEvaluator.getNextPropagationIdCounter(), PropagationContext.Type.MODIFICATION,
                                                                                                    internalMatch == null ? null : internalMatch.getRule(),
@@ -487,7 +488,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
 
         deleteFromTMS( handle, key, typeConf, propagationContext );
 
-        this.handleFactory.destroyFactHandle( handle );
+        this.factHandleFactory.destroyFactHandle( handle );
     }
 
     protected void beforeDestroy(RuleImpl rule, TerminalNode terminalNode, InternalFactHandle handle) {
@@ -662,7 +663,7 @@ public class NamedEntryPoint implements InternalWorkingMemoryEntryPoint, Propert
 
     private InternalFactHandle createHandle(final Object object,
                                             ObjectTypeConf typeConf) {
-        return this.handleFactory.newFactHandle( object, typeConf, this.reteEvaluator, this );
+        return this.factHandleFactory.newFactHandle( object, typeConf, this.reteEvaluator, this );
     }
 
     public void propertyChange(final PropertyChangeEvent event) {

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointFactory.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointFactory.java
@@ -22,16 +22,17 @@ import org.drools.core.common.EntryPointFactory;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.base.rule.EntryPointId;
 
 public class NamedEntryPointFactory implements EntryPointFactory {
 
     @Override
-    public NamedEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, EntryPointId id, EntryPointNode addedNode) {
-        return new NamedEntryPoint(ruleBase, reteEvaluator, id, addedNode);
+    public NamedEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactory, EntryPointId id, EntryPointNode addedNode) {
+        return new NamedEntryPoint(ruleBase, reteEvaluator, factHandleFactory, id, addedNode);
     }
 
-    public NamedEntryPointsManager createEntryPointsManager(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator) {
-        return new NamedEntryPointsManager(ruleBase, reteEvaluator);
+    public NamedEntryPointsManager createEntryPointsManager(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactory) {
+        return new NamedEntryPointsManager(ruleBase, reteEvaluator, factHandleFactory);
     }
 }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointsManager.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/entrypoints/NamedEntryPointsManager.java
@@ -29,6 +29,7 @@ import org.drools.core.EntryPointsManager;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.RuntimeComponentFactory;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.base.rule.EntryPointId;
 
 public class NamedEntryPointsManager implements EntryPointsManager {
@@ -39,10 +40,12 @@ public class NamedEntryPointsManager implements EntryPointsManager {
     InternalWorkingMemoryEntryPoint defaultEntryPoint;
 
     private final Map<String, WorkingMemoryEntryPoint> entryPoints = new ConcurrentHashMap<>();
+	private FactHandleFactory factHandleFactory;
 
-    public NamedEntryPointsManager(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator) {
+    public NamedEntryPointsManager(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactory) {
         this.reteEvaluator = reteEvaluator;
         this.ruleBase = ruleBase;
+		this.factHandleFactory = factHandleFactory;
         initDefaultEntryPoint();
         updateEntryPointsCache();
     }
@@ -60,7 +63,7 @@ public class NamedEntryPointsManager implements EntryPointsManager {
     }
 
     private InternalWorkingMemoryEntryPoint createNamedEntryPoint(EntryPointNode addedNode) {
-        return RuntimeComponentFactory.get().getEntryPointFactory().createEntryPoint(ruleBase, reteEvaluator, addedNode.getEntryPoint(), addedNode);
+        return RuntimeComponentFactory.get().getEntryPointFactory().createEntryPoint(ruleBase, reteEvaluator, factHandleFactory, addedNode.getEntryPoint(), addedNode);
     }
 
     public void updateEntryPointsCache() {

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -339,9 +339,9 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         RuleBaseConfiguration conf = kBase.getRuleBaseConfiguration();
         this.pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
 
-        this.agenda = RuntimeComponentFactory.get().getAgendaFactory( config ).createAgenda(kBase, this);
+        this.agenda = RuntimeComponentFactory.get().getAgendaFactory( config ).createAgenda(kBase, this, handleFactory);
 
-        this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(kBase, this);
+        this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(kBase, this, handleFactory);
 
         this.sequential = conf.isSequential();
 
@@ -589,7 +589,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
     public InternalFactHandle initInitialFact(MarshallerReaderContext context) {
         WorkingMemoryEntryPoint defaultEntryPoint = entryPointsManager.getDefaultEntryPoint();
-        InternalFactHandle handle = getFactHandleFactory().newInitialFactHandle(defaultEntryPoint);
+        InternalFactHandle handle = handleFactory.newInitialFactHandle(defaultEntryPoint);
 
         ObjectTypeNode otn = defaultEntryPoint.getEntryPointNode().getObjectTypeNodes().get( InitialFact_ObjectType );
         if (otn != null) {
@@ -753,7 +753,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
                 evaluator.getRuleExecutor().evaluateNetworkAndFire( StatefulKnowledgeSessionImpl.this, null, 0, -1 );
             }
 
-            getFactHandleFactory().destroyFactHandle( factHandle );
+            handleFactory.destroyFactHandle( factHandle );
             done(null);
         }
     }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgenda.java
@@ -22,14 +22,15 @@ import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Storage;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.PropagationList;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.kiesession.agenda.DefaultAgenda;
 
 import static org.drools.reliability.core.ReliablePropagationList.PROPAGATION_LIST;
 
 public class ReliableAgenda extends DefaultAgenda {
 
-    public ReliableAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
-        super( kieBase, workingMemory );
+    public ReliableAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, FactHandleFactory factHandleFactory) {
+        super( kieBase, workingMemory, factHandleFactory );
     }
 
     @Override

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgendaFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableAgendaFactory.java
@@ -23,6 +23,7 @@ import org.drools.core.common.AgendaFactory;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.impl.InternalRuleBase;
+import org.drools.core.rule.accessor.FactHandleFactory;
 
 import java.io.Serializable;
 
@@ -36,7 +37,7 @@ public class ReliableAgendaFactory implements AgendaFactory, Serializable {
 
     private ReliableAgendaFactory() { }
 
-    public InternalAgenda createAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory) {
-        return new ReliableAgenda( kieBase, workingMemory );
+    public InternalAgenda createAgenda(InternalRuleBase kieBase, InternalWorkingMemory workingMemory, FactHandleFactory factHandleFactory) {
+        return new ReliableAgenda( kieBase, workingMemory, factHandleFactory);
     }
 }

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPoint.java
@@ -23,14 +23,15 @@ import org.drools.core.common.ObjectStore;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.base.rule.EntryPointId;
 import org.drools.kiesession.entrypoints.NamedEntryPoint;
 import org.kie.api.runtime.conf.PersistedSessionOption;
 
 public class ReliableNamedEntryPoint extends NamedEntryPoint {
 
-    public ReliableNamedEntryPoint(EntryPointId entryPoint, EntryPointNode entryPointNode, InternalRuleBase ruleBase, ReteEvaluator reteEvaluator) {
-        super(ruleBase, reteEvaluator, entryPoint, entryPointNode);
+    public ReliableNamedEntryPoint(EntryPointId entryPoint, EntryPointNode entryPointNode, InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactory) {
+        super(ruleBase, reteEvaluator, factHandleFactory, entryPoint, entryPointNode);
     }
 
     @Override

--- a/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPointFactory.java
+++ b/drools-reliability/drools-reliability-core/src/main/java/org/drools/reliability/core/ReliableNamedEntryPointFactory.java
@@ -21,6 +21,7 @@ package org.drools.reliability.core;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.base.rule.EntryPointId;
 import org.drools.kiesession.entrypoints.NamedEntryPoint;
 import org.drools.kiesession.entrypoints.NamedEntryPointFactory;
@@ -28,10 +29,10 @@ import org.drools.kiesession.entrypoints.NamedEntryPointFactory;
 public class ReliableNamedEntryPointFactory extends NamedEntryPointFactory {
 
     @Override
-    public NamedEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, EntryPointId id, EntryPointNode addedNode) {
+    public NamedEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactory, EntryPointId id, EntryPointNode addedNode) {
         if (!reteEvaluator.getSessionConfiguration().hasPersistedSessionOption()) {
-            return super.createEntryPoint(ruleBase, reteEvaluator, id, addedNode);
+            return super.createEntryPoint(ruleBase, reteEvaluator, factHandleFactory, id, addedNode);
         }
-        return new ReliableNamedEntryPoint(id, addedNode, ruleBase, reteEvaluator);
+        return new ReliableNamedEntryPoint(id, addedNode, ruleBase, reteEvaluator, factHandleFactory);
     }
 }

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
@@ -130,16 +130,16 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
         this.handleFactory = knowledgeBase.newFactHandleFactory();
         this.nodeMemories = new ConcurrentNodeMemories(ruleBase);
 
-        this.activationsManager = new ActivationsManagerImpl(ruleBase, this);
-        this.entryPointsManager = RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(ruleBase, this);
+        this.activationsManager = new ActivationsManagerImpl(ruleBase, this, handleFactory);
+        this.entryPointsManager = RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(ruleBase, this, handleFactory);
         this.timerService = sessionConfiguration.createTimerService();
 
-        initInitialFact(ruleBase);
+        initInitialFact();
     }
 
-    private void initInitialFact(InternalRuleBase kBase) {
+    private void initInitialFact() {
         WorkingMemoryEntryPoint defaultEntryPoint = entryPointsManager.getDefaultEntryPoint();
-        InternalFactHandle handle = getFactHandleFactory().newInitialFactHandle(defaultEntryPoint);
+        InternalFactHandle handle = handleFactory.newInitialFactHandle(defaultEntryPoint);
 
         ObjectTypeNode otn = defaultEntryPoint.getEntryPointNode().getObjectTypeNodes().get( InitialFact_ObjectType );
         if (otn != null) {

--- a/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/FactHandleMarshallingTest.java
+++ b/drools-serialization-protobuf/src/test/java/org/drools/serialization/protobuf/FactHandleMarshallingTest.java
@@ -79,7 +79,7 @@ public class FactHandleMarshallingTest {
 
         RuleBasePartitionId partionId = RuleBasePartitionId.MAIN_PARTITION;
         EntryPointNode entryPointNode = nFacotry.buildEntryPointNode(1, partionId, rete , EntryPointId.DEFAULT);
-        WorkingMemoryEntryPoint wmEntryPoint = new NamedEntryPoint(kBase, wm, EntryPointId.DEFAULT, entryPointNode);
+        WorkingMemoryEntryPoint wmEntryPoint = new NamedEntryPoint(kBase, wm, wm.getFactHandleFactory(), EntryPointId.DEFAULT, entryPointNode);
 
         DefaultEventHandle factHandle = new DefaultEventHandle(1, new Person(), 0, (new Date()).getTime(), 0, wmEntryPoint);
         

--- a/drools-traits/src/main/java/org/drools/traits/core/common/TraitEntryPointFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/common/TraitEntryPointFactory.java
@@ -23,13 +23,14 @@ import org.drools.core.common.EntryPointFactory;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.EntryPointNode;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.base.rule.EntryPointId;
 import org.drools.kiesession.entrypoints.NamedEntryPointFactory;
 
 public class TraitEntryPointFactory extends NamedEntryPointFactory implements EntryPointFactory {
 
     @Override
-    public NamedEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, EntryPointId id, EntryPointNode addedNode) {
-        return new TraitNamedEntryPoint(id, addedNode, ruleBase, reteEvaluator);
+    public NamedEntryPoint createEntryPoint(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, FactHandleFactory factHandleFactroy, EntryPointId id, EntryPointNode addedNode) {
+        return new TraitNamedEntryPoint(id, addedNode, ruleBase, reteEvaluator, factHandleFactroy);
     }
 }

--- a/drools-traits/src/main/java/org/drools/traits/core/common/TraitNamedEntryPoint.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/common/TraitNamedEntryPoint.java
@@ -29,6 +29,7 @@ import org.drools.base.factmodel.traits.TraitableBean;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.base.rule.EntryPointId;
+import org.drools.core.rule.accessor.FactHandleFactory;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.kiesession.entrypoints.NamedEntryPoint;
 import org.drools.traits.core.base.TraitHelperImpl;
@@ -41,8 +42,9 @@ public class TraitNamedEntryPoint extends NamedEntryPoint {
     public TraitNamedEntryPoint(EntryPointId entryPoint,
                                 EntryPointNode entryPointNode,
                                 InternalRuleBase ruleBase, 
-                                ReteEvaluator reteEvaluator) {
-        super(ruleBase, reteEvaluator, entryPoint, entryPointNode);
+                                ReteEvaluator reteEvaluator,
+                                FactHandleFactory factHandleFactory) {
+        super(ruleBase, reteEvaluator, factHandleFactory, entryPoint, entryPointNode);
         this.traitHelper = new TraitHelperImpl((InternalWorkingMemoryActions) reteEvaluator, this);
     }
 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

This PR is part of a series of PRs to reduce the use of ReteEvaluator as a God object and obtain a better modularization of the drools drl engine.

This PR is focused on removing the use of getFactHandleFactory, by passing the FactHandleFactory in the constructor of the various objects. 

Not all invocations have been removed, because they require deeper interventions and I wanted to keep the PR simple and relatively small.

