### PR TITLE
[NO-ISSUE] Update version of logback to 1.5.19.

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -51,7 +51,7 @@
       - A version property must be specified in the format "version.{groupId}", optionally with a suffix to make it unique.
       - Version properties must be sorted alphabetically (other form of sorting were found to be unclear and ambiguous).
     -->
-    <version.ch.qos.logback>1.5.18</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.19</version.ch.qos.logback>
     <version.commons-codec>1.18.0</version.commons-codec>
     <version.commons-collections>3.2.2</version.commons-collections>
     <version.commons-logging>1.1.1</version.commons-logging>


### PR DESCRIPTION
Updates logback to 1.5.19. 

Related PRs: 
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4090
https://github.com/apache/incubator-kie-tools/pull/3306