### PR TITLE
[incubator-kie-issues#2091] Modify the `kogito-maven-plugin` to be a wrapper of the codegen library

### DIFF
--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileType.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileType.java
@@ -32,13 +32,11 @@ public interface GeneratedFileType {
     GeneratedFileType INTERNAL_RESOURCE = of(Category.INTERNAL_RESOURCE);
     GeneratedFileType STATIC_HTTP_RESOURCE = of(Category.STATIC_HTTP_RESOURCE);
     GeneratedFileType COMPILED_CLASS = of(Category.COMPILED_CLASS);
-
+    GeneratedFileType REST = of("REST", Category.SOURCE);
     GeneratedFileType RULE = of("RULE", Category.SOURCE);
 
     GeneratedFileType CONFIG = of("CONFIG", Category.SOURCE);
     GeneratedFileType DECLARED_TYPE = of("DECLARED_TYPE", Category.SOURCE);
-
-    GeneratedFileType REST = of("REST", Category.SOURCE, true, true);
 
     String name();
 

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileType.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileType.java
@@ -32,7 +32,7 @@ public interface GeneratedFileType {
     GeneratedFileType INTERNAL_RESOURCE = of(Category.INTERNAL_RESOURCE);
     GeneratedFileType STATIC_HTTP_RESOURCE = of(Category.STATIC_HTTP_RESOURCE);
     GeneratedFileType COMPILED_CLASS = of(Category.COMPILED_CLASS);
-    GeneratedFileType REST = of("REST", Category.SOURCE);
+    GeneratedFileType REST = of("REST", Category.SOURCE, true, true);
     GeneratedFileType RULE = of("RULE", Category.SOURCE);
 
     GeneratedFileType CONFIG = of("CONFIG", Category.SOURCE);

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileType.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileType.java
@@ -32,7 +32,7 @@ public interface GeneratedFileType {
     GeneratedFileType INTERNAL_RESOURCE = of(Category.INTERNAL_RESOURCE);
     GeneratedFileType STATIC_HTTP_RESOURCE = of(Category.STATIC_HTTP_RESOURCE);
     GeneratedFileType COMPILED_CLASS = of(Category.COMPILED_CLASS);
-    GeneratedFileType REST = of("REST", Category.SOURCE, true, true);
+    GeneratedFileType REST = of("REST", Category.SOURCE);
     GeneratedFileType RULE = of("RULE", Category.SOURCE);
 
     GeneratedFileType CONFIG = of("CONFIG", Category.SOURCE);

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileWriter.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/GeneratedFileWriter.java
@@ -51,16 +51,16 @@ public class GeneratedFileWriter {
      * @param finalPath
      * @param resourcesDirectoryProperty
      * @param sourcesDirectoryProperty
-     * @param bt
+     * @param buildTool
      * @return
      */
-    static Builder builder(String finalPath, String resourcesDirectoryProperty, String sourcesDirectoryProperty, AppPaths.BuildTool bt ) {
+    static Builder builder(String finalPath, String resourcesDirectoryProperty, String sourcesDirectoryProperty, AppPaths.BuildTool buildTool ) {
         // using runtime BT instead to allow usage of
         // Springboot from GRADLE
-        String targetClasses = bt.CLASSES_PATH.toString();
+        String targetClasses = buildTool.CLASSES_PATH.toString();
 
-        String generatedResourcesSourcesKogito = Path.of(bt.GENERATED_RESOURCES_PATH.toString(), finalPath).toString();
-        String generatedSourcesKogito = Path.of(bt.GENERATED_SOURCES_PATH.toString(), finalPath).toString();
+        String generatedResourcesSourcesKogito = Path.of(buildTool.GENERATED_RESOURCES_PATH.toString(), finalPath).toString();
+        String generatedSourcesKogito = Path.of(buildTool.GENERATED_SOURCES_PATH.toString(), finalPath).toString();
         return new Builder(targetClasses,
                            getConfig(resourcesDirectoryProperty, generatedResourcesSourcesKogito),
                            getConfig(sourcesDirectoryProperty, generatedSourcesKogito));
@@ -69,19 +69,19 @@ public class GeneratedFileWriter {
     public static class Builder {
         //Default-access for testing purpose
         final String classesDir;
-        final String resourcePath;
-        final String scaffoldedSourcesDir;
+        final String resourcesDir;
+        final String sourcesDir;
 
         /**
          *
          * @param classesDir usually target/classes/
          * @param resourcesDir usually target/generated-resources/kogito/
-         * @param scaffoldedSourcesDir usually target/generated-sources/kogito/
+         * @param sourcesDir usually target/generated-sources/kogito/
          */
-        private Builder(String classesDir, String resourcesDir, String scaffoldedSourcesDir) {
+        private Builder(String classesDir, String resourcesDir, String sourcesDir) {
             this.classesDir = classesDir;
-            this.resourcePath = resourcesDir;
-            this.scaffoldedSourcesDir = scaffoldedSourcesDir;
+            this.resourcesDir = resourcesDir;
+            this.sourcesDir = sourcesDir;
         }
 
         /**
@@ -92,25 +92,25 @@ public class GeneratedFileWriter {
         public GeneratedFileWriter build(Path basePath) {
             return new GeneratedFileWriter(
                     basePath.resolve(classesDir),
-                    basePath.resolve(resourcePath),
-                    basePath.resolve(scaffoldedSourcesDir));
+                    basePath.resolve(resourcesDir),
+                    basePath.resolve(sourcesDir));
         }
     }
 
     private final Path classesDir;
-    private final Path resourcePath;
-    private final Path scaffoldedSourcesDir;
+    private final Path resourcesDir;
+    private final Path sourcesDir;
     /**
      *
      * @param classesDir usually target/classes/
-     * @param resourcePath usually target/generated-resources/kogito/
-     * @param scaffoldedSourcesDir usually target/generated-sources/kogito/
+     * @param resourcesDir usually target/generated-resources/kogito/
+     * @param sourcesDir usually target/generated-sources/kogito/
      */
     //Default-access for testing purpose
-    GeneratedFileWriter(Path classesDir, Path resourcePath, Path scaffoldedSourcesDir) {
+    GeneratedFileWriter(Path classesDir, Path resourcesDir, Path sourcesDir) {
         this.classesDir = classesDir;
-        this.resourcePath = resourcePath;
-        this.scaffoldedSourcesDir = scaffoldedSourcesDir;
+        this.resourcesDir = resourcesDir;
+        this.sourcesDir = sourcesDir;
     }
 
     public void writeAll(Collection<GeneratedFile> generatedFiles) {
@@ -121,13 +121,13 @@ public class GeneratedFileWriter {
         try {
             GeneratedFileType.Category category = f.category();
             switch (category) {
-                case INTERNAL_RESOURCE: // since codegen happens after maven-resource-plugin (both in Quarkus and SB), need to manually place in the correct (CP) location
-                case STATIC_HTTP_RESOURCE:
-                case COMPILED_CLASS:
+                case INTERNAL_RESOURCE, // since codegen happens after maven-resource-plugin (both in Quarkus and SB), need to manually place in the correct (CP) location
+                     STATIC_HTTP_RESOURCE,
+                     COMPILED_CLASS:
                     writeGeneratedFile(f, classesDir);
                     break;
                 case SOURCE:
-                    writeGeneratedFile(f, scaffoldedSourcesDir);
+                    writeGeneratedFile(f, sourcesDir);
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown Category " + category.name());
@@ -141,12 +141,12 @@ public class GeneratedFileWriter {
         return classesDir;
     }
 
-    public Path getResourcePath() {
-        return resourcePath;
+    public Path getResourcesDir() {
+        return resourcesDir;
     }
 
-    public Path getScaffoldedSourcesDir() {
-        return scaffoldedSourcesDir;
+    public Path getSourcesDir() {
+        return sourcesDir;
     }
 
     void writeGeneratedFile(GeneratedFile f, Path location) throws IOException {

--- a/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/GeneratedFileWriterTest.java
+++ b/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/GeneratedFileWriterTest.java
@@ -50,8 +50,8 @@ class GeneratedFileWriterTest {
         GeneratedFileWriter.Builder retrieved = GeneratedFileWriter.builder(finalPath, resourcesDirectoryProperty,
                                                                             sourcesDirectoryProperty, bt);
         assertEquals(bt.CLASSES_PATH.toString(), retrieved.classesDir);
-        assertEquals(resourcesDirectory, retrieved.resourcePath);
-        assertEquals(sourcesDirectory, retrieved.scaffoldedSourcesDir);
+        assertEquals(resourcesDirectory, retrieved.resourcesDir);
+        assertEquals(sourcesDirectory, retrieved.sourcesDir);
         System.clearProperty(resourcesDirectoryProperty);
         System.clearProperty(sourcesDirectoryProperty);
     }
@@ -67,9 +67,9 @@ class GeneratedFileWriterTest {
         assertEquals(bt.CLASSES_PATH.toString(), retrieved.classesDir);
         String expected = String.format("%s/%s", bt.GENERATED_RESOURCES_PATH.toString(), finalPath).replace("/",
                                                                                                             File.separator);
-        assertEquals(expected, retrieved.resourcePath);
+        assertEquals(expected, retrieved.resourcesDir);
         expected = String.format("%s/%s", bt.GENERATED_SOURCES_PATH.toString(), finalPath).replace("/", File.separator);
-        assertEquals(expected, retrieved.scaffoldedSourcesDir);
+        assertEquals(expected, retrieved.sourcesDir);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Fixes 
https://github.com/apache/incubator-kie-issues/issues/2091
Simple renaming of some variables,

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
