### PR TITLE
[incubator-kie-issues#2118] Refactor DMNCompilerImpl.getId method to clarify behavior

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDecisionServiceEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNDecisionServiceEvaluator.java
@@ -66,7 +66,7 @@ public class DMNDecisionServiceEvaluator implements DMNExpressionEvaluator {
         DMNRuntimeEventManagerUtils.fireBeforeEvaluateDecisionService(eventManager, dsNode, result);
         DMNRuntime dmnRuntime = eventManager.getRuntime();
         DMNModel dmnModel = dmnRuntime.getModel(dsNode.getModelNamespace(), dsNode.getModelName());
-        List<String> decisionIDs = dsNode.getDecisionService().getOutputDecision().stream().map(er -> DMNCompilerImpl.getId(er)).collect(Collectors.toList());
+        List<String> decisionIDs = dsNode.getDecisionService().getOutputDecision().stream().map(DMNCompilerImpl::getReferenceId).toList();
         DMNResult evaluateById = dmnRuntime.evaluateById(dmnModel, result.getContext().clone(), decisionIDs.toArray(new String[]{}));
         Map<String, Object> ctx = new HashMap<>();
         List<DMNDecisionResult> decisionResults = new ArrayList<>();

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -454,7 +454,7 @@ public class DMNCompilerImpl implements DMNCompiler {
     public void linkRequirements(DMNModelImpl model, DMNBaseNode node) {
         for ( InformationRequirement ir : node.getInformationRequirement() ) {
             if ( ir.getRequiredInput() != null ) {
-                String id = getId( ir.getRequiredInput() );
+                String id = getReferenceId( ir.getRequiredInput() );
                 InputDataNode input = model.getInputById( id );
                 if ( input != null ) {
                     node.addDependency( input.getModelNamespace() + "." + input.getName(), input );
@@ -471,7 +471,7 @@ public class DMNCompilerImpl implements DMNCompiler {
                                            node.getModelNamespace());
                 }
             } else if ( ir.getRequiredDecision() != null ) {
-                String id = getId( ir.getRequiredDecision() );
+                String id = getReferenceId( ir.getRequiredDecision() );
                 DecisionNode dn = model.getDecisionById( id );
                 if ( dn != null ) {
                     node.addDependency( dn.getModelNamespace() + "." + dn.getName(), dn );
@@ -490,7 +490,7 @@ public class DMNCompilerImpl implements DMNCompiler {
         }
         for ( KnowledgeRequirement kr : node.getKnowledgeRequirement() ) {
             if ( kr.getRequiredKnowledge() != null ) {
-                String id = getId( kr.getRequiredKnowledge() );
+                String id = getReferenceId( kr.getRequiredKnowledge() );
                 BusinessKnowledgeModelNode bkmn = model.getBusinessKnowledgeModelById( id );
                 DecisionServiceNode dsn = model.getDecisionServiceById(id);
                 if ( bkmn != null ) {
@@ -516,9 +516,14 @@ public class DMNCompilerImpl implements DMNCompiler {
      * For the purpose of Compilation, in the DMNModel the DRGElements are stored with their full ID, so an ElementReference might reference in two forms:
      *  - #id (a local to the model ID)
      *  - namespace#id (an imported DRGElement ID)
-     * This method now returns in the first case the proper ID, while leave unchanged in the latter case, in order for the ID to be reconciliable on the DMNModel. 
+     *  This method returns:
+     *  The local ID (without the leading {@code #}) when the reference is local to the current model.
+     *  The trimmed ID (with namespace removed) when the reference includes the current model's namespace.
+     *  The full {@code namespace#id} unchanged when the reference targets an imported model.
+     *  This ensures that the returned ID can be reconciled correctly within the DMNModel, while preserving namespace context for imported elements.
+     *
      */
-    public static String getId(DMNElementReference er) {
+    public static String getReferenceId(DMNElementReference er) {
         String href = er.getHref();
         if (href.startsWith("#")) {
             return href.substring(1);

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DecisionServiceCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DecisionServiceCompiler.java
@@ -155,7 +155,7 @@ public class DecisionServiceCompiler implements DRGElementCompiler {
 
     private void processInputData(DecisionServiceNodeImpl ni, DMNModelImpl model, List<DSFormalParameter> parameters) {
         for (DMNElementReference er : ni.getDecisionService().getInputData()) {
-            String id = DMNCompilerImpl.getId(er);
+            String id = DMNCompilerImpl.getReferenceId(er);
             InputDataNode input = model.getInputById(id);
             if (input != null) {
                 String inputNamePrefix = inputQualifiedNamePrefix(input, model);
@@ -169,7 +169,7 @@ public class DecisionServiceCompiler implements DRGElementCompiler {
 
     private void processInputDecisions(DecisionServiceNodeImpl ni, DMNModelImpl model, List<DSFormalParameter> parameters) {
         for (DMNElementReference er : ni.getDecisionService().getInputDecision()) {
-            String id = DMNCompilerImpl.getId(er);
+            String id = DMNCompilerImpl.getReferenceId(er);
             DecisionNode input = model.getDecisionById(id);
             if (input != null) {
                 String inputNamePrefix = inputQualifiedNamePrefix(input, model);
@@ -183,7 +183,7 @@ public class DecisionServiceCompiler implements DRGElementCompiler {
 
     private void validateEncapsulatedDecision(DecisionServiceNodeImpl ni, DMNModelImpl model) {
         for (DMNElementReference er : ni.getDecisionService().getEncapsulatedDecision()) {
-            String id = DMNCompilerImpl.getId(er);
+            String id = DMNCompilerImpl.getReferenceId(er);
             if (model.getDecisionById(id) == null) {
                 reportReferenceError(ni, model, id);
             }
@@ -193,7 +193,7 @@ public class DecisionServiceCompiler implements DRGElementCompiler {
     private List<DecisionNode> getOutputDecisions(DecisionServiceNodeImpl ni, DMNModelImpl model) {
         List<DecisionNode> outputDecisions = new ArrayList<>();
         for (DMNElementReference er : ni.getDecisionService().getOutputDecision()) {
-            String id = DMNCompilerImpl.getId(er);
+            String id = DMNCompilerImpl.getReferenceId(er);
             DecisionNode outDecision = model.getDecisionById(id);
             if (outDecision != null) {
                 outputDecisions.add(outDecision);

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNEventUtils.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNEventUtils.java
@@ -70,7 +70,7 @@ public final class DMNEventUtils {
     public static Map<String, Object> extractDSOutputDecisionsValues(AfterEvaluateDecisionServiceEvent event) {
         Map<String, Object> results = new LinkedHashMap<>();
         String namespace = event.getDecisionService().getModelNamespace();
-        List<String> decisionIDs = event.getDecisionService().getDecisionService().getOutputDecision().stream().map(er -> DMNCompilerImpl.getId(er)).collect(Collectors.toList());
+        List<String> decisionIDs = event.getDecisionService().getDecisionService().getOutputDecision().stream().map(DMNCompilerImpl::getReferenceId).toList();
         DMNModel dmnModel = ((DMNResultImpl) event.getResult()).getModel();
         for (String id : decisionIDs) {
             DecisionNode decisionNode = retrieveDecisionNode(dmnModel, id, namespace);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/DMNCompilerImplTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/DMNCompilerImplTest.java
@@ -63,18 +63,23 @@ class DMNCompilerImplTest {
     }
 
     @Test
-    void getId() {
+    void getReferenceId() {
         String localPart = "reference";
         DMNElementReference elementReference = new TDMNElementReference();
         elementReference.setHref(String.format("%s#%s", NAMESPACE, localPart));
         elementReference.setParent(parent);
-        String retrieved = DMNCompilerImpl.getId(elementReference);
+        String retrieved = DMNCompilerImpl.getReferenceId(elementReference);
         assertThat(retrieved).isNotNull().isEqualTo(localPart);
 
         String expected = String.format("%s#%s", "http://a-different-namespace", localPart);
         elementReference.setHref(expected);
-        retrieved = DMNCompilerImpl.getId(elementReference);
+        retrieved = DMNCompilerImpl.getReferenceId(elementReference);
         assertThat(retrieved).isNotNull().isEqualTo(expected);
+
+        expected = String.format("#%s", localPart);
+        elementReference.setHref(expected);
+        retrieved = DMNCompilerImpl.getReferenceId(elementReference);
+        assertThat(retrieved).isNotNull().isEqualTo(localPart);
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/DMNEventUtilsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/impl/DMNEventUtilsTest.java
@@ -78,7 +78,7 @@ public class DMNEventUtilsTest {
         when(event.getResult()).thenReturn(dmnResult);
 
         try (MockedStatic<DMNCompilerImpl> mockedStatic = Mockito.mockStatic(DMNCompilerImpl.class)) {
-            mockedStatic.when(() -> DMNCompilerImpl.getId(dmnElementReference)).thenReturn(decisionId);
+            mockedStatic.when(() -> DMNCompilerImpl.getReferenceId(dmnElementReference)).thenReturn(decisionId);
             Map<String, Object> resultMap = DMNEventUtils.extractDSOutputDecisionsValues(event);
 
             assertThat(resultMap).isNotNull();
@@ -123,7 +123,7 @@ public class DMNEventUtilsTest {
         when(event.getResult()).thenReturn(dmnResult);
 
         try (MockedStatic<DMNCompilerImpl> mockedStatic = Mockito.mockStatic(DMNCompilerImpl.class)) {
-            mockedStatic.when(() -> DMNCompilerImpl.getId(dmnElementReference)).thenReturn(null);
+            mockedStatic.when(() -> DMNCompilerImpl.getReferenceId(dmnElementReference)).thenReturn(null);
             Assertions.assertThatThrownBy(
                             () -> DMNEventUtils.retrieveDecisionNode(dmnModel, null, "ns"))
                     .isInstanceOf(NoSuchElementException.class);

--- a/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/model/DMNModelIOSets.java
+++ b/kie-dmn/kie-dmn-openapi/src/main/java/org/kie/dmn/openapi/model/DMNModelIOSets.java
@@ -153,7 +153,7 @@ public class DMNModelIOSets {
 
         private void buildOutputSet() {
             if (ds.getDecisionService().getOutputDecision().size() == 1) {
-                String id = DMNCompilerImpl.getId(ds.getDecisionService().getOutputDecision().get(0));
+                String id = DMNCompilerImpl.getReferenceId(ds.getDecisionService().getOutputDecision().get(0));
                 DecisionNode outputDecision = model.getDecisionById(id);
                 this.outputSet = new SimpleTypeImpl(ds.getModelNamespace(), TEMP, ds.getId() + "DSOutputSet", false, null,  null, outputDecision != null ? outputDecision.getResultType() : ds.getResultType(), null);
                 if (outputDecision != null) {
@@ -162,7 +162,7 @@ public class DMNModelIOSets {
             } else {
                 CompositeTypeImpl os = new CompositeTypeImpl(ds.getModelNamespace(), TEMP, ds.getId() + "DSOutputSet");
                 for (DMNElementReference er : ds.getDecisionService().getOutputDecision()) {
-                    String id = DMNCompilerImpl.getId(er);
+                    String id = DMNCompilerImpl.getReferenceId(er);
                     DecisionNode outputDecision = model.getDecisionById(id);
                     if (outputDecision != null) {
                         os.addField(outputDecision.getName(), outputDecision.getResultType());

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/NamespaceTests/ImportedModel.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/NamespaceTests/ImportedModel.dmn
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20240513/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="https://kie.org/dmn/extensions/1.0" expressionLanguage="https://www.omg.org/spec/DMN/20240513/FEEL/" namespace="ImportedModel" id="_EC6CFAD5-AA33-40EB-8615-427935BFAAF6" name="ImportedModel">
+  <decision name="Decision A" id="_CE7D37D7-FC33-4C3A-AD3D-6EB6BECBC2B7">
+    <variable name="Decision A" id="_5EFFE710-FF95-4854-AB4C-1A6B854317CE" typeRef="number" />
+    <informationRequirement id="_397746AF-2A29-4812-A781-071E208B9398">
+      <requiredInput href="#_D57E59F9-FC14-4B53-888C-CAADBA0AEFF6" />
+    </informationRequirement>
+    <literalExpression id="_81F5684D-7D54-4ED0-9BCC-9F4895305192" typeRef="number" label="Decision A">
+      <text>Input A </text>
+    </literalExpression>
+  </decision>
+  <inputData name="Input A" id="_D57E59F9-FC14-4B53-888C-CAADBA0AEFF6">
+    <variable name="Input A" id="_3A5900B4-28DE-452A-8832-CF08EF2F5AA8" typeRef="number" />
+  </inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_158DB90B-806A-427D-A7C8-BD0B6AA29A71" name="Default DRD" useAlternativeInputDataShape="false">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_81F5684D-7D54-4ED0-9BCC-9F4895305192">
+            <kie:width>190</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="_ABA414FB-9E13-40FD-9CC1-8A129CEBC2FB" dmnElementRef="_CE7D37D7-FC33-4C3A-AD3D-6EB6BECBC2B7" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="520" y="60" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_B0DF4CF3-C1C5-4ACC-B0FF-D6A378BBFA6A" dmnElementRef="_D57E59F9-FC14-4B53-888C-CAADBA0AEFF6" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="520" y="220" width="160" height="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="_CA9E6CF1-FE84-42BD-AACE-D2F375B8C7DB" dmnElementRef="_397746AF-2A29-4812-A781-071E208B9398" sourceElement="_B0DF4CF3-C1C5-4ACC-B0FF-D6A378BBFA6A" targetElement="_ABA414FB-9E13-40FD-9CC1-8A129CEBC2FB">
+        <di:waypoint x="600" y="260" />
+        <di:waypoint x="600" y="140" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/NamespaceTests/ImportingModel.dmn
+++ b/kie-dmn/kie-dmn-test-resources/src/test/resources/valid_models/DMNv1_6/NamespaceTests/ImportingModel.dmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20240513/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="https://kie.org/dmn/extensions/1.0" expressionLanguage="https://www.omg.org/spec/DMN/20240513/FEEL/" namespace="ImportingModel" id="_A822E73F-8B05-4484-B190-056F1E905EC4" name="ImportingModel" xmlns:included0="ImportedModel">
+  <import id="_01CB2056-514C-44F8-AA0F-BA0A20007ACD" name="A" importType="http://www.omg.org/spec/DMN/20180521/MODEL/" namespace="ImportedModel" locationURI="./Model A.dmn" />
+  <decisionService name="DecisionService B" id="_95293839-C5D1-44D7-88EE-2DA10076B3DB">
+    <variable name="DecisionService B" id="_93560E9F-93FD-4A4C-8F0D-D6DB583B4B63" typeRef="number" />
+    <outputDecision href="ImportedModel#_CE7D37D7-FC33-4C3A-AD3D-6EB6BECBC2B7" />
+    <inputData href="ImportedModel#_D57E59F9-FC14-4B53-888C-CAADBA0AEFF6" />
+  </decisionService>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_51EDA251-7952-49AE-9F55-099AB47EB130" name="Default DRD" useAlternativeInputDataShape="false">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths />
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="_0E3535FD-057C-47A5-9222-1AF5E4034AD3" dmnElementRef="_95293839-C5D1-44D7-88EE-2DA10076B3DB" isCollapsed="false" isListedInputData="false">
+        <dc:Bounds x="500" y="0" width="320" height="320" />
+        <dmndi:DMNDecisionServiceDividerLine id="_1D23636A-117D-4B39-AE0F-E4E32F294AA0">
+          <di:waypoint x="500" y="160" />
+          <di:waypoint x="820" y="160" />
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="_1AFCAACA-D2DB-4FE9-95C1-253E9CB2EF11" dmnElementRef="included0:_CE7D37D7-FC33-4C3A-AD3D-6EB6BECBC2B7">
+        <dc:Bounds x="580" y="60" width="160" height="80" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
This PR aims to refactor **DMNCompilerImpl.getId** method to clarify behavior.
Closes : https://github.com/apache/incubator-kie-issues/issues/2118

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
