### PR TITLE
Fix: handle non-DataSource fields in RuleUnitData to avoid CNFE (#2100)

### DIFF
--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/SimpleRuleUnitVariable.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/SimpleRuleUnitVariable.java
@@ -48,14 +48,18 @@ public final class SimpleRuleUnitVariable implements RuleUnitVariable {
         this.type = type;
         this.dataSourceParameterType = dataSourceParameterType;
 
+        Class<?> _boxedVarType;
         Class<?> varType = type instanceof Class ? convertFromPrimitiveType((Class)type) : rawType(type);
         try {
-            this.boxedVarType = varType.getClassLoader() == null || varType.getClassLoader() == DataSource.class.getClassLoader() ?
+            _boxedVarType = varType.getClassLoader() == null || varType.getClassLoader() == DataSource.class.getClassLoader() ?
                     varType :
                     DataSource.class.getClassLoader().loadClass(varType.getCanonicalName());
         } catch (ClassNotFoundException e) {
+            _boxedVarType = type instanceof Class ? convertFromPrimitiveType((Class)type) : rawType(type);
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
+        this.boxedVarType = _boxedVarType;
     }
 
     public SimpleRuleUnitVariable(String name, Class<?> type) {

--- a/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/SimpleRuleUnitVariableClassNotFoundTest.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/test/java/org/drools/ruleunits/impl/SimpleRuleUnitVariableClassNotFoundTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.ruleunits.impl;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.implementation.FieldAccessor;
+import org.drools.ruleunits.api.DataSource;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+public class SimpleRuleUnitVariableClassNotFoundTest {
+
+    @Test
+    public void testNullClassLoader() throws Exception {
+        Class<?> isolatedDataSourceClass = new ByteBuddy()
+                .subclass(Object.class)
+                .name("org.drools.ruleunits.isolated.IsolatedDataSource")
+                .defineField("data", List.class, Modifier.PRIVATE)
+                .defineMethod("getData", List.class, Modifier.PUBLIC)
+                .intercept(FieldAccessor.ofField("data"))
+                .defineMethod("setData", void.class, Modifier.PUBLIC)
+                .withParameters(List.class)
+                .intercept(FieldAccessor.ofField("data"))
+                .make()
+                .load(null) // null parent = isolated classloader
+                .getLoaded();
+
+        assertThat(isolatedDataSourceClass.getClassLoader())
+                .isNotNull()
+                .isNotEqualTo(DataSource.class.getClassLoader());
+
+        try {
+            DataSource.class.getClassLoader().loadClass(isolatedDataSourceClass.getCanonicalName());
+            fail("Should have thrown ClassNotFoundException");
+        } catch (ClassNotFoundException e) {
+        }
+
+        String variableName = "testVariable";
+        Type variableType = isolatedDataSourceClass;
+        Class<?> dataSourceParameterType = isolatedDataSourceClass;
+        String setter = "setData";
+
+        SimpleRuleUnitVariable variable = new SimpleRuleUnitVariable(variableName, variableType, dataSourceParameterType, setter);
+
+        assertThat(variable).isNotNull();
+        assertThat(variable.getName()).isEqualTo(variableName);
+
+        Field boxedVarTypeField = SimpleRuleUnitVariable.class.getDeclaredField("boxedVarType");
+        boxedVarTypeField.setAccessible(true);
+        Class<?> actualBoxedVarType = (Class<?>) boxedVarTypeField.get(variable);
+
+        assertThat(actualBoxedVarType).isEqualTo(isolatedDataSourceClass);
+    }
+
+}


### PR DESCRIPTION
Resolves a regression where RuleUnitData classes containing non-DataSource fields referencing application-defined types caused a ClassNotFoundException during build in Drools 10. This was working as expected in Drools 8.44.

Fixes apache/incubator-kie-issues#2100

