### PR TITLE
[incubator-kie-issues #203] Cleanup Phreak code - initial steps

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -52,7 +52,6 @@ import org.drools.core.reteoo.AsyncReceiveNode;
 import org.drools.core.reteoo.AsyncSendNode;
 import org.drools.core.reteoo.BetaMemory;
 import org.drools.core.reteoo.BetaNode;
-import org.drools.core.reteoo.RightInputAdapterNode;
 import org.drools.core.reteoo.ConditionalBranchNode;
 import org.drools.core.reteoo.EvalConditionNode;
 import org.drools.core.reteoo.FromNode;
@@ -68,8 +67,7 @@ import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.PathEndNode;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.QueryElementNode;
-import org.drools.core.reteoo.TupleToObjectNode;
-import org.drools.core.reteoo.TupleToObjectNode.SubnetworkPathMemory;
+import org.drools.core.reteoo.RightInputAdapterNode;
 import org.drools.core.reteoo.RightTuple;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
 import org.drools.core.reteoo.RuntimeComponentFactory;
@@ -81,6 +79,8 @@ import org.drools.core.reteoo.Tuple;
 import org.drools.core.reteoo.TupleFactory;
 import org.drools.core.reteoo.TupleImpl;
 import org.drools.core.reteoo.TupleMemory;
+import org.drools.core.reteoo.TupleToObjectNode;
+import org.drools.core.reteoo.TupleToObjectNode.SubnetworkPathMemory;
 import org.drools.core.reteoo.WindowNode;
 import org.drools.core.util.FastIterator;
 import org.kie.api.definition.rule.Rule;
@@ -96,8 +96,8 @@ import static org.drools.core.phreak.BuildtimeSegmentUtilities.isRootNode;
 import static org.drools.core.phreak.BuildtimeSegmentUtilities.isSet;
 import static org.drools.core.phreak.BuildtimeSegmentUtilities.nextNodePosMask;
 import static org.drools.core.phreak.BuildtimeSegmentUtilities.updateNodeTypesMask;
-import static org.drools.core.phreak.EagerPhreakBuilder.Add.attachAdapterAndPropagate;
 import static org.drools.core.phreak.EagerPhreakBuilder.deleteLeftTuple;
+import static org.drools.core.phreak.EagerPhreakBuilder.Add.attachAdapterAndPropagate;
 import static org.drools.core.phreak.RuntimeSegmentUtilities.createSubnetworkSegmentMemory;
 import static org.drools.core.phreak.RuntimeSegmentUtilities.getOrCreateSegmentMemory;
 import static org.drools.core.phreak.RuntimeSegmentUtilities.getQuerySegmentMemory;
@@ -585,7 +585,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
     public static void flushStagedTuples(InternalWorkingMemory wm, TerminalNode tn, PathMemory pmem, List<LeftTupleNode> splits) {
         // first flush the subject rule, then flush any staging lists that are part of a merge
         if ( pmem.isInitialized() ) {
-            RuleNetworkEvaluator.INSTANCE.evaluateNetwork(pmem, pmem.getRuleAgendaItem().getRuleExecutor(), wm);
+            RuleNetworkEvaluator.INSTANCE.evaluateNetwork(wm, pmem.getRuleAgendaItem().getRuleExecutor(), pmem);
         }
 
         // With the removing rules being flushed, we need to check any splits that will be merged, to see if they need flushing

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -48,10 +48,10 @@ import static org.drools.core.phreak.RuleNetworkEvaluator.normalizeStagedTuples;
 
 public class PhreakAccumulateNode {
 
-    public void doNode(AccumulateNode accNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       AccumulateNode accNode,
                        LeftTupleSink sink,
                        AccumulateMemory am,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncReceiveNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncReceiveNode.java
@@ -36,10 +36,10 @@ import static org.drools.core.phreak.PhreakAsyncSendNode.isAllowed;
 public class PhreakAsyncReceiveNode {
     private static final Logger log = LoggerFactory.getLogger( PhreakAsyncReceiveNode.class );
 
-    public void doNode(AsyncReceiveNode node,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       AsyncReceiveNode node,
                        AsyncReceiveMemory memory,
                        LeftTupleSink sink,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples) {
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncSendNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncSendNode.java
@@ -42,9 +42,9 @@ public class PhreakAsyncSendNode {
         return ExecutorProviderFactory.getExecutorProvider().getExecutor();
     }
 
-    public void doNode(AsyncSendNode node,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       AsyncSendNode node,
                        AsyncSendMemory memory,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples) {
 
         if (srcLeftTuples.getInsertFirst() != null) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
@@ -35,10 +35,10 @@ import static org.drools.core.phreak.RuleNetworkEvaluator.normalizeStagedTuples;
 
 
 public class PhreakBranchNode {
-    public void doNode(ConditionalBranchNode branchNode,
+    public void doNode(ActivationsManager activationsManager,
+                       ConditionalBranchNode branchNode,
                        ConditionalBranchMemory cbm,
                        LeftTupleSink sink,
-                       ActivationsManager activationsManager,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples,

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakEvalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakEvalNode.java
@@ -40,10 +40,10 @@ public class PhreakEvalNode {
 
     private static final String EVAL_LEFT_TUPLE_DELETED = "EVAL_LEFT_TUPLE_DELETED";
 
-    public void doNode(EvalConditionNode evalNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       EvalConditionNode evalNode,
                        EvalMemory em,
                        LeftTupleSink sink,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -124,7 +124,7 @@ public class PhreakEvalNode {
 
                     TupleImpl childLeftTuple = leftTuple.getFirstChild();
                     childLeftTuple.setPropagationContext( leftTuple.getPropagationContext());
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                 }
                 // else do nothing
             }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
@@ -35,10 +35,10 @@ import org.drools.core.util.FastIterator;
 import static org.drools.core.phreak.PhreakJoinNode.updateChildLeftTuple;
 
 public class PhreakExistsNode {
-    public void doNode(ExistsNode existsNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       ExistsNode existsNode,
                        LeftTupleSink sink,
                        BetaMemory bm,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -266,7 +266,7 @@ public class PhreakExistsNode {
 
                 if (leftTuple.getFirstChild() != null) {
                     // no need to update pctx, as no right available, and pctx will exist on a parent LeftTuple anyway
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( leftTuple.getFirstChild(), trgLeftTuples, stagedLeftTuples );
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, leftTuple.getFirstChild() );
                 }
                 // with no previous children. do nothing.
             } else if (leftTuple.getFirstChild() == null) {
@@ -401,7 +401,7 @@ public class PhreakExistsNode {
                         TupleImpl childLeftTuple = leftTuple.getFirstChild();
                         if ( childLeftTuple != null ) {
                             childLeftTuple.setPropagationContext( rightTuple.getPropagationContext() );
-                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                         }
                     }
 
@@ -431,7 +431,7 @@ public class PhreakExistsNode {
             } else {
                 if (leftTuple.getFirstChild() != null) {
                     // no need to update pctx, as no right available, and pctx will exist on a parent LeftTuple anyway
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( leftTuple.getFirstChild(), trgLeftTuples, stagedLeftTuples );
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, leftTuple.getFirstChild() );
                 }
                 blocker.removeBlocked(leftTuple);
             }
@@ -495,7 +495,7 @@ public class PhreakExistsNode {
                         TupleImpl childLeftTuple = leftTuple.getFirstChild();
                         if (childLeftTuple != null) {
                             childLeftTuple.setPropagationContext(rightTuple.getPropagationContext());
-                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                         }
                     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
@@ -43,10 +43,10 @@ import org.kie.api.runtime.rule.FactHandle;
 import static org.drools.core.phreak.PhreakJoinNode.updateChildLeftTuple;
 
 public class PhreakFromNode {
-    public void doNode(FromNode fromNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       FromNode fromNode,
                        FromMemory fm,
                        LeftTupleSink sink,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -205,7 +205,7 @@ public class PhreakFromNode {
                 while (childLeftTuple != null) {
                     childLeftTuple.setPropagationContext( leftTuple.getPropagationContext());
                     TupleImpl nextChild = childLeftTuple.getHandleNext();
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                     childLeftTuple = nextChild;
                 }
             }
@@ -266,7 +266,7 @@ public class PhreakFromNode {
                                             TupleImpl childLeftTuple) {
         if (childLeftTuple != null) {
             childLeftTuple.setPropagationContext( propagationContext );
-            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(childLeftTuple, trgLeftTuples, stagedLeftTuples);
+            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(trgLeftTuples, stagedLeftTuples, childLeftTuple);
         }
     }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
@@ -32,10 +32,10 @@ import org.drools.core.util.AbstractHashTable;
 import org.drools.core.util.FastIterator;
 
 public class PhreakJoinNode {
-    public void doNode(JoinNode joinNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       JoinNode joinNode,
                        LeftTupleSink sink,
                        BetaMemory bm,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -200,7 +200,7 @@ public class PhreakJoinNode {
                 for (TupleImpl childLeftTuple = leftTuple.getFirstChild(); childLeftTuple != null; ) {
                     TupleImpl nextChild = childLeftTuple.getHandleNext();
                     if (rightTuple == null || rightTuple.getMemory() != childLeftTuple.getRightParent().getMemory()) {
-                        RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                        RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                     }
                     childLeftTuple = nextChild;
                 }
@@ -266,7 +266,7 @@ public class PhreakJoinNode {
                 } else if (childLeftTuple != null && childLeftTuple.getRightParent() == rightTuple) {
                     // delete, childLeftTuple is updated
                     TupleImpl nextChild = childLeftTuple.getHandleNext();
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                     childLeftTuple = nextChild;
                 }
             }
@@ -305,7 +305,7 @@ public class PhreakJoinNode {
                     while ( childLeftTuple != null ) {
                         childLeftTuple.setPropagationContext( rightTuple.getPropagationContext() );
                         TupleImpl nextChild = childLeftTuple.getRightParentNext();
-                        RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                        RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                         childLeftTuple = nextChild;
                     }
                     // childLeftTuple is now null, so the next check will attempt matches for new bucket
@@ -382,7 +382,7 @@ public class PhreakJoinNode {
                     // delete, childLeftTuple is updated
                     childLeftTuple.setPropagationContext(rightTuple.getPropagationContext());
                     TupleImpl nextChild = childLeftTuple.getRightParentNext();
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                     childLeftTuple = nextChild;
                 }
             }
@@ -409,7 +409,7 @@ public class PhreakJoinNode {
 
                 while (childLeftTuple != null) {
                     TupleImpl nextChild = childLeftTuple.getHandleNext();
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                     childLeftTuple = nextChild;
                 }
             }
@@ -436,7 +436,7 @@ public class PhreakJoinNode {
                 childLeftTuple.setPropagationContext(rightTuple.getPropagationContext());
                 while (childLeftTuple != null) {
                     TupleImpl nextChild = childLeftTuple.getRightParentNext();
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                     childLeftTuple = nextChild;
                 }
             }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
@@ -35,10 +35,10 @@ import org.drools.core.util.FastIterator;
 import static org.drools.core.phreak.PhreakJoinNode.updateChildLeftTuple;
 
 public class PhreakNotNode {
-    public void doNode(NotNode notNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       NotNode notNode,
                        LeftTupleSink sink,
                        BetaMemory bm,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -192,7 +192,7 @@ public class PhreakNotNode {
 
                         if ( childLeftTuple != null ) { // NotNode only has one child
                             childLeftTuple.setPropagationContext( rightTuple.getPropagationContext() );
-                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                         }
                     }
 
@@ -288,7 +288,7 @@ public class PhreakNotNode {
                         // no need to remove, as we removed at the start
                         // to be matched against, as it's now blocked
                         childLeftTuple.setPropagationContext(leftTuple.getBlocker().getPropagationContext()); // we have the righttuple, so use it for the pctx
-                        RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                        RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                     } // else: it's blocked now and no children so blocked before, thus do nothing
                 } else if (childLeftTuple == null) {
                     // not blocked, with no children, must have been previously blocked so assert
@@ -357,7 +357,7 @@ public class PhreakNotNode {
                         TupleImpl childLeftTuple = leftTuple.getFirstChild();
                         if ( childLeftTuple != null ) {
                             childLeftTuple.setPropagationContext( rightTuple.getPropagationContext() );
-                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                         }
                     }
 
@@ -450,7 +450,7 @@ public class PhreakNotNode {
 
                 if (childLeftTuple != null) { // NotNode only has one child
                     childLeftTuple.setPropagationContext(leftTuple.getPropagationContext());
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples ); // no need to update pctx, as no right available, and pctx will exist on a parent LeftTuple anyway
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple ); // no need to update pctx, as no right available, and pctx will exist on a parent LeftTuple anyway
                 }
             } else {
                 blocker.removeBlocked(leftTuple);

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
@@ -131,7 +131,7 @@ public class PhreakQueryNode {
                 TupleImpl childLeftTuple = leftTuple.getFirstChild();
                 while (childLeftTuple != null) {
                     TupleImpl nextChild = childLeftTuple.getHandleNext();
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( childLeftTuple, trgLeftTuples, stagedLeftTuples );
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple( trgLeftTuples, stagedLeftTuples, childLeftTuple );
                     childLeftTuple = nextChild;
                 }
             }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryTerminalNode.java
@@ -39,10 +39,10 @@ import org.drools.core.util.LinkedList;
 * To change this template use File | Settings | File Templates.
 */
 public class PhreakQueryTerminalNode {
-    public void doNode(QueryTerminalNode qtnNode,
-                       ActivationsManager activationsManager,
-                       TupleSets srcLeftTuples,
-                       LinkedList<StackEntry> stack) {
+    public void doNode(ActivationsManager activationsManager,
+                       LinkedList<StackEntry> stack,
+                       QueryTerminalNode qtnNode,
+                       TupleSets srcLeftTuples) {
         if (srcLeftTuples.getDeleteFirst() != null) {
             doLeftDeletes(qtnNode, activationsManager, srcLeftTuples, stack);
         }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakReactiveFromNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakReactiveFromNode.java
@@ -25,15 +25,15 @@ import org.drools.core.reteoo.ReactiveFromNode;
 import org.drools.core.reteoo.ReactiveFromNode.ReactiveFromMemory;
 
 public class PhreakReactiveFromNode extends PhreakFromNode {
-    public void doNode(ReactiveFromNode fromNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       ReactiveFromNode fromNode,
                        ReactiveFromMemory fm,
                        LeftTupleSink sink,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
 
-        super.doNode(fromNode, fm, sink, reteEvaluator, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+        super.doNode(reteEvaluator, fromNode, fm, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
         trgLeftTuples.addAll(fm.getStagedLeftTuples().takeAll());
     }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
@@ -44,10 +44,10 @@ import org.kie.api.event.rule.MatchCancelledCause;
 * To change this template use File | Settings | File Templates.
 */
 public class PhreakRuleTerminalNode {
-    public void doNode(TerminalNode rtnNode,
-                       ActivationsManager activationsManager,
-                       TupleSets srcLeftTuples,
-                       RuleExecutor executor) {
+    public void doNode(ActivationsManager activationsManager,
+                       RuleExecutor executor,
+                       TerminalNode rtnNode,
+                       TupleSets srcLeftTuples) {
         if (srcLeftTuples.getDeleteFirst() != null) {
             doLeftDeletes(activationsManager, srcLeftTuples, executor);
         }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakSubnetworkNotExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakSubnetworkNotExistsNode.java
@@ -96,7 +96,7 @@ public class PhreakSubnetworkNotExistsNode {
                     if (node.getType() == NodeTypeEnums.ExistsNode) {
                         TupleImpl childLeftTuple = leftTuple.getFirstChild();
                         childLeftTuple.setPropagationContext(rightTuple.getPropagationContext());
-                        RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(childLeftTuple, trgLeftTuples, stagedLeftTuples);
+                        RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(trgLeftTuples, stagedLeftTuples, childLeftTuple);
                     } else if (!leftTuple.isExpired()) { // else !exists
                         trgLeftTuples.addInsert(TupleFactory.createLeftTuple(leftTuple, sink, leftTuple.getPropagationContext(), true));
                     }
@@ -168,7 +168,7 @@ public class PhreakSubnetworkNotExistsNode {
                         TupleImpl childLeftTuple = leftTuple.getFirstChild();
                         if (childLeftTuple != null) { // this can be null if the LT is not yet added
                             childLeftTuple.setPropagationContext(rightTuple.getPropagationContext());
-                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(childLeftTuple, trgLeftTuples, stagedLeftTuples);
+                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(trgLeftTuples, stagedLeftTuples, childLeftTuple);
                         }
                     }
                 }
@@ -189,7 +189,7 @@ public class PhreakSubnetworkNotExistsNode {
                 TupleImpl childLeftTuple = leftTuple.getFirstChild();
                 if (childLeftTuple != null) {
                     childLeftTuple.setPropagationContext(leftTuple.getPropagationContext());
-                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(childLeftTuple, trgLeftTuples, stagedLeftTuples);
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(trgLeftTuples, stagedLeftTuples, childLeftTuple);
                 }
 
                 leftTuple.setContextObject(null); // this is now right delete knows the LT is also being removed

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -452,9 +452,9 @@ public class PhreakTimerNode {
             bit = nextNodePosMask(bit);
         }
 
-        RuleNetworkEvaluator.INSTANCE.outerEval(pmem, sink, bit, tm,
-                                                smems, smemIndex, trgLeftTuples,
-                                                activationsManager, true, pmem.getRuleAgendaItem().getRuleExecutor());
+        RuleNetworkEvaluator.INSTANCE.outerEval(activationsManager, pmem.getRuleAgendaItem().getRuleExecutor(), pmem, smems,
+                                                smemIndex, bit, tm,
+                                                sink, trgLeftTuples, true);
     }
 
     public static class TimerNodeJobContext

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -227,7 +227,7 @@ public class RuleExecutor {
     }
 
     public void evaluateNetwork(ActivationsManager activationsManager) {
-        RuleNetworkEvaluator.INSTANCE.evaluateNetwork( pmem, this, activationsManager );
+        RuleNetworkEvaluator.INSTANCE.evaluateNetwork( activationsManager, this, pmem );
         setDirty( false );
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -108,11 +108,15 @@ public class RuleNetworkEvaluator {
 
     private RuleNetworkEvaluator() { }
 
-    public void evaluateNetwork(ReteEvaluator reteEvaluator, RuleExecutor executor, PathMemory pmem) {
+    public void evaluateNetwork(ReteEvaluator reteEvaluator,
+                                RuleExecutor executor,
+                                PathMemory pmem) {
         evaluateNetwork(pmem.getActualActivationsManager(reteEvaluator), executor, pmem);
     }
 
-    public void evaluateNetwork(ActivationsManager activationsManager, RuleExecutor executor, PathMemory pmem) {
+    public void evaluateNetwork(ActivationsManager activationsManager,
+                                RuleExecutor executor,
+                                PathMemory pmem) {
         SegmentMemory[] smems = pmem.getSegmentMemories();
 
 
@@ -146,34 +150,6 @@ public class RuleNetworkEvaluator {
         outerEval(activationsManager, executor, pmem, smems, firstSegmentIsOnlyLia ? 1 : 0, firstSegmentIsOnlyLia ? 1L : 2L, nodeMem, node, srcTuples, true);
     }
 
-    public static String indent(int size) {
-        StringBuilder sbuilder = new StringBuilder();
-        for (int i = 0; i < size; i++) {
-            sbuilder.append("  ");
-        }
-
-        return sbuilder.toString();
-    }
-
-    public static int getOffset(NetworkNode node) {
-        LeftTupleSource lt;
-        int offset = 1;
-        if (NodeTypeEnums.isTerminalNode(node)) {
-            lt = ((TerminalNode) node).getLeftTupleSource();
-            offset++;
-        } else if (node.getType() == NodeTypeEnums.TupleToObjectNode) {
-            lt = ((TupleToObjectNode) node).getLeftTupleSource();
-        } else {
-            lt = (LeftTupleSource) node;
-        }
-        while (!NodeTypeEnums.isLeftInputAdapterNode(lt)) {
-            offset++;
-            lt = lt.getLeftTupleSource();
-        }
-
-        return offset;
-    }
-
     public void outerEval(ActivationsManager activationsManager,
                           RuleExecutor executor,
                           PathMemory pmem,
@@ -194,7 +170,10 @@ public class RuleNetworkEvaluator {
         }
     }
 
-    public void evalStackEntry(ActivationsManager activationsManager, RuleExecutor executor, LinkedList<StackEntry> stack, StackEntry entry) {
+    public void evalStackEntry(ActivationsManager activationsManager,
+                               RuleExecutor executor,
+                               LinkedList<StackEntry> stack,
+                               StackEntry entry) {
         NetworkNode node = entry.getNode();
         Memory nodeMem = entry.getNodeMem();
         TupleSets trgTuples = entry.getTrgTuples();
@@ -325,13 +304,13 @@ public class RuleNetworkEvaluator {
             boolean terminalNode = true;
             switch (node.getType()) {
                 case NodeTypeEnums.RuleTerminalNode:
-                    pRtNode.doNode((AbstractTerminalNode) node, activationsManager, srcTuples, executor);
+                    pRtNode.doNode(activationsManager, executor, (AbstractTerminalNode) node, srcTuples);
                     break;
                 case NodeTypeEnums.QueryTerminalNode:
-                    pQtNode.doNode((QueryTerminalNode) node, activationsManager, srcTuples, stack);
+                    pQtNode.doNode(activationsManager, stack, (QueryTerminalNode) node, srcTuples);
                     break;
                 case NodeTypeEnums.TupleToObjectNode:
-                    doSubnetwork2(activationsManager.getReteEvaluator(), srcTuples, (TupleToObjectNode) node);
+                    doSubnetwork2(activationsManager.getReteEvaluator(), (TupleToObjectNode) node, srcTuples);
                     break;
                 default:
                     terminalNode = false;
@@ -377,10 +356,20 @@ public class RuleNetworkEvaluator {
         }
     }
 
-    public TupleSets evalNode(ActivationsManager activationsManager, RuleExecutor executor, LinkedList<StackEntry> stack, PathMemory pmem,
-                                         SegmentMemory[] smems, SegmentMemory smem, int smemIndex, long bit,
-                                         Memory nodeMem, NetworkNode node, LeftTupleSinkNode sink, TupleSets srcTuples,
-                                         TupleSets stagedLeftTuples, boolean processSubnetwork) {
+    public TupleSets evalNode(ActivationsManager activationsManager,
+                              RuleExecutor executor,
+                              LinkedList<StackEntry> stack,
+                              PathMemory pmem,
+                              SegmentMemory[] smems,
+                              SegmentMemory smem,
+                              int smemIndex,
+                              long bit,
+                              Memory nodeMem,
+                              NetworkNode node,
+                              LeftTupleSinkNode sink,
+                              TupleSets srcTuples,
+                              TupleSets stagedLeftTuples,
+                              boolean processSubnetwork) {
         TupleSets trgTuples = new TupleSetsImpl();
         if (NodeTypeEnums.isBetaNode(node)) {
             boolean exitInnerEval = evalBetaNode(activationsManager, executor, stack, pmem, smems, smemIndex, nodeMem, node, sink, trgTuples, srcTuples, stagedLeftTuples, processSubnetwork);
@@ -391,19 +380,19 @@ public class RuleNetworkEvaluator {
             boolean exitInnerEval = false;
             switch (node.getType()) {
                 case NodeTypeEnums.EvalConditionNode: {
-                    pEvalNode.doNode((EvalConditionNode) node, (EvalMemory) nodeMem, sink,
-                            activationsManager.getReteEvaluator(), srcTuples, trgTuples, stagedLeftTuples);
+                    pEvalNode.doNode(activationsManager.getReteEvaluator(), (EvalConditionNode) node, (EvalMemory) nodeMem,
+                            sink, srcTuples, trgTuples, stagedLeftTuples);
                     break;
 
                 }
                 case NodeTypeEnums.FromNode: {
-                    pFromNode.doNode((FromNode) node, (FromMemory) nodeMem, sink,
-                            activationsManager.getReteEvaluator(), srcTuples, trgTuples, stagedLeftTuples);
+                    pFromNode.doNode(activationsManager.getReteEvaluator(), (FromNode) node, (FromMemory) nodeMem,
+                            sink, srcTuples, trgTuples, stagedLeftTuples);
                     break;
                 }
                 case NodeTypeEnums.ReactiveFromNode: {
-                    pReactiveFromNode.doNode((ReactiveFromNode) node, (ReactiveFromNode.ReactiveFromMemory) nodeMem, sink,
-                                             activationsManager.getReteEvaluator(), srcTuples, trgTuples, stagedLeftTuples);
+                    pReactiveFromNode.doNode(activationsManager.getReteEvaluator(), (ReactiveFromNode) node, (ReactiveFromNode.ReactiveFromMemory) nodeMem,
+                                             sink, srcTuples, trgTuples, stagedLeftTuples);
                     break;
                 }
                 case NodeTypeEnums.QueryElementNode: {
@@ -416,16 +405,16 @@ public class RuleNetworkEvaluator {
                     break;
                 }
                 case NodeTypeEnums.ConditionalBranchNode: {
-                    pBranchNode.doNode((ConditionalBranchNode) node, (ConditionalBranchMemory) nodeMem, sink,
-                            activationsManager, srcTuples, trgTuples, stagedLeftTuples, executor);
+                    pBranchNode.doNode(activationsManager, (ConditionalBranchNode) node, (ConditionalBranchMemory) nodeMem,
+                            sink, srcTuples, trgTuples, stagedLeftTuples, executor);
                     break;
                 }
                 case NodeTypeEnums.AsyncSendNode: {
-                    pSendNode.doNode((AsyncSendNode) node, (AsyncSendMemory) nodeMem, activationsManager.getReteEvaluator(), srcTuples);
+                    pSendNode.doNode(activationsManager.getReteEvaluator(), (AsyncSendNode) node, (AsyncSendMemory) nodeMem, srcTuples);
                     break;
                 }
                 case NodeTypeEnums.AsyncReceiveNode: {
-                    pReceiveNode.doNode((AsyncReceiveNode) node, (AsyncReceiveMemory) nodeMem, sink, activationsManager.getReteEvaluator(), srcTuples, trgTuples);
+                    pReceiveNode.doNode(activationsManager.getReteEvaluator(), (AsyncReceiveNode) node, (AsyncReceiveMemory) nodeMem, sink, srcTuples, trgTuples);
                     break;
                 }
             }
@@ -436,7 +425,9 @@ public class RuleNetworkEvaluator {
         return trgTuples;
     }
 
-    private static TupleSets getTargetStagedLeftTuples(ReteEvaluator reteEvaluator, SegmentMemory smem, NetworkNode node) {
+    private static TupleSets getTargetStagedLeftTuples(ReteEvaluator reteEvaluator,
+                                                       SegmentMemory smem,
+                                                       NetworkNode node) {
         if (node == smem.getTipNode()) {
             // we are about to process the segment tip, allow it to merge insert/update/delete clashes
             if (smem.isEmpty()) {
@@ -483,60 +474,69 @@ public class RuleNetworkEvaluator {
             return false;
         } 
         // only process the Query Node if there are src tuples
-		StackEntry stackEntry = new StackEntry(node, bit, sink, pmem, nodeMem, smems,
-		                                       smemIndex, trgTuples, true, true);
+        StackEntry stackEntry = new StackEntry(node, bit, sink, pmem, nodeMem, smems,
+                                               smemIndex, trgTuples, true, true);
 
-		stack.add(stackEntry);
+        stack.add(stackEntry);
 
-		pQueryNode.doNode(qnode, (QueryElementNodeMemory) nodeMem, stackEntry,
-		        reteEvaluator, srcTuples, trgTuples, stagedLeftTuples);
+        pQueryNode.doNode(qnode, (QueryElementNodeMemory) nodeMem, stackEntry,
+                reteEvaluator, srcTuples, trgTuples, stagedLeftTuples);
 
-		SegmentMemory qsmem = ((QueryElementNodeMemory) nodeMem).getQuerySegmentMemory();
-		List<PathMemory> qpmems = qsmem.getPathMemories();
+        SegmentMemory qsmem = ((QueryElementNodeMemory) nodeMem).getQuerySegmentMemory();
+        List<PathMemory> qpmems = qsmem.getPathMemories();
 
-		// Build the evaluation information for each 'or' branch
-		for (int i = 0; i < qpmems.size() ; i++) {
-		    PathMemory qpmem = qpmems.get(i);
+        // Build the evaluation information for each 'or' branch
+        for (int i = 0; i < qpmems.size() ; i++) {
+            PathMemory qpmem = qpmems.get(i);
 
-		    pmem = qpmem;
-		    smems = qpmem.getSegmentMemories();
-		    smemIndex = 0;
-		    SegmentMemory smem = smems[smemIndex]; // 0
+            pmem = qpmem;
+            smems = qpmem.getSegmentMemories();
+            smemIndex = 0;
+            SegmentMemory smem = smems[smemIndex]; // 0
 
-		    LeftTupleNode liaNode = qpmem.getPathEndNode().getPathNodes()[0];
+            LeftTupleNode liaNode = qpmem.getPathEndNode().getPathNodes()[0];
 
-		    if (liaNode == smem.getTipNode()) {
-		        // segment only has liaNode in it
-		        // nothing is staged in the liaNode, so skip to next segment
-		        smem = smems[++smemIndex]; // 1
-		        node = smem.getRootNode();
-		        nodeMem = smem.getNodeMemories()[0];
-		        bit = 1;
-		    } else {
-		        // lia is in shared segment, so point to next node
-		        node = liaNode.getSinkPropagator().getFirstLeftTupleSink();
-		        nodeMem = smem.getNodeMemories()[1]; // skip the liaNode memory
-		        bit = 2;
-		    }
+            if (liaNode == smem.getTipNode()) {
+                // segment only has liaNode in it
+                // nothing is staged in the liaNode, so skip to next segment
+                smem = smems[++smemIndex]; // 1
+                node = smem.getRootNode();
+                nodeMem = smem.getNodeMemories()[0];
+                bit = 1;
+            } else {
+                // lia is in shared segment, so point to next node
+                node = liaNode.getSinkPropagator().getFirstLeftTupleSink();
+                nodeMem = smem.getNodeMemories()[1]; // skip the liaNode memory
+                bit = 2;
+            }
 
-		    trgTuples = smem.getStagedLeftTuples().takeAll();
-		    stackEntry = new StackEntry(node, bit, null, pmem,
-		                                nodeMem, smems, smemIndex,
-		                                trgTuples, false, true);
-		    if (log.isTraceEnabled()) {
-		        int offset = getOffset(stackEntry.getNode());
-		        log.trace("{} ORQueue branch={} {} {}", indent(offset), i, stackEntry.getNode().toString(), trgTuples.toStringSizes());
-		    }
-		    stack.add(stackEntry);
-		}
-		return true;
+            trgTuples = smem.getStagedLeftTuples().takeAll();
+            stackEntry = new StackEntry(node, bit, null, pmem,
+                                        nodeMem, smems, smemIndex,
+                                        trgTuples, false, true);
+            if (log.isTraceEnabled()) {
+                int offset = getOffset(stackEntry.getNode());
+                log.trace("{} ORQueue branch={} {} {}", indent(offset), i, stackEntry.getNode().toString(), trgTuples.toStringSizes());
+            }
+            stack.add(stackEntry);
+        }
+        return true;
 
     }
 
-    private boolean evalBetaNode(ActivationsManager activationsManager, RuleExecutor executor, LinkedList<StackEntry> stack,
-                                 PathMemory pmem, SegmentMemory[] smems, int smemIndex, Memory nodeMem,
-                                 NetworkNode node, LeftTupleSinkNode sink, TupleSets trgTuples,
-                                 TupleSets srcTuples, TupleSets stagedLeftTuples, boolean processSubnetwork) {
+    private boolean evalBetaNode(ActivationsManager activationsManager,
+                                 RuleExecutor executor,
+                                 LinkedList<StackEntry> stack,
+                                 PathMemory pmem,
+                                 SegmentMemory[] smems,
+                                 int smemIndex,
+                                 Memory nodeMem,
+                                 NetworkNode node,
+                                 LeftTupleSinkNode sink,
+                                 TupleSets trgTuples,
+                                 TupleSets srcTuples,
+                                 TupleSets stagedLeftTuples,
+                                 boolean processSubnetwork) {
         BetaNode betaNode = (BetaNode) node;
         BetaMemory bm;
         AccumulateMemory am = null;
@@ -555,13 +555,19 @@ public class RuleNetworkEvaluator {
             return true; // return here, TupleToObjectNode queues the evaluation on the stack, which is necessary to handled nested query nodes
         }
 
-        switchOnDoBetaNode(node, trgTuples, activationsManager.getReteEvaluator(), srcTuples, stagedLeftTuples, sink, bm, am);
+        switchOnDoBetaNode(activationsManager.getReteEvaluator(), bm, am, node, sink, trgTuples, srcTuples, stagedLeftTuples);
 
         return false;
     }
 
-    private void switchOnDoBetaNode(NetworkNode node, TupleSets trgTuples, ReteEvaluator reteEvaluator, TupleSets srcTuples,
-                                    TupleSets stagedLeftTuples, LeftTupleSinkNode sink, BetaMemory bm, AccumulateMemory am) {
+    private void switchOnDoBetaNode(ReteEvaluator reteEvaluator,
+                                    BetaMemory bm,
+                                    AccumulateMemory am,
+                                    NetworkNode node,
+                                    LeftTupleSinkNode sink,
+                                    TupleSets trgTuples,
+                                    TupleSets srcTuples,
+                                    TupleSets stagedLeftTuples) {
         if (log.isTraceEnabled()) {
             int offset = getOffset(node);
             log.trace("{} rightTuples {}", indent(offset), bm.getStagedRightTuples().toStringSizes());
@@ -569,26 +575,26 @@ public class RuleNetworkEvaluator {
 
         switch (node.getType()) {
             case NodeTypeEnums.JoinNode: {
-                pJoinNode.doNode((JoinNode) node, sink, bm,
-                        reteEvaluator, srcTuples, trgTuples, stagedLeftTuples);
+                pJoinNode.doNode(reteEvaluator, (JoinNode) node, sink,
+                        bm, srcTuples, trgTuples, stagedLeftTuples);
                 break;
             }
             case NodeTypeEnums.NotNode: {
-                pNotNode.doNode((NotNode) node, sink, bm,
-                        reteEvaluator, srcTuples, trgTuples, stagedLeftTuples);
+                pNotNode.doNode(reteEvaluator, (NotNode) node, sink,
+                        bm, srcTuples, trgTuples, stagedLeftTuples);
                 break;
             }
             case NodeTypeEnums.ExistsNode: {
-                pExistsNode.doNode((ExistsNode) node, sink, bm,
-                        reteEvaluator, srcTuples, trgTuples, stagedLeftTuples);
+                pExistsNode.doNode(reteEvaluator, (ExistsNode) node, sink,
+                        bm, srcTuples, trgTuples, stagedLeftTuples);
                 break;
             }
             case NodeTypeEnums.AccumulateNode: {
                 AccumulateNode accumulateNode = (AccumulateNode) node;
                 if (accumulateNode.getAccumulate().isGroupBy()) {
-                    pGroupByNode.doNode(accumulateNode, sink, am, reteEvaluator, srcTuples, trgTuples, stagedLeftTuples);
+                    pGroupByNode.doNode(reteEvaluator, accumulateNode, sink, am, srcTuples, trgTuples, stagedLeftTuples);
                 } else {
-                    pAccNode.doNode(accumulateNode, sink, am, reteEvaluator, srcTuples, trgTuples, stagedLeftTuples);
+                    pAccNode.doNode(reteEvaluator, accumulateNode, sink, am, srcTuples, trgTuples, stagedLeftTuples);
                 }
                 break;
             }
@@ -634,8 +640,8 @@ public class RuleNetworkEvaluator {
     }
 
     private void doSubnetwork2(ReteEvaluator reteEvaluator,
-                               TupleSets srcTuples,
-                               TupleToObjectNode tton) {
+                               TupleToObjectNode tton,
+                               TupleSets srcTuples) {
 
         ObjectSink[] sinks = tton.getObjectSinkPropagator().getSinks();
 
@@ -688,7 +694,6 @@ public class RuleNetworkEvaluator {
                     bms[i].getStagedRightTuples().addInsert(subnetworkTuple);
                 }
             }
-
             subnetworkTuple = next;
         }
 
@@ -722,7 +727,6 @@ public class RuleNetworkEvaluator {
                     subnetworkTuple.setStagedOnRight();
                 }
             }
-
             subnetworkTuple = next;
         }
 
@@ -747,16 +751,17 @@ public class RuleNetworkEvaluator {
                     subnetworkTuple.setStagedOnRight();
                 }
             }
-
             subnetworkTuple = next;
         }
-
         srcTuples.resetAll();
     }
 
-    public static void findLeftTupleBlocker(BetaNode betaNode, TupleMemory rtm,
-                                            Object contextEntry, BetaConstraints constraints,
-                                            TupleImpl leftTuple, boolean useLeftMemory) {
+    public static void findLeftTupleBlocker(BetaNode betaNode,
+                                            TupleMemory rtm,
+                                            Object contextEntry,
+                                            BetaConstraints constraints,
+                                            TupleImpl leftTuple,
+                                            boolean useLeftMemory) {
         // This method will also remove rightTuples that are from subnetwork where no leftmemory use used
         FastIterator it = betaNode.getRightIterator(rtm);
         for (RightTuple rightTuple = betaNode.getFirstRightTuple(leftTuple, rtm, it); rightTuple != null;) {
@@ -781,9 +786,9 @@ public class RuleNetworkEvaluator {
     }
 
 
-    public static void unlinkAndDeleteChildLeftTuple(TupleImpl childLeftTuple,
-                                                      TupleSets trgLeftTuples,
-                                                      TupleSets stagedLeftTuples) {
+    public static void unlinkAndDeleteChildLeftTuple(TupleSets trgLeftTuples,
+                                                     TupleSets stagedLeftTuples,
+                                                     TupleImpl childLeftTuple) {
         childLeftTuple.unlinkFromRightParent();
         childLeftTuple.unlinkFromLeftParent();
         deleteChildLeftTuple(childLeftTuple, trgLeftTuples, stagedLeftTuples);
@@ -807,7 +812,8 @@ public class RuleNetworkEvaluator {
         trgLeftTuples.addDelete(childLeftTuple);
     }
 
-    public static void doUpdatesReorderLeftMemory(BetaMemory bm, TupleSets srcLeftTuples) {
+    public static void doUpdatesReorderLeftMemory(BetaMemory bm,
+                                                  TupleSets srcLeftTuples) {
         TupleMemory ltm = bm.getLeftTupleMemory();
 
         // sides must first be re-ordered, to ensure iteration integrity
@@ -827,7 +833,8 @@ public class RuleNetworkEvaluator {
         }
     }
 
-    public static void doUpdatesExistentialReorderLeftMemory(BetaMemory bm, TupleSets srcLeftTuples) {
+    public static void doUpdatesExistentialReorderLeftMemory(BetaMemory bm,
+                                                             TupleSets srcLeftTuples) {
         TupleMemory ltm = bm.getLeftTupleMemory();
 
         // sides must first be re-ordered, to ensure iteration integrity
@@ -853,7 +860,8 @@ public class RuleNetworkEvaluator {
         }
     }
 
-    public static void doUpdatesReorderRightMemory(BetaMemory bm, TupleSets srcRightTuples) {
+    public static void doUpdatesReorderRightMemory(BetaMemory bm,
+                                                   TupleSets srcRightTuples) {
         TupleMemory rtm = bm.getRightTupleMemory();
 
         for (TupleImpl rightTuple = srcRightTuples.getUpdateFirst(); rightTuple != null; rightTuple = rightTuple.getStagedNext()) {
@@ -872,7 +880,9 @@ public class RuleNetworkEvaluator {
         }
     }
 
-    public static void doUpdatesExistentialReorderRightMemory(BetaMemory bm, BetaNode betaNode, TupleSets srcRightTuples) {
+    public static void doUpdatesExistentialReorderRightMemory(BetaMemory bm,
+                                                              BetaNode betaNode,
+                                                              TupleSets srcRightTuples) {
         TupleMemory rtm = bm.getRightTupleMemory();
 
         boolean resumeFromCurrent = !(betaNode.isIndexedUnificationJoin() || rtm.getIndexType().isComparison());
@@ -888,11 +898,11 @@ public class RuleNetworkEvaluator {
         }
 
         for (TupleImpl rightTuple = srcRightTuples.getUpdateFirst(); rightTuple != null; rightTuple = rightTuple.getStagedNext()) {
-            doRemoveExistentialRightMemoryForReorder(rtm, resumeFromCurrent, (RightTuple) rightTuple);
+            doRemoveExistentialRightMemoryForReorder(rtm, (RightTuple) rightTuple, resumeFromCurrent);
         }
 
         for (TupleImpl rightTuple = srcRightTuples.getUpdateFirst(); rightTuple != null; rightTuple = rightTuple.getStagedNext()) {
-            doAddExistentialRightMemoryForReorder(rtm, resumeFromCurrent, (RightTuple) rightTuple);
+            doAddExistentialRightMemoryForReorder(rtm, (RightTuple) rightTuple, resumeFromCurrent);
         }
 
         if (rtm.getIndexType() != TupleMemory.IndexType.NONE) {
@@ -902,18 +912,22 @@ public class RuleNetworkEvaluator {
         }
     }
 
-    public static void doExistentialUpdatesReorderChildLeftTuple(ReteEvaluator reteEvaluator, NotNode notNode, RightTuple rightTuple) {
+    public static void doExistentialUpdatesReorderChildLeftTuple(ReteEvaluator reteEvaluator,
+                                                                 NotNode notNode,
+                                                                 RightTuple rightTuple) {
         BetaMemory bm = getBetaMemory(notNode, reteEvaluator);
         TupleMemory rtm = bm.getRightTupleMemory();
 
         boolean resumeFromCurrent = !(notNode.isIndexedUnificationJoin() || rtm.getIndexType().isComparison());
-        doRemoveExistentialRightMemoryForReorder(rtm, resumeFromCurrent, rightTuple);
-        doAddExistentialRightMemoryForReorder(rtm, resumeFromCurrent, rightTuple);
+        doRemoveExistentialRightMemoryForReorder(rtm, rightTuple, resumeFromCurrent);
+        doAddExistentialRightMemoryForReorder(rtm, rightTuple, resumeFromCurrent);
 
         updateBlockersAndPropagate(notNode, rightTuple, reteEvaluator, rtm, bm.getContext(), notNode.getRawConstraints(), !resumeFromCurrent, null, null, null);
     }
 
-    private static void doAddExistentialRightMemoryForReorder(TupleMemory rtm, boolean resumeFromCurrent, RightTuple rightTuple) {
+    private static void doAddExistentialRightMemoryForReorder(TupleMemory rtm,
+                                                              RightTuple rightTuple,
+                                                              boolean resumeFromCurrent) {
         rtm.add(rightTuple);
 
         if (resumeFromCurrent) {
@@ -926,7 +940,9 @@ public class RuleNetworkEvaluator {
         doUpdatesReorderChildLeftTuple(rightTuple);
     }
 
-    private static void doRemoveExistentialRightMemoryForReorder(TupleMemory rtm, boolean resumeFromCurrent, RightTuple rightTuple) {
+    private static void doRemoveExistentialRightMemoryForReorder(TupleMemory rtm,
+                                                                 RightTuple rightTuple,
+                                                                 boolean resumeFromCurrent) {
         if (rightTuple.getMemory() != null) {
 
             if (resumeFromCurrent) {
@@ -957,7 +973,8 @@ public class RuleNetworkEvaluator {
         }
     }
 
-    public static boolean useLeftMemory(LeftTupleSource tupleSource, TupleImpl tuple) {
+    public static boolean useLeftMemory(LeftTupleSource tupleSource,
+                                        TupleImpl tuple) {
         boolean useLeftMemory = true;
         if (!tupleSource.isLeftTupleMemoryEnabled()) {
             // This is a hack, to not add closed DroolsQuery objects
@@ -969,7 +986,8 @@ public class RuleNetworkEvaluator {
         return useLeftMemory;
     }
 
-    public static void normalizeStagedTuples(TupleSets stagedLeftTuples, TupleImpl childLeftTuple) {
+    public static void normalizeStagedTuples(TupleSets stagedLeftTuples,
+                                             TupleImpl childLeftTuple) {
         if (!childLeftTuple.isStagedOnRight()) {
             switch (childLeftTuple.getStagedType()) {
                 // handle clash with already staged entries
@@ -981,5 +999,34 @@ public class RuleNetworkEvaluator {
                     break;
             }
         }
+    }
+    
+
+    private static String indent(int size) {
+        StringBuilder sbuilder = new StringBuilder();
+        for (int i = 0; i < size; i++) {
+            sbuilder.append("  ");
+        }
+
+        return sbuilder.toString();
+    }
+
+    private static int getOffset(NetworkNode node) {
+        LeftTupleSource lt;
+        int offset = 1;
+        if (NodeTypeEnums.isTerminalNode(node)) {
+            lt = ((TerminalNode) node).getLeftTupleSource();
+            offset++;
+        } else if (node.getType() == NodeTypeEnums.TupleToObjectNode) {
+            lt = ((TupleToObjectNode) node).getLeftTupleSource();
+        } else {
+            lt = (LeftTupleSource) node;
+        }
+        while (!NodeTypeEnums.isLeftInputAdapterNode(lt)) {
+            offset++;
+            lt = lt.getLeftTupleSource();
+        }
+
+        return offset;
     }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/TupleEvaluationUtil.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/TupleEvaluationUtil.java
@@ -128,8 +128,8 @@ public class TupleEvaluationUtil {
                 reteEvaluator.getNodeMemory((AbstractTerminalNode) pmem.getPathEndNode().getPathEndNodes()[0]);
 
         ActivationsManager activationsManager = pmem.getActualActivationsManager( reteEvaluator );
-        RuleNetworkEvaluator.INSTANCE.outerEval(pmem, node, bit, mem, smems, sm.getPos(), leftTupleSets, activationsManager,
-                true,
-                rtnPmem.getOrCreateRuleAgendaItem(activationsManager).getRuleExecutor());
+        RuleNetworkEvaluator.INSTANCE.outerEval(activationsManager, rtnPmem.getOrCreateRuleAgendaItem(activationsManager).getRuleExecutor(), pmem, smems, sm.getPos(), bit, mem, node,
+                leftTupleSets,
+                true);
     }
 }

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAccumulateNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAccumulateNodeMetric.java
@@ -30,10 +30,10 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakAccumulateNodeMetric extends PhreakAccumulateNode {
 
     @Override
-    public void doNode(AccumulateNode accNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       AccumulateNode accNode,
                        LeftTupleSink sink,
                        AccumulateMemory am,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -41,7 +41,7 @@ public class PhreakAccumulateNodeMetric extends PhreakAccumulateNode {
         try {
             MetricLogUtils.getInstance().startMetrics(accNode);
 
-            super.doNode(accNode, sink, am, reteEvaluator, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(reteEvaluator, accNode, sink, am, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAsyncReceiveNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAsyncReceiveNodeMetric.java
@@ -30,17 +30,17 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakAsyncReceiveNodeMetric extends PhreakAsyncReceiveNode {
 
     @Override
-    public void doNode(AsyncReceiveNode node,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       AsyncReceiveNode node,
                        AsyncReceiveMemory memory,
                        LeftTupleSink sink,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(node);
 
-            super.doNode(node, memory, sink, reteEvaluator, srcLeftTuples, trgLeftTuples);
+            super.doNode(reteEvaluator, node, memory, sink, srcLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAsyncSendNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAsyncSendNodeMetric.java
@@ -29,15 +29,15 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakAsyncSendNodeMetric extends PhreakAsyncSendNode {
 
     @Override
-    public void doNode(AsyncSendNode node,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       AsyncSendNode node,
                        AsyncSendMemory memory,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(node);
 
-            super.doNode(node, memory, reteEvaluator, srcLeftTuples);
+            super.doNode(reteEvaluator, node, memory, srcLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakBranchNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakBranchNodeMetric.java
@@ -31,10 +31,10 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakBranchNodeMetric extends PhreakBranchNode {
 
     @Override
-    public void doNode(ConditionalBranchNode branchNode,
+    public void doNode(ActivationsManager activationsManager,
+                       ConditionalBranchNode branchNode,
                        ConditionalBranchMemory cbm,
                        LeftTupleSink sink,
-                       ActivationsManager activationsManager,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples,
@@ -43,7 +43,7 @@ public class PhreakBranchNodeMetric extends PhreakBranchNode {
         try {
             MetricLogUtils.getInstance().startMetrics(branchNode);
 
-            super.doNode(branchNode, cbm, sink, activationsManager, srcLeftTuples, trgLeftTuples, stagedLeftTuples, executor);
+            super.doNode(activationsManager, branchNode, cbm, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples, executor);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakEvalNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakEvalNodeMetric.java
@@ -30,10 +30,10 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakEvalNodeMetric extends PhreakEvalNode {
 
     @Override
-    public void doNode(EvalConditionNode evalNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       EvalConditionNode evalNode,
                        EvalMemory em,
                        LeftTupleSink sink,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -41,7 +41,7 @@ public class PhreakEvalNodeMetric extends PhreakEvalNode {
         try {
             MetricLogUtils.getInstance().startMetrics(evalNode);
 
-            super.doNode(evalNode, em, sink, reteEvaluator, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(reteEvaluator, evalNode, em, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakExistsNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakExistsNodeMetric.java
@@ -29,10 +29,10 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakExistsNodeMetric extends PhreakExistsNode {
 
     @Override
-    public void doNode(ExistsNode existsNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       ExistsNode existsNode,
                        LeftTupleSink sink,
                        BetaMemory bm,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -40,7 +40,7 @@ public class PhreakExistsNodeMetric extends PhreakExistsNode {
         try {
             MetricLogUtils.getInstance().startMetrics(existsNode);
 
-            super.doNode(existsNode, sink, bm, reteEvaluator, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(reteEvaluator, existsNode, sink, bm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakFromNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakFromNodeMetric.java
@@ -30,10 +30,10 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakFromNodeMetric extends PhreakFromNode {
 
     @Override
-    public void doNode(FromNode fromNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       FromNode fromNode,
                        FromMemory fm,
                        LeftTupleSink sink,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -41,7 +41,7 @@ public class PhreakFromNodeMetric extends PhreakFromNode {
         try {
             MetricLogUtils.getInstance().startMetrics(fromNode);
 
-            super.doNode(fromNode, fm, sink, reteEvaluator, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(reteEvaluator, fromNode, fm, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakGroupByNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakGroupByNodeMetric.java
@@ -29,10 +29,10 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakGroupByNodeMetric extends PhreakGroupByNode {
 
     @Override
-    public void doNode( AccumulateNode accNode,
+    public void doNode( ReteEvaluator reteEvaluator,
+                        AccumulateNode accNode,
                         LeftTupleSink sink,
                         AccumulateNode.AccumulateMemory am,
-                        ReteEvaluator reteEvaluator,
                         TupleSets srcLeftTuples,
                         TupleSets trgLeftTuples,
                         TupleSets stagedLeftTuples) {
@@ -40,7 +40,7 @@ public class PhreakGroupByNodeMetric extends PhreakGroupByNode {
         try {
             MetricLogUtils.getInstance().startMetrics(accNode);
 
-            super.doNode(accNode, sink, am, reteEvaluator, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(reteEvaluator, accNode, sink, am, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakJoinNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakJoinNodeMetric.java
@@ -29,17 +29,17 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakJoinNodeMetric extends PhreakJoinNode {
 
     @Override
-    public void doNode(JoinNode joinNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       JoinNode joinNode,
                        LeftTupleSink sink,
                        BetaMemory bm,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
         try {
             MetricLogUtils.getInstance().startMetrics(joinNode);
 
-            super.doNode(joinNode, sink, bm, reteEvaluator, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(reteEvaluator, joinNode, sink, bm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakNotNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakNotNodeMetric.java
@@ -29,10 +29,10 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakNotNodeMetric extends PhreakNotNode {
 
     @Override
-    public void doNode(NotNode notNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       NotNode notNode,
                        LeftTupleSink sink,
                        BetaMemory bm,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -40,7 +40,7 @@ public class PhreakNotNodeMetric extends PhreakNotNode {
         try {
             MetricLogUtils.getInstance().startMetrics(notNode);
 
-            super.doNode(notNode, sink, bm, reteEvaluator, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(reteEvaluator, notNode, sink, bm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakQueryTerminalNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakQueryTerminalNodeMetric.java
@@ -30,15 +30,15 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakQueryTerminalNodeMetric extends PhreakQueryTerminalNode {
 
     @Override
-    public void doNode(QueryTerminalNode qtnNode,
-                       ActivationsManager activationsManager,
-                       TupleSets srcLeftTuples,
-                       LinkedList<StackEntry> stack) {
+    public void doNode(ActivationsManager activationsManager,
+                       LinkedList<StackEntry> stack,
+                       QueryTerminalNode qtnNode,
+                       TupleSets srcLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(qtnNode);
 
-            super.doNode(qtnNode, activationsManager, srcLeftTuples, stack);
+            super.doNode(activationsManager, stack, qtnNode, srcLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakReactiveFromNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakReactiveFromNodeMetric.java
@@ -30,10 +30,10 @@ import org.drools.metric.util.MetricLogUtils;
 public class PhreakReactiveFromNodeMetric extends PhreakReactiveFromNode {
 
     @Override
-    public void doNode(ReactiveFromNode fromNode,
+    public void doNode(ReteEvaluator reteEvaluator,
+                       ReactiveFromNode fromNode,
                        ReactiveFromMemory fm,
                        LeftTupleSink sink,
-                       ReteEvaluator reteEvaluator,
                        TupleSets srcLeftTuples,
                        TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples) {
@@ -41,7 +41,7 @@ public class PhreakReactiveFromNodeMetric extends PhreakReactiveFromNode {
         try {
             MetricLogUtils.getInstance().startMetrics(fromNode);
 
-            super.doNode(fromNode, fm, sink, reteEvaluator, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(reteEvaluator, fromNode, fm, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Scenario.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Scenario.java
@@ -177,15 +177,15 @@ public class Scenario {
         actualResultLeftTuples = new TupleSetsImpl();
         
         if ( phreakNode == PhreakJoinNode.class ) {
-            new PhreakJoinNode().doNode( (JoinNode) betaNode, sinkNode,
-                                          bm, wm, leftTuples, actualResultLeftTuples, previousResultTuples );
+            new PhreakJoinNode().doNode( wm, (JoinNode) betaNode,
+                                          sinkNode, bm, leftTuples, actualResultLeftTuples, previousResultTuples );
             
         } else if ( phreakNode == PhreakNotNode.class ) {
-            new PhreakNotNode().doNode( (NotNode) betaNode, sinkNode,
-                                        bm, wm, leftTuples, actualResultLeftTuples, previousResultTuples );            
+            new PhreakNotNode().doNode( wm, (NotNode) betaNode,
+                                        sinkNode, bm, leftTuples, actualResultLeftTuples, previousResultTuples );            
         } else if ( phreakNode == PhreakExistsNode.class ) {
-            new PhreakExistsNode().doNode( (ExistsNode) betaNode, sinkNode,
-                                           bm, wm, leftTuples, actualResultLeftTuples, previousResultTuples );            
+            new PhreakExistsNode().doNode( wm, (ExistsNode) betaNode,
+                                           sinkNode, bm, leftTuples, actualResultLeftTuples, previousResultTuples );            
         }
         
         if ( expectedResultBuilder != null ) {


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->
This PR is an initial attempt to cleanup the code in the Phreak evaluation engine. 

The PR is minimalistic because the code is quite complex and there are lots of issues, so we need to move slowly and address it one by one. 

This is a prerequisite for the work for query caching, because the code that we have to modify for query caching is too complex at the moment to be modified with some proper criteria.

The modifications are mostly here in the RuleNetworkEvaluator class, namely:

- the cycle to evaluate the stack has been simplified and clarified
- some variable had their scope reduced, so that they are closer to where they are used
- parameters in all the functions have been reordered, following the scheme of [Global Objects, Path/Segment Memories, Node Memories, Node, TupleSets, Tuples]. Possibly there are more sensible schemes, but this is what I have found so far
- the parameters reordering has been extended to a number of methods of other objects called from the code, to make the code more coherent. We have not finished, but we cannot have a giant PR.
- code has been reformatted to be a bit more uniform - expecially spaces near parentheses have been removed and parameters in method declarations have been modified.

As said, there is a lot more to do here, but I hope this is a good step in the right direction
- 
