### PR TITLE
[incubator-kie-drools-6442] Remove reteevaluator from mvel

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -18,6 +18,7 @@
  */
 package org.drools.core.phreak;
 
+import org.drools.base.base.ValueResolver;
 import org.drools.base.reteoo.AccumulateContextEntry;
 import org.drools.base.reteoo.BaseTuple;
 import org.drools.base.rule.Accumulate;
@@ -206,7 +207,7 @@ public class PhreakAccumulateNode {
         return accContext;
     }
 
-    public static void initContext(Object workingMemoryContext, ReteEvaluator reteEvaluator, Accumulate accumulate, BaseTuple leftTuple, AccumulateContextEntry accContext) {
+    public static void initContext(Object workingMemoryContext, ValueResolver reteEvaluator, Accumulate accumulate, BaseTuple leftTuple, AccumulateContextEntry accContext) {
         // Create the function context, but allow init to override it.
         Object funcContext = accumulate.createFunctionContext();
         funcContext = accumulate.init(workingMemoryContext, accContext, funcContext, leftTuple, reteEvaluator);

--- a/drools-core/src/main/java/org/drools/core/reteoo/AccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AccumulateNode.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.drools.base.base.ClassObjectType;
 import org.drools.base.base.ObjectType;
+import org.drools.base.base.ValueResolver;
 import org.drools.base.common.NetworkNode;
 import org.drools.base.reteoo.AccumulateContextEntry;
 import org.drools.base.reteoo.BaseTuple;
@@ -184,7 +185,7 @@ public class AccumulateNode extends BetaNode {
      * Creates a BetaMemory for the BetaNode's memory.
      */
     public Memory createMemory(final RuleBaseConfiguration config, ReteEvaluator reteEvaluator) {
-        BetaMemory betaMemory = (BetaMemory) this.constraints.createBetaMemory(config, NodeTypeEnums.AccumulateNode);
+        BetaMemory betaMemory = this.constraints.createBetaMemory(config, NodeTypeEnums.AccumulateNode);
         AccumulateMemory memory = this.accumulate.isMultiFunction() ?
                                   new MultiAccumulateMemory(betaMemory, this.accumulate.getAccumulators()) :
                                   new SingleAccumulateMemory(betaMemory, this.accumulate.getAccumulators()[0]);
@@ -320,7 +321,7 @@ public class AccumulateNode extends BetaNode {
         }
 
         public TupleListWithContext<AccumulateContextEntry> getGroup(Object workingMemoryContext, Accumulate accumulate, BaseTuple leftTuple,
-                                                          Object key, ReteEvaluator reteEvaluator) {
+                                                          Object key, ValueResolver reteEvaluator) {
             return groupsMap.computeIfAbsent(key, k -> {
                 AccumulateContextEntry entry = new AccumulateContextEntry(key);
                 entry.setFunctionContext( accumulate.init(workingMemoryContext, entry, accumulate.createFunctionContext(), leftTuple, reteEvaluator) );

--- a/drools-mvel/src/main/java/org/drools/mvel/EvaluatorConstraint.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/EvaluatorConstraint.java
@@ -24,7 +24,6 @@ import java.io.ObjectOutput;
 import java.util.Arrays;
 
 import org.drools.base.base.ValueResolver;
-import org.drools.core.common.InternalFactHandle;
 import org.drools.base.reteoo.BaseTuple;
 import org.drools.base.rule.Declaration;
 import org.drools.base.rule.IntervalProviderConstraint;
@@ -187,7 +186,7 @@ public class EvaluatorConstraint extends MutableTypeConstraint<ContextEntry> imp
         public void readExternal(ObjectInput in) throws IOException,
                                                 ClassNotFoundException {
             extractor = (ReadAccessor) in.readObject();
-            factHandle = ( InternalFactHandle ) in.readObject();
+            factHandle = ( FactHandle ) in.readObject();
             next = (ContextEntry) in.readObject();
             valueResolver = ( ValueResolver ) in .readObject();
         }

--- a/drools-mvel/src/main/java/org/drools/mvel/EvaluatorHelper.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/EvaluatorHelper.java
@@ -27,7 +27,6 @@ import org.drools.base.base.CoreComponentsBuilder;
 import org.drools.compiler.rule.builder.EvaluatorWrapper;
 import org.drools.base.reteoo.BaseTuple;
 import org.drools.base.rule.Declaration;
-import org.drools.core.reteoo.Tuple;
 import org.kie.api.runtime.rule.FactHandle;
 
 public class EvaluatorHelper {
@@ -50,7 +49,7 @@ public class EvaluatorHelper {
         return map;
     }
 
-    public static void initOperators(FactHandle handle, Tuple tuple, EvaluatorWrapper[] operators) {
+    public static void initOperators(FactHandle handle, BaseTuple tuple, EvaluatorWrapper[] operators) {
         FactHandle[] handles = tuple != null ? tuple.toFactHandles() : new FactHandle[0];
         for (EvaluatorWrapper operator : operators) {
             operator.loadHandles(handles, handle);

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraint.java
@@ -61,8 +61,6 @@ import org.drools.base.rule.constraint.Constraint;
 import org.drools.base.util.IndexedValueReader;
 import org.drools.base.util.index.ConstraintTypeOperator;
 import org.drools.compiler.rule.builder.EvaluatorWrapper;
-import org.drools.core.impl.KnowledgeBaseImpl;
-import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.mvel.ConditionAnalyzer.CombinedCondition;
 import org.drools.mvel.ConditionAnalyzer.Condition;
 import org.drools.mvel.ConditionAnalyzer.EvaluatedExpression;
@@ -812,8 +810,8 @@ public class MVELConstraint extends MutableTypeConstraint<ContextEntry> implemen
             return true;
         }
 
-        Map<String, Object> thisImports = (( MVELDialectRuntimeData ) ((KnowledgeBaseImpl)kbase).getPackage(thisPkg).getDialectRuntimeRegistry().getDialectData("mvel")).getImports();
-        Map<String, Object> otherImports = (( MVELDialectRuntimeData ) ((KnowledgeBaseImpl)kbase).getPackage(otherPkg).getDialectRuntimeRegistry().getDialectData("mvel")).getImports();
+        Map<String, Object> thisImports = (( MVELDialectRuntimeData ) kbase.getPackage(thisPkg).getDialectRuntimeRegistry().getDialectData("mvel")).getImports();
+        Map<String, Object> otherImports = (( MVELDialectRuntimeData ) kbase.getPackage(otherPkg).getDialectRuntimeRegistry().getDialectData("mvel")).getImports();
 
                     if (fieldValue != null && constraintType.getOperator() != null) {
             return equalsExpressionTokensInBothImports(getLeftInExpression(constraintType), thisImports, otherImports);
@@ -877,7 +875,7 @@ public class MVELConstraint extends MutableTypeConstraint<ContextEntry> implemen
 
     protected MVELDialectRuntimeData getMVELDialectRuntimeData(RuleBase kbase) {
         for (String packageName : packageNames) {
-            InternalKnowledgePackage pkg = ((InternalKnowledgeBase)kbase).getPackage(packageName);
+            InternalKnowledgePackage pkg = kbase.getPackage(packageName);
             if (pkg != null) {
                 return ((MVELDialectRuntimeData) pkg.getDialectRuntimeRegistry().getDialectData("mvel"));
             }

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraintBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraintBuilder.java
@@ -21,7 +21,6 @@ package org.drools.mvel;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,7 +29,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import org.drools.base.base.DroolsQuery;
@@ -118,7 +116,6 @@ import static org.drools.compiler.rule.builder.PatternBuilder.registerDescrBuild
 import static org.drools.compiler.rule.builder.util.PatternBuilderUtil.getNormalizeDate;
 import static org.drools.compiler.rule.builder.util.PatternBuilderUtil.normalizeEmptyKeyword;
 import static org.drools.compiler.rule.builder.util.PatternBuilderUtil.normalizeStringOperator;
-import static org.drools.util.ClassUtils.convertFromPrimitiveType;
 import static org.drools.mvel.asm.AsmUtil.copyErrorLocation;
 import static org.drools.mvel.builder.MVELExprAnalyzer.analyze;
 import static org.drools.mvel.expr.MvelEvaluator.createMvelEvaluator;
@@ -545,7 +542,7 @@ public class MVELConstraintBuilder implements ConstraintBuilder {
 
     private static MVELAnalysisResult analyzeExpression(String expr, ParserConfiguration conf, BoundIdentifiers availableIdentifiers) {
         if (expr.trim().isEmpty()) {
-            MVELAnalysisResult result = analyze( (Set<String> ) Collections.EMPTY_SET, availableIdentifiers );
+            MVELAnalysisResult result = analyze( Collections.emptySet(), availableIdentifiers );
             result.setMvelVariables( new HashMap<>() );
             result.setTypesafe( true );
             return result;
@@ -628,7 +625,7 @@ public class MVELConstraintBuilder implements ConstraintBuilder {
 
         MVELAnalysisResult result = analyze( requiredInputs, availableIdentifiers );
         result.setReturnType( returnType );
-        result.setMvelVariables( (Map<String, Class< ? >>) (Map) variables );
+        result.setMvelVariables( (Map) variables );
         result.setTypesafe( true );
         return result;
     }

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELGroupByAccumulate.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELGroupByAccumulate.java
@@ -28,7 +28,6 @@ import org.drools.base.rule.accessor.FieldValue;
 import org.drools.base.rule.accessor.ReturnValueExpression;
 import org.drools.base.rule.accessor.Wireable;
 import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.ReteEvaluator;
 import org.drools.core.reteoo.AccumulateNode;
 import org.drools.core.reteoo.EvalNodeLeftTuple;
 import org.drools.core.reteoo.Tuple;
@@ -61,7 +60,7 @@ public class MVELGroupByAccumulate extends Accumulate {
         return innerAccumulate;
     }
 
-    private Object getKey( Tuple tuple, FactHandle handle, ReteEvaluator reteEvaluator ) {
+    private Object getKey( Tuple tuple, FactHandle handle, ValueResolver reteEvaluator ) {
         try {
             Tuple keyTuple = isMvel? tuple : new EvalNodeLeftTuple((InternalFactHandle) handle, (TupleImpl) tuple, tuple
                     .getSink());
@@ -114,7 +113,7 @@ public class MVELGroupByAccumulate extends Accumulate {
             BaseTuple match, FactHandle handle, ValueResolver valueResolver) {
         AccumulateNode.GroupByContext groupByContext = (AccumulateNode.GroupByContext) context;
         TupleListWithContext<AccumulateContextEntry> tupleList = groupByContext.getGroup(workingMemoryContext, innerAccumulate,
-                                                                                         match, getKey( (Tuple) match, handle, (ReteEvaluator) valueResolver), (ReteEvaluator) valueResolver);
+                                                                                         match, getKey( (Tuple) match, handle, valueResolver), valueResolver);
 
         return accumulate(workingMemoryContext, match, handle, groupByContext, tupleList, valueResolver);
     }

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ClassFieldAccessorFactory.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ClassFieldAccessorFactory.java
@@ -26,7 +26,6 @@ import org.drools.core.base.*;
 import org.drools.core.base.ClassFieldAccessorCache.CacheEntry;
 import org.drools.base.base.extractors.BaseObjectClassFieldReader;
 import org.drools.base.base.extractors.SelfReferenceClassFieldReader;
-import org.drools.core.common.InternalWorkingMemory;
 import org.drools.base.util.Drools;
 import org.drools.mvel.accessors.*;
 import org.drools.wiring.api.util.ByteArrayClassLoader;
@@ -358,7 +357,7 @@ public class ClassFieldAccessorFactory implements FieldAccessorFactory {
                                l1,
                                0 );
         mv.visitLocalVariable( "workingMemory",
-                               Type.getDescriptor( InternalWorkingMemory.class ),
+                               Type.getDescriptor( ValueResolver.class ),
                                null,
                                l0,
                                l1,

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/GeneratorHelper.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/GeneratorHelper.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 import org.drools.base.base.ValueResolver;
 import org.drools.base.reteoo.BaseTuple;
-import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.util.ClassTypeResolver;
 import org.drools.util.TypeResolver;
 import org.drools.core.common.InternalFactHandle;
@@ -136,7 +135,7 @@ public final class GeneratorHelper {
     }
 
     static TypeResolver getTypeResolver(final InvokerStub stub, final ValueResolver valueResolver, final ClassLoader classLoader) {
-        InternalKnowledgePackage pkg = ((InternalKnowledgeBase)valueResolver.getRuleBase()).getPackage(stub.getPackageName());
+        InternalKnowledgePackage pkg = valueResolver.getRuleBase().getPackage(stub.getPackageName());
         TypeResolver typeResolver = pkg == null ? null : pkg.getTypeResolver();
         if (typeResolver == null) {
             Set<String> imports = new HashSet<>();

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/AfterEvaluatorDefinition.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/AfterEvaluatorDefinition.java
@@ -29,9 +29,9 @@ import org.drools.base.base.ValueType;
 import org.drools.compiler.rule.builder.EvaluatorDefinition;
 import org.drools.drl.parser.impl.Operator;
 import org.drools.base.util.TimeIntervalParser;
-import org.drools.core.common.DefaultEventHandle;
 import org.drools.base.rule.accessor.Evaluator;
 import org.drools.base.time.Interval;
+import org.kie.api.runtime.rule.EventHandle;
 import org.kie.api.runtime.rule.FactHandle;
 
 /**
@@ -249,12 +249,12 @@ public class AfterEvaluatorDefinition
 
         @Override
         protected long getLeftTimestamp( FactHandle handle) {
-            return ( (DefaultEventHandle) handle ).getEndTimestamp();
+            return ( (EventHandle) handle ).getEndTimestamp();
         }
 
         @Override
         protected long getRightTimestamp( FactHandle handle ) {
-            return ( (DefaultEventHandle) handle ).getStartTimestamp();
+            return ( (EventHandle) handle ).getStartTimestamp();
         }
     }
 }

--- a/drools-mvel/src/main/java/org/drools/mvel/evaluators/VariableRestriction.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/evaluators/VariableRestriction.java
@@ -34,7 +34,6 @@ import org.drools.mvel.evaluators.MeetsEvaluatorDefinition.MeetsEvaluator;
 import org.drools.mvel.evaluators.MetByEvaluatorDefinition.MetByEvaluator;
 import org.drools.core.common.DefaultEventHandle;
 import org.drools.base.rule.accessor.Evaluator;
-import org.drools.core.reteoo.Tuple;
 import org.kie.api.runtime.rule.EventHandle;
 import org.kie.api.runtime.rule.FactHandle;
 
@@ -122,7 +121,7 @@ public class VariableRestriction {
             evaluator = (Evaluator) in.readObject();
             object = in.readObject();
             declaration = (Declaration) in.readObject();
-            tuple = (Tuple) in.readObject();
+            tuple = (BaseTuple) in.readObject();
             entry = (ContextEntry) in.readObject();
             leftNull = in.readBoolean();
             rightNull = in.readBoolean();

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELAccumulator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELAccumulator.java
@@ -33,7 +33,6 @@ import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.reteoo.BaseTuple;
 import org.drools.base.rule.Declaration;
 import org.drools.base.rule.accessor.Accumulator;
-import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.drools.mvel.expr.MVELCompilationUnit.DroolsVarFactory;
 import org.kie.api.runtime.rule.FactHandle;
@@ -123,7 +122,7 @@ public class MVELAccumulator
         VariableResolverFactory factory = factoryContext.getInitFactory();
         initUnit.updateFactory( null, tuple, localVars, valueResolver, valueResolver.getGlobalResolver(), factory );
 
-        InternalKnowledgePackage pkg = ((InternalKnowledgeBase)valueResolver.getRuleBase()).getPackage("MAIN");
+        InternalKnowledgePackage pkg = valueResolver.getRuleBase().getPackage("MAIN");
         if ( pkg != null ) {
             MVELDialectRuntimeData data = ( MVELDialectRuntimeData ) pkg.getDialectRuntimeRegistry().getDialectData( "mvel" );
             factory.setNextFactory( data.getFunctionFactory() );

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELConsequence.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELConsequence.java
@@ -29,7 +29,6 @@ import org.drools.base.definitions.InternalKnowledgePackage;
 import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.rule.consequence.Consequence;
 import org.drools.core.rule.consequence.KnowledgeHelper;
-import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.mvel2.integration.VariableResolverFactory;
 
@@ -88,7 +87,7 @@ public class MVELConsequence
                 knowledgeHelper.getRule(), knowledgeHelper.getTuple(), null, valueResolver, valueResolver.getGlobalResolver());
 
         // do we have any functions for this namespace?
-        InternalKnowledgePackage pkg = ((InternalKnowledgeBase)valueResolver.getRuleBase()).getPackage("MAIN");
+        InternalKnowledgePackage pkg = valueResolver.getRuleBase().getPackage("MAIN");
         if (pkg != null) {
             MVELDialectRuntimeData data = (MVELDialectRuntimeData) pkg.getDialectRuntimeRegistry().getDialectData(this.id);
             factory.setNextFactory(data.getFunctionFactory());

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELEnabledExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELEnabledExpression.java
@@ -32,7 +32,6 @@ import org.drools.base.reteoo.BaseTuple;
 import org.drools.base.reteoo.SortDeclarations;
 import org.drools.base.rule.Declaration;
 import org.drools.base.rule.accessor.Enabled;
-import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.mvel2.integration.VariableResolverFactory;
 
@@ -91,7 +90,7 @@ public class MVELEnabledExpression
                                                            rule, null, tuple, null, valueResolver, valueResolver.getGlobalResolver()  );
 
         // do we have any functions for this namespace?
-        InternalKnowledgePackage pkg = ((InternalKnowledgeBase)valueResolver.getRuleBase()).getPackage("MAIN");
+        InternalKnowledgePackage pkg = valueResolver.getRuleBase().getPackage("MAIN");
         if ( pkg != null ) {
             MVELDialectRuntimeData data = ( MVELDialectRuntimeData ) pkg.getDialectRuntimeRegistry().getDialectData( this.id );
             factory.setNextFactory( data.getFunctionFactory() );

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELEvalExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELEvalExpression.java
@@ -29,7 +29,6 @@ import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.reteoo.BaseTuple;
 import org.drools.base.rule.Declaration;
 import org.drools.base.rule.accessor.EvalExpression;
-import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.mvel2.integration.VariableResolverFactory;
 
@@ -94,7 +93,7 @@ public class MVELEvalExpression
                             factory );
 
         // do we have any functions for this namespace?
-        InternalKnowledgePackage pkg = ((InternalKnowledgeBase)valueResolver.getRuleBase()).getPackage("MAIN");
+        InternalKnowledgePackage pkg = valueResolver.getRuleBase().getPackage("MAIN");
         if ( pkg != null ) {
             MVELDialectRuntimeData data = ( MVELDialectRuntimeData ) pkg.getDialectRuntimeRegistry().getDialectData( this.id );
             factory.setNextFactory( data.getFunctionFactory() );

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELObjectExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELObjectExpression.java
@@ -29,7 +29,6 @@ import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.reteoo.BaseTuple;
 import org.drools.base.rule.Declaration;
 import org.drools.core.time.TimerExpression;
-import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.mvel2.ParserConfiguration;
 import org.mvel2.integration.VariableResolverFactory;
@@ -92,7 +91,7 @@ public class MVELObjectExpression implements MVELCompileable, TimerExpression, E
                                                            null, null, leftTuple, null, valueResolver, valueResolver.getGlobalResolver() );
         
         // do we have any functions for this namespace?
-        InternalKnowledgePackage pkg = ((InternalKnowledgeBase)valueResolver.getRuleBase()).getPackage("MAIN");
+        InternalKnowledgePackage pkg = valueResolver.getRuleBase().getPackage("MAIN");
         if ( pkg != null ) {
             MVELDialectRuntimeData data = ( MVELDialectRuntimeData ) pkg.getDialectRuntimeRegistry().getDialectData( this.id );
             factory.setNextFactory( data.getFunctionFactory() );

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELReturnValueExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELReturnValueExpression.java
@@ -22,13 +22,10 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.Arrays;
 
 import org.drools.base.base.ValueResolver;
 import org.drools.base.definitions.InternalKnowledgePackage;
 import org.drools.base.definitions.rule.impl.RuleImpl;
-import org.drools.core.impl.InternalRuleBase;
-import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.base.reteoo.BaseTuple;
 import org.drools.base.rule.Declaration;
 import org.drools.base.rule.accessor.FieldValue;
@@ -96,7 +93,7 @@ public class MVELReturnValueExpression
 
         
         // do we have any functions for this namespace?
-        InternalKnowledgePackage pkg = ((InternalRuleBase)valueResolver.getRuleBase()).getPackage("MAIN");
+        InternalKnowledgePackage pkg = valueResolver.getRuleBase().getPackage("MAIN");
         if ( pkg != null ) {
             MVELDialectRuntimeData data = ( MVELDialectRuntimeData ) pkg.getDialectRuntimeRegistry().getDialectData( this.id );
             factory.setNextFactory( data.getFunctionFactory() );

--- a/drools-mvel/src/main/java/org/drools/mvel/expr/MVELSalienceExpression.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/expr/MVELSalienceExpression.java
@@ -33,7 +33,6 @@ import org.drools.base.rule.Declaration;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.base.rule.accessor.Salience;
 import org.drools.base.time.TimeUtils;
-import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.kie.api.definition.rule.Rule;
 import org.kie.api.runtime.rule.Match;
@@ -97,7 +96,7 @@ public class MVELSalienceExpression
                                                            null, valueResolver, valueResolver.getGlobalResolver() );
         
         // do we have any functions for this namespace?
-        InternalKnowledgePackage pkg = ((InternalKnowledgeBase)valueResolver.getRuleBase()).getPackage("MAIN");
+        InternalKnowledgePackage pkg = valueResolver.getRuleBase().getPackage("MAIN");
         if ( pkg != null ) {
             MVELDialectRuntimeData data = ( MVELDialectRuntimeData ) pkg.getDialectRuntimeRegistry().getDialectData( this.id );
             factory.setNextFactory( data.getFunctionFactory() );

--- a/drools-mvel/src/main/java/org/drools/mvel/field/ClassFieldImpl.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/field/ClassFieldImpl.java
@@ -19,7 +19,6 @@
 package org.drools.mvel.field;
 
 import org.drools.base.common.DroolsObjectInput;
-import org.drools.core.common.InternalWorkingMemory;
 import org.drools.base.rule.accessor.FieldValue;
 
 import java.io.Externalizable;


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

New PR to cleanup unnecessary dependencies from drools-core in general and ReteEvaluator in particular.

This PR targets drools-mvel. Where possible I have used drools-base classes instead of drools-core classes.

Two major points that will require further work are the parts related to code generation and the parts related to grouping functions. 

