### PR TITLE
[incubator-kie-issues#2084] Updating decisionresult status on strictMode

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
@@ -629,6 +629,16 @@ public class DMNRuntimeImpl
                 // if result messages contains errors && runtime mode = strict -> stop execution and return null
                 if (strictMode && result.hasErrors()) {
                     logger.warn("Immediately return due to strict mode");
+                    DMNMessage message = MsgUtil.reportMessage(logger,
+                                                               DMNMessage.Severity.ERROR,
+                                                               decision.getSource(),
+                                                               result,
+                                                               null,
+                                                               null,
+                                                               Msg.ERROR_EVAL_DECISION_NODE_STRICT_MODE,
+                                                               getIdentifier(decision),
+                                                               decision.getResultType());
+                    reportFailure(dr, message, DMNDecisionResult.DecisionEvaluationStatus.FAILED);
                     return false;
                 } else if (er.getResultType() == EvaluatorResult.ResultType.SUCCESS ||
                         (((DMNModelImpl) result.getModel()).getFeelDialect().equals(FEELDialect.BFEEL) && er.getResult() != null)) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
@@ -102,6 +102,7 @@ public final class Msg {
     public static final Message2 ERROR_EVAL_DS_NODE                                  = new Message2( DMNMessageType.ERROR_EVAL_NODE, "Error evaluating Decision Service node '%s': %s" );
     public static final Message2 ERROR_EVAL_BKM_NODE                                 = new Message2( DMNMessageType.ERROR_EVAL_NODE, "Error evaluating Business Knowledge Model node '%s': %s" );
     public static final Message2 ERROR_EVAL_DECISION_NODE                            = new Message2( DMNMessageType.ERROR_EVAL_NODE, "Error evaluating Decision node '%s': %s" );
+    public static final Message2 ERROR_EVAL_DECISION_NODE_STRICT_MODE                = new Message2( DMNMessageType.ERROR_EVAL_NODE, "Error evaluating Decision node on strict mode '%s': %s" );
     public static final Message4 ERROR_EVAL_NODE_DEP_WRONG_TYPE                      = new Message4( DMNMessageType.ERROR_EVAL_NODE, "Error while evaluating node '%s' for dependency '%s': the dependency value '%s' is not allowed by the declared type (%s)" );
     public static final Message3 ERROR_EVAL_NODE_RESULT_WRONG_TYPE                   = new Message3( DMNMessageType.ERROR_EVAL_NODE, "Error while evaluating node '%s': the declared result type is '%s' but the actual value '%s' is not an instance of that type" );
     public static final Message2 EXPR_TYPE_NOT_SUPPORTED_IN_NODE                     = new Message2( DMNMessageType.EXPR_TYPE_NOT_SUPPORTED_IN_NODE, "Expression type '%s' not supported in node '%s'" );

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsCompiledTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsCompiledTest.java
@@ -20,6 +20,10 @@ package org.kie.dmn.core;
 
 import org.junit.jupiter.api.AfterEach;
 import org.kie.dmn.core.compiler.ExecModelCompilerOption;
+import org.kie.dmn.core.compiler.RuntimeModeOption;
+
+import static org.kie.dmn.core.compiler.RuntimeModeOption.MODE.LENIENT;
+import static org.kie.dmn.core.compiler.RuntimeModeOption.MODE.STRICT;
 
 public abstract class BaseInterpretedVsCompiledTest {
 
@@ -27,15 +31,28 @@ public abstract class BaseInterpretedVsCompiledTest {
         return new Object[]{false};
     }
 
+    protected static Object[] strictMode() {
+        return new Object[]{false, true};
+    }
+
     protected boolean useExecModelCompiler;
+    protected boolean useStrictMode;
 
     protected void init(boolean useExecModelCompiler){
+        init(useExecModelCompiler, false);
+    }
+
+    protected void init(boolean useExecModelCompiler, boolean useStrictMode) {
         this.useExecModelCompiler = useExecModelCompiler;
+        this.useStrictMode = useStrictMode;
         System.setProperty(ExecModelCompilerOption.PROPERTY_NAME, Boolean.toString(useExecModelCompiler));
+        String modeToSet = useStrictMode ? STRICT.getMode() : LENIENT.getMode();
+        System.setProperty(RuntimeModeOption.PROPERTY_NAME, modeToSet);
     }
 
     @AfterEach
     public void after() {
         System.clearProperty(ExecModelCompilerOption.PROPERTY_NAME);
+        System.clearProperty(RuntimeModeOption.PROPERTY_NAME);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
@@ -765,7 +765,6 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
         String nameSpace = "https://kie.org/dmn/_79591DB5-1EE1-4CBD-AA5D-2E3EDF31155E";
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("invalid_models/DMNv1_6/DMN-MultipleInvalidElements" +
                                                                         ".dmn", this.getClass());
-        //((DMNRuntimeImpl)runtime).setOption(new RuntimeModeOption(RuntimeModeOption.MODE.STRICT));
         final DMNModel dmnModel = runtime.getModel(
                 nameSpace,
                 "DMN_8F7C4323-412A-4E0B-9AEF-0F24C8F55282");

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNInputRuntimeTest.java
@@ -759,13 +759,13 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    void errorHandlingWithStrictModeEvaluateAll(boolean useExecModelCompiler) {
-        init(useExecModelCompiler);
+    @MethodSource("strictMode")
+    void errorHandlingWithWithoutStrictModeEvaluateAll(boolean strictMode) {
+        init(false, strictMode);
         String nameSpace = "https://kie.org/dmn/_79591DB5-1EE1-4CBD-AA5D-2E3EDF31155E";
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("invalid_models/DMNv1_6/DMN-MultipleInvalidElements" +
                                                                         ".dmn", this.getClass());
-        ((DMNRuntimeImpl)runtime).setOption(new RuntimeModeOption(RuntimeModeOption.MODE.STRICT));
+        //((DMNRuntimeImpl)runtime).setOption(new RuntimeModeOption(RuntimeModeOption.MODE.STRICT));
         final DMNModel dmnModel = runtime.getModel(
                 nameSpace,
                 "DMN_8F7C4323-412A-4E0B-9AEF-0F24C8F55282");
@@ -774,13 +774,25 @@ public class DMNInputRuntimeTest extends BaseInterpretedVsCompiledTest {
         final DMNContext dmnContext = DMNFactory.newContext();
         dmnContext.set("id", "_7273EA2E-2CC3-4012-8F87-39E310C8DF3C");
         dmnContext.set("Conditional Input", 107);
-        dmnContext.set("New Input Data", 8888);
+        dmnContext.set("New Input Data", "8888");
         dmnContext.set("Score", 80);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, dmnContext);
         assertThat(dmnResult.hasErrors()).as(DMNRuntimeUtil.formatMessages(dmnResult.getMessages())).isTrue();
-        assertThat(dmnResult.getMessages(DMNMessage.Severity.ERROR).size()).isEqualTo(2);
-        assertThat(dmnResult.getDecisionResults()).isNotNull().hasSize(3);
-        dmnResult.getDecisionResults().forEach(decisionResult -> assertThat(decisionResult.getResult()).isNull());
+        if (strictMode) {
+            assertThat(dmnResult.getMessages(DMNMessage.Severity.ERROR).size()).isEqualTo(5);
+            assertThat(dmnResult.getDecisionResults()).isNotNull().hasSize(3);
+            dmnResult.getDecisionResults().forEach(decisionResult -> {
+                assertThat(decisionResult.getResult()).isNull();
+                assertThat(decisionResult.getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.FAILED);
+            });
+        } else {
+            assertThat(dmnResult.getDecisionResultByName("Decision1").getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.SUCCEEDED);
+            assertThat(dmnResult.getDecisionResultByName("Decision2").getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.FAILED);
+            assertThat(dmnResult.getDecisionResultByName("Decision3").getEvaluationStatus()).isEqualTo(DMNDecisionResult.DecisionEvaluationStatus.SUCCEEDED);
+            assertThat(dmnResult.getDecisionResultByName("Decision1").getResult()).isNull();
+            assertThat(dmnResult.getDecisionResultByName("Decision2").getResult()).isNull();
+            assertThat(dmnResult.getDecisionResultByName("Decision3").getResult()).isEqualTo("Good");
+        }
     }
 
     @ParameterizedTest

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNRuntimeUtil.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/util/DMNRuntimeUtil.java
@@ -44,6 +44,7 @@ import org.kie.dmn.api.core.event.BeforeEvaluateDecisionEvent;
 import org.kie.dmn.api.core.event.BeforeEvaluateDecisionTableEvent;
 import org.kie.dmn.api.core.event.DMNRuntimeEventListener;
 import org.kie.dmn.core.api.event.DefaultDMNRuntimeEventListener;
+import org.kie.dmn.core.compiler.RuntimeModeOption;
 import org.kie.dmn.core.compiler.RuntimeTypeCheckOption;
 import org.kie.dmn.core.impl.DMNRuntimeImpl;
 import org.kie.internal.builder.InternalKieBuilder;
@@ -96,7 +97,7 @@ public final class DMNRuntimeUtil {
                                                    .filter(DMNMessage.class::isInstance)
                                                    .map(DMNMessage.class::cast)
                                                    .collect(Collectors.toList());
-        assertThat(dmnMessages).isNotEmpty();;
+        assertThat(dmnMessages).isNotEmpty();
         return dmnMessages;
     }
 
@@ -137,6 +138,8 @@ public final class DMNRuntimeUtil {
     public static DMNRuntime typeSafeGetKieRuntime(final KieContainer kieContainer) {
         DMNRuntime dmnRuntime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         ((DMNRuntimeImpl) dmnRuntime).setOption(new RuntimeTypeCheckOption(true));
+        String runtimeMode = System.getProperty(RuntimeModeOption.PROPERTY_NAME, RuntimeModeOption.MODE.LENIENT.getMode());
+        ((DMNRuntimeImpl)dmnRuntime).setOption(new RuntimeModeOption(runtimeMode));
         return dmnRuntime;
     }
     


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2084

This PR:
1: introduce the status update if decision result when evaluation is `strictMode` and there are errors in the evaluation itself
2: updated related test
3: modify `DMNMRUntimeUtil` to automatically set the strict/lenient mode when instantiated, based on related System property

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
