### PR TITLE
[incubator-kie-issues #203] Cleanup Phreak code - next step 

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -1053,7 +1053,7 @@ public class KnowledgeBaseImpl implements InternalRuleBase {
             // All Protos must be created, before inserting objects.
             for (TerminalNode tn : terminalNodes) {
                 tn.getPathMemSpec();
-                BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, this);
+                BuildtimeSegmentUtilities.createPathProtoMemories(this, tn, null);
             }
             Set<Integer> visited = new HashSet<>();
             for (TerminalNode tn : terminalNodes) {

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -1059,8 +1059,8 @@ public class KnowledgeBaseImpl implements InternalRuleBase {
             for (TerminalNode tn : terminalNodes) {
                 // populate memories
                 wms.stream().forEach( wm -> {
-                    Add.insertLiaFacts(tn.getPathNodes()[0], wm, visited, true);
-                    Add.insertFacts(tn, wm, visited, true);
+                    Add.insertLiaFacts(wm, tn.getPathNodes()[0], visited, true);
+                    Add.insertFacts(wm, tn, visited, true);
                 });
             }
         }

--- a/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
@@ -63,24 +63,24 @@ import org.drools.core.reteoo.TimerNode;
 public class BuildtimeSegmentUtilities {
 
     public static void updateSegmentEndNodes(PathEndNode endNode) {
-        SegmentPrototype smproto = endNode.getSegmentPrototypes()[endNode.getSegmentPrototypes().length-1];
+        SegmentPrototype smproto = endNode.getSegmentPrototypes()[endNode.getSegmentPrototypes().length - 1];
         if (smproto.getPathEndNodes() != null) {
             // This is a special check, for shared subnetwork paths. It ensure it's initallysed only once,
             // even though the TupleToObjectNode is shared with different TNs.
             return;
         }
 
-        for ( int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
+        for (int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
             smproto = endNode.getSegmentPrototypes()[i];
 
-            if ( smproto.getPathEndNodes() != null) {
+            if (smproto.getPathEndNodes() != null) {
                 PathEndNode[] existingNodes = smproto.getPathEndNodes();
-                PathEndNode[] newNodes = new PathEndNode[existingNodes.length+1];
+                PathEndNode[] newNodes = new PathEndNode[existingNodes.length + 1];
                 System.arraycopy(existingNodes, 0, newNodes, 0, existingNodes.length);
-                newNodes[newNodes.length-1] = endNode;
+                newNodes[newNodes.length - 1] = endNode;
                 smproto.setPathEndNodes(newNodes);
             } else {
-                smproto.setPathEndNodes( new PathEndNode[]{endNode});
+                smproto.setPathEndNodes(new PathEndNode[]{endNode});
             }
         }
     }
@@ -95,7 +95,7 @@ public class BuildtimeSegmentUtilities {
         }
         endNode.setEagerSegmentPrototypes(eager.toArray(new SegmentPrototype[eager.size()]));
 
-        long allLinkedMaskTest = getPathAllLinkedMaskTest(smems, endNode);
+        long allLinkedMaskTest = getPathAllLinkedMaskTest(endNode, smems);
 
         endNode.setPathMemSpec(new PathMemSpec(allLinkedMaskTest, smems.length));
 
@@ -104,7 +104,7 @@ public class BuildtimeSegmentUtilities {
         updateSegmentEndNodes(endNode);
     }
 
-    public static long getPathAllLinkedMaskTest(SegmentPrototype[] smems, PathEndNode endNode) {
+    public static long getPathAllLinkedMaskTest(PathEndNode endNode, SegmentPrototype[] smems) {
         long allLinkedMaskTest = 0;
         for (int i = smems.length - 1; i >= 0; i--) {
             SegmentPrototype smem = smems[i];
@@ -119,26 +119,30 @@ public class BuildtimeSegmentUtilities {
         return allLinkedMaskTest;
     }
 
-    public static SegmentPrototype[] createPathProtoMemories(TerminalNode tn, TerminalNode removingTn, InternalRuleBase rbase) {
+    public static SegmentPrototype[] createPathProtoMemories(InternalRuleBase rbase,
+                                                             TerminalNode tn,
+                                                             TerminalNode removingTn) {
         // Will initialise all segments in a path
-        SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(tn, removingTn, rbase);
+        SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(rbase, tn, removingTn);
 
         // smems are empty, if there is no beta network. Which means it has an AlphaTerminalNode
-        if  (smems.length > 0) {
+        if (smems.length > 0) {
             setSegments(tn, smems);
         }
 
         return smems;
     }
 
-    public static SegmentPrototype[] createLeftTupleNodeProtoMemories(LeftTupleNode lts, TerminalNode removingTn, InternalRuleBase rbase) {
+    public static SegmentPrototype[] createLeftTupleNodeProtoMemories(InternalRuleBase rbase,
+                                                                      LeftTupleNode lts,
+                                                                      TerminalNode removingTn) {
         LeftTupleNode segmentRoot = lts;
         LeftTupleNode segmentTip = lts;
         List<SegmentPrototype> smems = new ArrayList<>();
         int start = 0;
 
         LeftTupleNode firstConditional = getFirstConditionalBranchNode(lts);
-        int recordBefore = firstConditional == null  ? Integer.MAX_VALUE : firstConditional.getPathIndex();  // nodes after a branch CE can notify, but they cannot impact linking
+        int recordBefore = firstConditional == null ? Integer.MAX_VALUE : firstConditional.getPathIndex(); // nodes after a branch CE can notify, but they cannot impact linking
 
         do {
             // iterate to find the actual segment root
@@ -150,7 +154,7 @@ public class BuildtimeSegmentUtilities {
             SegmentPrototype smem = rbase.getSegmentPrototype(segmentRoot);
             if (smem == null) {
                 start = segmentRoot.getPathIndex(); // we want counter to start from the new segment proto only
-                smem = createSegmentMemory(segmentRoot, segmentTip, recordBefore, removingTn, rbase);
+                smem = createSegmentMemory(rbase, segmentRoot, segmentTip, removingTn, recordBefore);
             }
             smems.add(0, smem);
 
@@ -162,7 +166,7 @@ public class BuildtimeSegmentUtilities {
         // reset to find the next segments and set their position and their bit mask
         int ruleSegmentPosMask = 1;
         for (int i = 0; i < smems.size(); i++) {
-            if ( start >= 0 && smems.get(i) != null) { // The segments before the start of a subnetwork, will be null for a TupleToObjectNode path.
+            if (start >= 0 && smems.get(i) != null) { // The segments before the start of a subnetwork, will be null for a TupleToObjectNode path.
                 smems.get(i).setPos(i);
                 if (smems.get(i).getAllLinkedMaskTest() > 0) {
                     smems.get(i).setSegmentPosMaskBit(ruleSegmentPosMask);
@@ -178,8 +182,8 @@ public class BuildtimeSegmentUtilities {
 
     static LeftTupleNode getFirstConditionalBranchNode(LeftTupleNode tupleSource) {
         LeftTupleNode conditionalBranch = null;
-        while (  !NodeTypeEnums.isLeftInputAdapterNode(tupleSource)) {
-            if ( tupleSource.getType() == NodeTypeEnums.ConditionalBranchNode ) {
+        while (!NodeTypeEnums.isLeftInputAdapterNode(tupleSource)) {
+            if (tupleSource.getType() == NodeTypeEnums.ConditionalBranchNode) {
                 conditionalBranch = tupleSource;
             }
             tupleSource = tupleSource.getLeftTupleSource();
@@ -190,7 +194,11 @@ public class BuildtimeSegmentUtilities {
     /**
      * Initialises the NodeSegment memory for all nodes in the segment.
      */
-    public static SegmentPrototype createSegmentMemory(LeftTupleNode segmentRoot, LeftTupleNode segmentTip, int recordBefore, TerminalNode removingTn, InternalRuleBase rbase) {
+    public static SegmentPrototype createSegmentMemory(InternalRuleBase rbase,
+                                                       LeftTupleNode segmentRoot,
+                                                       LeftTupleNode segmentTip,
+                                                       TerminalNode removingTn,
+                                                       int recordBefore) {
         LeftTupleNode node = segmentRoot;
         int nodeTypesInSegment = 0;
 
@@ -208,12 +216,14 @@ public class BuildtimeSegmentUtilities {
             nodeTypesInSegment = updateNodeTypesMask(node, nodeTypesInSegment);
             if (NodeTypeEnums.isBetaNode(node)) {
                 boolean updateAllLinked = node.getPathIndex() < recordBefore && updateNodeBit;
-                allLinkedTestMask = processBetaNode((BetaNode)node, smem, memories, nodes, nodePosMask, allLinkedTestMask, updateAllLinked, removingTn, rbase);
+                allLinkedTestMask = processBetaNode(rbase, (BetaNode) node, removingTn, smem, memories,
+                        nodes, nodePosMask, allLinkedTestMask, updateAllLinked);
             } else {
                 switch (node.getType()) {
                     case NodeTypeEnums.LeftInputAdapterNode:
                     case NodeTypeEnums.AlphaTerminalNode:
-                        allLinkedTestMask = processLiaNode((LeftInputAdapterNode) node, memories, nodes, nodePosMask, allLinkedTestMask);
+                        allLinkedTestMask = processLiaNode((LeftInputAdapterNode) node, memories, nodes, nodePosMask,
+                                allLinkedTestMask);
                         break;
                     case NodeTypeEnums.ConditionalBranchNode:
                         processConditionalBranchNode((ConditionalBranchNode) node, memories, nodes);
@@ -255,12 +265,12 @@ public class BuildtimeSegmentUtilities {
                 break;
             }
 
-            node = ((LeftTupleSource)node).getFirstLeftTupleSinkIgnoreRemoving(removingTn);
+            node = ((LeftTupleSource) node).getFirstLeftTupleSinkIgnoreRemoving(removingTn);
         }
         smem.setAllLinkedMaskTest(allLinkedTestMask);
 
-        smem.setNodesInSegment(nodes.toArray( new LeftTupleNode[nodes.size()]));
-        smem.setMemories(memories.toArray( new MemoryPrototype[memories.size()]));
+        smem.setNodesInSegment(nodes.toArray(new LeftTupleNode[nodes.size()]));
+        smem.setMemories(memories.toArray(new MemoryPrototype[memories.size()]));
         smem.setNodeTypesInSegment(nodeTypesInSegment);
 
         rbase.registerSegmentPrototype(segmentRoot, smem);
@@ -271,8 +281,8 @@ public class BuildtimeSegmentUtilities {
     public static boolean requiresAnEagerSegment(int nodeTypesInSegment) {
         // A Not node has to be eagerly initialized unless in its segment there is at least a join node
         return isSet(nodeTypesInSegment, NOT_NODE_BIT) &&
-             !isSet(nodeTypesInSegment, JOIN_NODE_BIT) &&
-             !isSet(nodeTypesInSegment, REACTIVE_EXISTS_NODE_BIT);
+               !isSet(nodeTypesInSegment, JOIN_NODE_BIT) &&
+               !isSet(nodeTypesInSegment, REACTIVE_EXISTS_NODE_BIT);
     }
 
     public static long nextNodePosMask(long posMask) {
@@ -283,70 +293,97 @@ public class BuildtimeSegmentUtilities {
         return nextNodePosMask > 0 ? nextNodePosMask : posMask;
     }
 
-    private static boolean processQueryNode(QueryElementNode queryNode, List<MemoryPrototype> memories, List<LeftTupleNode> nodes, long nodePosMask) {
+    private static boolean processQueryNode(QueryElementNode queryNode,
+                                            List<MemoryPrototype> memories,
+                                            List<LeftTupleNode> nodes,
+                                            long nodePosMask) {
         QueryMemoryPrototype queryNodeMem = new QueryMemoryPrototype(nodePosMask, queryNode);
         memories.add(queryNodeMem);
         nodes.add(queryNode);
 
-        return ! queryNode.getQueryElement().isAbductive();
+        return !queryNode.getQueryElement().isAbductive();
     }
 
-    private static void processAsyncSendNode(AsyncSendNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes) {
+    private static void processAsyncSendNode(AsyncSendNode tupleSource,
+                                             List<MemoryPrototype> memories,
+                                             List<LeftTupleNode> nodes) {
         AsyncSendMemoryPrototype mem = new AsyncSendMemoryPrototype();
         memories.add(mem);
         nodes.add(tupleSource);
     }
 
-    private static void processAsyncReceiveNode(AsyncReceiveNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes, long nodePosMask) {
+    private static void processAsyncReceiveNode(AsyncReceiveNode tupleSource,
+                                                List<MemoryPrototype> memories,
+                                                List<LeftTupleNode> nodes,
+                                                long nodePosMask) {
         AsyncReceiveMemoryPrototype mem = new AsyncReceiveMemoryPrototype(nodePosMask);
         memories.add(mem);
         nodes.add(tupleSource);
     }
 
-    private static void processConditionalBranchNode(ConditionalBranchNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes) {
+    private static void processConditionalBranchNode(ConditionalBranchNode tupleSource,
+                                                     List<MemoryPrototype> memories,
+                                                     List<LeftTupleNode> nodes) {
         ConditionalBranchMemoryPrototype mem = new ConditionalBranchMemoryPrototype();
         memories.add(mem);
         nodes.add(tupleSource);
     }
 
-    private static void processRightInputAdapterNode(TupleToObjectNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes) {
+    private static void processRightInputAdapterNode(TupleToObjectNode tupleSource,
+                                                     List<MemoryPrototype> memories,
+                                                     List<LeftTupleNode> nodes) {
         RightInputAdapterPrototype mem = new RightInputAdapterPrototype();
         memories.add(mem);
         nodes.add(tupleSource);
     }
 
-    private static void processTerminalNode(TerminalNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes) {
+    private static void processTerminalNode(TerminalNode tupleSource,
+                                            List<MemoryPrototype> memories,
+                                            List<LeftTupleNode> nodes) {
         TerminalPrototype mem = new TerminalPrototype();
         memories.add(mem);
         nodes.add(tupleSource);
     }
 
-    private static void processFromNode(FromNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes) {
+    private static void processFromNode(FromNode tupleSource,
+                                        List<MemoryPrototype> memories,
+                                        List<LeftTupleNode> nodes) {
         FromMemoryPrototype mem = new FromMemoryPrototype();
         memories.add(mem);
         nodes.add(tupleSource);
     }
 
-    private static void processEvalFromNode(EvalConditionNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes) {
+    private static void processEvalFromNode(EvalConditionNode tupleSource,
+                                            List<MemoryPrototype> memories,
+                                            List<LeftTupleNode> nodes) {
         EvalMemoryPrototype mem = new EvalMemoryPrototype();
         memories.add(mem);
         nodes.add(tupleSource);
     }
 
-    private static void processReactiveFromNode(ReactiveFromNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes, long nodePosMask) {
+    private static void processReactiveFromNode(ReactiveFromNode tupleSource,
+                                                List<MemoryPrototype> memories,
+                                                List<LeftTupleNode> nodes,
+                                                long nodePosMask) {
         ReactiveFromMemoryPrototype mem = new ReactiveFromMemoryPrototype(nodePosMask);
         memories.add(mem);
         nodes.add(tupleSource);
     }
 
-    private static void processTimerNode(TimerNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes, long nodePosMask) {
+    private static void processTimerNode(TimerNode tupleSource,
+                                         List<MemoryPrototype> memories,
+                                         List<LeftTupleNode> nodes,
+                                         long nodePosMask) {
         TimerMemoryPrototype tnMem = new TimerMemoryPrototype(nodePosMask);
         memories.add(tnMem);
         nodes.add(tupleSource);
     }
 
-    private static long processLiaNode(LeftInputAdapterNode tupleSource, List<MemoryPrototype> memories, List<LeftTupleNode> nodes,
-                                       long nodePosMask, long allLinkedTestMask) {
+    private static long processLiaNode(LeftInputAdapterNode tupleSource,
+                                       List<MemoryPrototype> memories,
+                                       List<LeftTupleNode> nodes,
+                                       long nodePosMask,
+                                       long allLinkedTestMask) {
         LiaMemoryPrototype liaMemory = new LiaMemoryPrototype(nodePosMask);
         memories.add(liaMemory);
         nodes.add(tupleSource);
@@ -354,14 +391,21 @@ public class BuildtimeSegmentUtilities {
         return allLinkedTestMask;
     }
 
-    private static long processBetaNode(BetaNode betaNode, SegmentPrototype smem, List<MemoryPrototype> memories, List<LeftTupleNode> nodes,
-                                        long nodePosMask, long allLinkedTestMask, boolean updateNodeBit, TerminalNode removingTn, InternalRuleBase rbase) {
+    private static long processBetaNode(InternalRuleBase rbase,
+                                        BetaNode betaNode,
+                                        TerminalNode removingTn,
+                                        SegmentPrototype smem,
+                                        List<MemoryPrototype> memories,
+                                        List<LeftTupleNode> nodes,
+                                        long nodePosMask,
+                                        long allLinkedTestMask,
+                                        boolean updateNodeBit) {
         TupleToObjectNode tton = null;
         if (betaNode.getRightInput().inputIsTupleToObjectNode()) {
             // there is a subnetwork, so create all it's segment memory prototypes
             tton = (TupleToObjectNode) betaNode.getRightInput().getParent();
 
-            SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(tton, removingTn, rbase);
+            SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(rbase, tton, removingTn);
             setSegments(tton, smems);
 
             if (updateNodeBit && canBeDisabled(betaNode) && tton.getPathMemSpec().allLinkedTestMask() > 0) {
@@ -379,7 +423,7 @@ public class BuildtimeSegmentUtilities {
 
         BetaMemoryPrototype bm = new BetaMemoryPrototype(nodePosMask, tton);
 
-        if (NodeTypeEnums.AccumulateNode == betaNode.getType())  {
+        if (NodeTypeEnums.AccumulateNode == betaNode.getType()) {
             AccumulateMemoryPrototype am = new AccumulateMemoryPrototype(bm);
             memories.add(am);
         } else {
@@ -406,7 +450,7 @@ public class BuildtimeSegmentUtilities {
      * if the rule had already been removed from the network.
      */
     public static boolean isRootNode(LeftTupleNode node, TerminalNode ignoreTn) {
-        return NodeTypeEnums.isLeftInputAdapterNode(node) || isTipNode( node.getLeftTupleSource(), ignoreTn );
+        return NodeTypeEnums.isLeftInputAdapterNode(node) || isTipNode(node.getLeftTupleSource(), ignoreTn);
     }
 
     /**
@@ -418,11 +462,11 @@ public class BuildtimeSegmentUtilities {
      * The result should discount any removingRule. That means it gives you the result as
      * if the rule had already been removed from the network.
      */
-    public static boolean isTipNode( LeftTupleNode node, TerminalNode removingTN ) {
-        return NodeTypeEnums.isEndNode(node) || isNonTerminalTipNode( node, removingTN );
+    public static boolean isTipNode(LeftTupleNode node, TerminalNode removingTN) {
+        return NodeTypeEnums.isEndNode(node) || isNonTerminalTipNode(node, removingTN);
     }
 
-    public static boolean isNonTerminalTipNode( LeftTupleNode node, TerminalNode removingTN ) {
+    public static boolean isNonTerminalTipNode(LeftTupleNode node, TerminalNode removingTN) {
         LeftTupleSinkPropagator sinkPropagator = node.getSinkPropagator();
 
         if (removingTN == null) {
@@ -435,10 +479,11 @@ public class BuildtimeSegmentUtilities {
 
         // we know the sink size is greater than 1 and that there is a removingRule that needs to be ignored.
         int count = 0;
-        for ( LeftTupleSinkNode sink = sinkPropagator.getFirstLeftTupleSink(); sink != null; sink = sink.getNextLeftTupleSinkNode() ) {
-            if ( sinkNotExclusivelyAssociatedWithTerminal( removingTN, sink ) ) {
+        for (LeftTupleSinkNode sink = sinkPropagator.getFirstLeftTupleSink(); sink != null; sink = sink
+                .getNextLeftTupleSinkNode()) {
+            if (sinkNotExclusivelyAssociatedWithTerminal(sink, removingTN)) {
                 count++;
-                if ( count > 1 ) {
+                if (count > 1) {
                     // There is more than one sink that is not for the removing rule
                     return true;
                 }
@@ -448,25 +493,25 @@ public class BuildtimeSegmentUtilities {
         return false;
     }
 
-    public static boolean sinkNotExclusivelyAssociatedWithTerminal( TerminalNode removingTN, LeftTupleNode sink ) {
+    public static boolean sinkNotExclusivelyAssociatedWithTerminal(LeftTupleNode sink, TerminalNode removingTN) {
         return sink.getAssociatedTerminalsSize() > 1 || !sink.hasAssociatedTerminal(removingTN);
     }
 
-    public static final int NOT_NODE_BIT               = 1;
-    public static final int JOIN_NODE_BIT              = 1 << 1;
-    public static final int REACTIVE_EXISTS_NODE_BIT   = 1 << 2;
-    public static final int PASSIVE_EXISTS_NODE_BIT    = 1 << 3;
+    public static final int NOT_NODE_BIT = 1;
+    public static final int JOIN_NODE_BIT = 1 << 1;
+    public static final int REACTIVE_EXISTS_NODE_BIT = 1 << 2;
+    public static final int PASSIVE_EXISTS_NODE_BIT = 1 << 3;
 
     public static final int CONDITIONAL_BRANCH_BIT = 1 << 4;
 
     public static int updateNodeTypesMask(NetworkNode node, int mask) {
         if (node != null) {
-            switch ( node.getType() ) {
+            switch (node.getType()) {
                 case NodeTypeEnums.JoinNode:
                     mask |= JOIN_NODE_BIT;
                     break;
                 case NodeTypeEnums.ExistsNode:
-                    if ( ( (ExistsNode) node ).getRightInput().isRightInputPassive() ) {
+                    if (((ExistsNode) node).getRightInput().isRightInputPassive()) {
                         mask |= PASSIVE_EXISTS_NODE_BIT;
                     } else {
                         mask |= REACTIVE_EXISTS_NODE_BIT;

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -102,7 +102,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
         Set<Integer> visited = new HashSet<>();
         if (tn.getPathNodes()[0].getAssociatedTerminalsSize() == 1) {
-            BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
 
             // rule added with no sharing, so populate it's lian
             wms.forEach(wm -> Add.insertLiaFacts(wm, tn.getPathNodes()[0], visited, false));
@@ -487,7 +487,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                                         TerminalNode tn,
                                         Set<SegmentMemoryPair> smemsToNotify) {
             // create protos
-            BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
 
             // update SegmentProtos with new EndNodes
             for (PathEndNode endNode : tn.getPathEndNodes()) {
@@ -1255,7 +1255,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                                     SegmentPrototype proto,
                                     PathEndNode endNode) {
         PathMemSpec spec = endNode.getPathMemSpec();
-        spec.update(BuildtimeSegmentUtilities.getPathAllLinkedMaskTest(endNode.getSegmentPrototypes(), endNode),
+        spec.update(BuildtimeSegmentUtilities.getPathAllLinkedMaskTest(endNode, endNode.getSegmentPrototypes()),
                 endNode.getSegmentPrototypes().length);
 
         // Now update the PathMemories array of SegmentMemories.

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -379,7 +379,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 }
             }
 
-            splitBitMasks(sm1, sm2, currentLinkedNodeMask);
+            sm1.splitBitMasks(sm2, currentLinkedNodeMask);
 
             Memory[] mem1 = new Memory[proto1.getMemories().length];
             Memory[] mem2 = new Memory[proto2.getMemories().length];
@@ -490,7 +490,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
 
             proto2.setMemories(proto2Mems);
-            splitBitMasks(proto1, proto2);
+            proto1.splitBitMasks(proto2);
         }
 
         private static void splitEagerProtos(SegmentPrototype proto1, boolean proto1WasEager, SegmentPrototype proto2, PathEndNode endNode) {
@@ -513,37 +513,6 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 } // else if ( proto1.requiresEager() && !proto2.requiresEager()) do nothing as proto1 already in the array
             }
         }
-
-        private static void splitBitMasks(SegmentMemory sm1, SegmentMemory sm2, long currentLinkedNodeMask) {
-            // @TODO Haven't made this work for more than 64 nodes, as per SegmentUtilities.nextNodePosMask (mdp)
-            int  splitPos              = sm1.getSegmentPrototype().getNodesInSegment().length; // +1 as zero based
-            long currentDirtyNodeMask  = sm1.getDirtyNodeMask();
-            long splitMask         =  ((1L << (splitPos)) - 1);
-
-            sm1.setDirtyNodeMask(currentDirtyNodeMask & splitMask);
-            sm1.setLinkedNodeMask(currentLinkedNodeMask & splitMask);
-
-            sm2.setLinkedNodeMask(currentLinkedNodeMask >> splitPos);
-            sm2.setDirtyNodeMask(currentDirtyNodeMask >> splitPos);
-        }
-
-        private static void splitBitMasks(SegmentPrototype sm1, SegmentPrototype sm2) {
-            // @TODO Haven't made this work for more than 64 nodes, as per SegmentUtilities.nextNodePosMask (mdp)
-            int  splitPos          = sm1.getNodesInSegment().length; // +1 as zero based
-            long splitMask         = ((1L << (splitPos)) - 1);
-
-            long currentLinkedNodeMask = sm1.getLinkedNodeMask();
-            long currentAllLinkedMaskTest = sm1.getAllLinkedMaskTest();
-
-            sm1.setLinkedNodeMask(currentLinkedNodeMask & splitMask);
-            sm1.setAllLinkedMaskTest(currentAllLinkedMaskTest & splitMask);
-
-            sm2.setLinkedNodeMask(currentLinkedNodeMask >> splitPos);
-            sm2.setAllLinkedMaskTest(currentAllLinkedMaskTest >> splitPos);
-
-            sm2.setSegmentPosMaskBit(sm1.getSegmentPosMaskBit() << 1);
-        }
-
 
         private static void addNewPaths(List<Pair> exclBranchRoots, TerminalNode tn,
                                         Collection<InternalWorkingMemory> wms, InternalRuleBase kBase,
@@ -837,7 +806,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
             setNodeTypes(proto1, nodes);
 
-            mergeBitMasks(proto1, proto2, origNodes);
+            proto1.mergeBitMasks(proto2, origNodes);
         }
 
 
@@ -913,20 +882,6 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             proto1.shallowUpdateSegmentMemory(sm1);
 
             mergeBitMasks(sm1, sm2, origNodes, currentLinkedNodeMask);
-        }
-
-        private static void mergeBitMasks(SegmentPrototype sm1, SegmentPrototype sm2, LeftTupleNode[] origNodes) {
-            // @TODO Haven't made this work for more than 64 nodes, as per SegmentUtilities.nextNodePosMask (mdp)
-            int shiftBits = origNodes.length;
-
-            long currentLinkedNodeMask = sm1.getLinkedNodeMask();
-            long currentAllLinkedMaskTest = sm1.getAllLinkedMaskTest();
-
-            long linkedBitsToAdd = sm2.getLinkedNodeMask() << shiftBits;
-            long allBitsToAdd = sm2.getAllLinkedMaskTest() << shiftBits;
-
-            sm1.setLinkedNodeMask(linkedBitsToAdd | currentLinkedNodeMask);
-            sm1.setAllLinkedMaskTest(allBitsToAdd | currentAllLinkedMaskTest);
         }
 
         private static void mergeBitMasks(SegmentMemory sm1, SegmentMemory sm2, LeftTupleNode[] origNodes, long currentLinkedNodeMask) {

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 
 import org.drools.base.common.NetworkNode;
 import org.drools.base.reteoo.NodeTypeEnums;
-import org.drools.core.WorkingMemory;
 import org.drools.core.common.BaseNode;
 import org.drools.core.common.DefaultEventHandle;
 import org.drools.core.common.InternalAgenda;
@@ -39,6 +38,7 @@ import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Memory;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.PropagationContextFactory;
+import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.SuperCacheFixer;
 import org.drools.core.common.TupleSets;
 import org.drools.core.impl.InternalRuleBase;
@@ -66,7 +66,6 @@ import org.drools.core.reteoo.RightTuple;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
 import org.drools.core.reteoo.RuntimeComponentFactory;
 import org.drools.core.reteoo.SegmentMemory;
-import org.drools.core.reteoo.SegmentMemory.MemoryPrototype;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 import org.drools.core.reteoo.SegmentNodeMemory;
 import org.drools.core.reteoo.TerminalNode;
@@ -147,7 +146,8 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         for (InternalWorkingMemory wm : wms) {
             PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(tn);
             if (pmem != null) {
-                List<LeftTupleNode> splits = exclBranchRoots.stream().map( pair -> pair.parent).filter(Objects::nonNull).collect(Collectors.toList());
+                List<LeftTupleNode> splits = exclBranchRoots.stream().map(pair -> pair.parent).filter(Objects::nonNull)
+                        .collect(Collectors.toList());
                 LazyPhreakBuilder.flushStagedTuples(wm, tn, pmem, splits);
             }
         }
@@ -168,20 +168,23 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         for (InternalWorkingMemory wm : wms) {
             PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(tn);
 
-            if (pmem!= null && pmem.isInitialized() && pmem.getRuleAgendaItem().isQueued()) {
+            if (pmem != null && pmem.isInitialized() && pmem.getRuleAgendaItem().isQueued()) {
                 // pmem can be null, if it was never initialized
                 pmem.getRuleAgendaItem().dequeue();
             }
         }
     }
 
-    public static void notifyImpactedSegments(SegmentMemory smem, InternalWorkingMemory wm, Set<SegmentMemoryPair> segmentsToNotify) {
+    public static void notifyImpactedSegments(SegmentMemory smem,
+                                              InternalWorkingMemory wm,
+                                              Set<SegmentMemoryPair> segmentsToNotify) {
         if (smem.getAllLinkedMaskTest() > 0) {
             segmentsToNotify.add(new SegmentMemoryPair(smem, wm));
         }
     }
 
     public static class SegmentMemoryPair {
+
         public SegmentMemory sm;
 
         public InternalWorkingMemory wm;
@@ -215,6 +218,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
     }
 
     public static class Pair {
+
         public final LeftTupleNode parent;
         public final LeftTupleNode child;
 
@@ -226,9 +230,9 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         @Override
         public String toString() {
             return "Pair{" +
-                   "parent=" + parent +
-                   ", child=" + child +
-                   '}';
+                    "parent=" + parent +
+                    ", child=" + child +
+                    '}';
         }
     }
 
@@ -242,14 +246,15 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 return;
             }
 
-            while (node.getLeftTupleSource()  != null) {
-                if (NodeTypeEnums.isBetaNodeWithSubnetwork(node) && ((BetaNode)node).getRightInput().getParent().getAssociatedTerminalsSize() > 1) {
-                    exclbranchRoots.add( new Pair((LeftTupleNode) ((BetaNode)node).getRightInput().getParent(), node));
+            while (node.getLeftTupleSource() != null) {
+                if (NodeTypeEnums.isBetaNodeWithSubnetwork(node) && ((BetaNode) node).getRightInput().getParent()
+                        .getAssociatedTerminalsSize() > 1) {
+                    exclbranchRoots.add(new Pair((LeftTupleNode) ((BetaNode) node).getRightInput().getParent(), node));
                 }
 
-                if (node.getLeftTupleSource().getAssociatedTerminalsSize()> 1) {
+                if (node.getLeftTupleSource().getAssociatedTerminalsSize() > 1) {
                     if (visited.add(node.getId())) {
-                        exclbranchRoots.add( new Pair(node.getLeftTupleSource(), node));
+                        exclbranchRoots.add(new Pair(node.getLeftTupleSource(), node));
                     }
                     return;
                 }
@@ -261,36 +266,46 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
     public static class Add {
 
-        public static void insertLiaFacts(LeftTupleNode startNode, InternalWorkingMemory wm, Set<Integer> visited, boolean allBranches) {
+        public static void insertLiaFacts(LeftTupleNode startNode,
+                                          InternalWorkingMemory wm,
+                                          Set<Integer> visited,
+                                          boolean allBranches) {
             // rule added with no sharing
             PropagationContextFactory pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
-            final PropagationContext  pctx        = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(), PropagationContext.Type.RULE_ADDITION, null, null, null);
-            LeftInputAdapterNode      lian        = (LeftInputAdapterNode) startNode;
-            if (allBranches && visited.add(lian.getId()) || lian.getAssociatedTerminalsSize() == 1 ) {
+            final PropagationContext pctx = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(),
+                    PropagationContext.Type.RULE_ADDITION, null, null, null);
+            LeftInputAdapterNode lian = (LeftInputAdapterNode) startNode;
+            if (allBranches && visited.add(lian.getId()) || lian.getAssociatedTerminalsSize() == 1) {
                 attachAdapterAndPropagate(wm, lian, pctx);
             }
         }
 
-        public static void attachAdapterAndPropagate(InternalWorkingMemory wm, LeftInputAdapterNode lian, PropagationContext pctx) {
-            List<DetachedTuple>  detachedTuples = new ArrayList<>();
-            LeftTupleSinkAdapter liaAdapter     = new LeftTupleSinkAdapter(lian, detachedTuples);
+        public static void attachAdapterAndPropagate(InternalWorkingMemory wm,
+                                                     LeftInputAdapterNode lian,
+                                                     PropagationContext pctx) {
+            List<DetachedTuple> detachedTuples = new ArrayList<>();
+            LeftTupleSinkAdapter liaAdapter = new LeftTupleSinkAdapter(lian, detachedTuples);
             lian.getObjectSource().updateSink(liaAdapter, pctx, wm);
             detachedTuples.forEach(d -> d.reattachToLeft());
         }
 
         public static void attachAdapterAndPropagate(InternalWorkingMemory wm, BetaNode bn) {
             PropagationContextFactory pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
-            final PropagationContext pctx = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(), PropagationContext.Type.RULE_ADDITION, null, null, null);
+            final PropagationContext pctx = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(),
+                    PropagationContext.Type.RULE_ADDITION, null, null, null);
             List<DetachedTuple> detachedTuples = new ArrayList<>();
             RightTupleSinkAdapter bnAdapter = new RightTupleSinkAdapter(bn, detachedTuples);
             bn.getRightInput().updateSink(bnAdapter, pctx, wm);
             detachedTuples.forEach(d -> d.reattachToRight());
         }
 
-        public static SegmentPrototype processSplit(LeftTupleNode splitNode, InternalRuleBase kbase, Collection<InternalWorkingMemory> wms, Set<SegmentMemoryPair> smemsToNotify) {
+        public static SegmentPrototype processSplit(LeftTupleNode splitNode,
+                                                    InternalRuleBase kbase,
+                                                    Collection<InternalWorkingMemory> wms,
+                                                    Set<SegmentMemoryPair> smemsToNotify) {
             LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(splitNode);
             SegmentPrototype proto1 = kbase.getSegmentPrototype(segmentRoot);
-            if ( proto1.getTipNode() != splitNode) {
+            if (proto1.getTipNode() != splitNode) {
                 // split does not already exist, add it.
                 return splitSegment(proto1, splitNode, kbase, wms, smemsToNotify);
             }
@@ -324,19 +339,22 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }));
         }
 
-        public static void insertFacts(TerminalNode tn, InternalWorkingMemory wm, Set<Integer> visited, boolean allBranches) {
-            for ( PathEndNode endNode : tn.getPathEndNodes() ) {
-                LeftTupleNode[]  nodes = endNode.getPathNodes();
+        public static void insertFacts(TerminalNode tn,
+                                       InternalWorkingMemory wm,
+                                       Set<Integer> visited,
+                                       boolean allBranches) {
+            for (PathEndNode endNode : tn.getPathEndNodes()) {
+                LeftTupleNode[] nodes = endNode.getPathNodes();
 
                 // Iterate each PathEnd of the TerminalNode. Stop at either the path branch start (to avoid processing nodes twice), or
                 // when the path is no longer uniquely associated with the terminal node.
-                for ( int i = nodes.length-1;
-                      i > 0 &&
-                      nodes[i].getPathIndex() >= endNode.getStartTupleSource().getPathIndex() &&
-                      (allBranches && visited.add(nodes[i].getId()) || nodes[i].getAssociatedTerminalsSize() == 1 );
-                      i-- ) {
+                for (int i = nodes.length - 1; i > 0 &&
+                                               nodes[i].getPathIndex() >= endNode.getStartTupleSource()
+                                                       .getPathIndex() &&
+                                               (allBranches && visited.add(nodes[i].getId()) || nodes[i]
+                                                       .getAssociatedTerminalsSize() == 1); i--) {
                     LeftTupleNode node = nodes[i];
-                    if  ( NodeTypeEnums.isBetaNode(node) ) {
+                    if (NodeTypeEnums.isBetaNode(node)) {
                         BetaNode bn = (BetaNode) node;
 
                         if (!bn.getRightInput().inputIsTupleToObjectNode()) {
@@ -347,8 +365,11 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
         }
 
-        public static void splitSegment(InternalWorkingMemory wm, SegmentMemory sm1, SegmentPrototype proto1, SegmentPrototype proto2,
-                                                 Set<SegmentMemoryPair> smemsToNotify) {
+        public static void splitSegment(InternalWorkingMemory wm,
+                                        SegmentMemory sm1,
+                                        SegmentPrototype proto1,
+                                        SegmentPrototype proto2,
+                                        Set<SegmentMemoryPair> smemsToNotify) {
             Memory[] origMemories = sm1.getNodeMemories();
 
             // create new segment, starting after split
@@ -356,7 +377,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
             // Move the children of sm1 to sm2
             if (sm1.getFirst() != null) {
-                for (SegmentMemory sm = sm1.getFirst(); sm != null; ) {
+                for (SegmentMemory sm = sm1.getFirst(); sm != null;) {
                     SegmentMemory next = sm.getNext();
                     sm1.remove(sm);
                     sm2.add(sm);
@@ -369,8 +390,8 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             sm2.mergePathMemories(sm1);
 
             // preserve values that get changed updateSegmentMemory, for split
-            long currentLinkedNodeMask  = sm1.getLinkedNodeMask();
-            proto1.shallowUpdateSegmentMemory(sm1);
+            long currentLinkedNodeMask = sm1.getLinkedNodeMask();
+            sm1.updateFromPrototype(proto1);
 
             if (NodeTypeEnums.isLeftInputAdapterNode(sm1.getTipNode())) {
                 if (!sm1.getStagedLeftTuples().isEmpty()) {
@@ -397,7 +418,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
 
             // break the references, between segments
-            mem1[mem1.length-1].setNext(null);
+            mem1[mem1.length - 1].setNext(null);
             mem2[0].setPrevious(null);
 
             sm1.setNodeMemories(mem1);
@@ -407,22 +428,26 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             notifyImpactedSegments(sm2, wm, smemsToNotify);
         }
 
-        public static SegmentPrototype splitSegment(SegmentPrototype proto1, LeftTupleNode splitNode, InternalRuleBase kbase, Collection<InternalWorkingMemory> wms, Set<SegmentMemoryPair> smemsToNotify) {
+        public static SegmentPrototype splitSegment(SegmentPrototype proto1,
+                                                    LeftTupleNode splitNode,
+                                                    InternalRuleBase kbase,
+                                                    Collection<InternalWorkingMemory> wms,
+                                                    Set<SegmentMemoryPair> smemsToNotify) {
             boolean proto1WasEager = proto1.requiresEager();
 
             // Create the new segment proto
             LeftTupleNode proto2RootNode = splitNode.getSinkPropagator().getFirstLeftTupleSink();
             SegmentPrototype proto2 = new SegmentPrototype(proto2RootNode, proto1.getTipNode());
             kbase.registerSegmentPrototype(proto2RootNode, proto2);
-            proto2.setPos(proto1.getPos()+1);
+            proto2.setPos(proto1.getPos() + 1);
 
             // Split the nodes across proto1 and proto2
-            splitProtos(proto1, proto2, splitNode);
+            proto1.splitProtos(proto2, splitNode);
 
             // now split any existing Segments, using the updated Protos
             for (InternalWorkingMemory wm : wms) {
                 Memory mem = wm.getNodeMemories().peekNodeMemory(proto1.getRootNode());
-                if ( mem != null && mem.getSegmentMemory() != null) {
+                if (mem != null && mem.getSegmentMemory() != null) {
                     splitSegment(wm, mem.getSegmentMemory(), proto1, proto2, smemsToNotify);
                 }
             }
@@ -431,20 +456,20 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             PathEndNode[] endNodes = proto1.getPathEndNodes();
             for (PathEndNode endNode : endNodes) {
                 // process eager changes
-                splitEagerProtos(proto1, proto1WasEager, proto2, endNode);
+                proto1.splitEagerProtos(proto1WasEager, proto2, endNode);
 
                 proto2.setPathEndNodes(proto1.getPathEndNodes());
 
                 // insert the new proto into the segment list
                 SegmentPrototype[] oldList = endNode.getSegmentPrototypes();
                 SegmentPrototype[] newList = new SegmentPrototype[oldList.length + 1];
-                System.arraycopy(oldList, 0, newList, 0, proto1.getPos()+1);
+                System.arraycopy(oldList, 0, newList, 0, proto1.getPos() + 1);
                 newList[proto2.getPos()] = proto2;
 
                 // If the proto isn't end, copy over the remaining protos and adjust their pos and bit pos
-                if ( proto2.getPos()+1 != newList.length) {
-                    for (int i = proto2.getPos()+1; i <newList.length; i++) {
-                        newList[i] = oldList[i-1];
+                if (proto2.getPos() + 1 != newList.length) {
+                    for (int i = proto2.getPos() + 1; i < newList.length; i++) {
+                        newList[i] = oldList[i - 1];
                         newList[i].setPos(i);
                         newList[i].setSegmentPosMaskBit(1 << i);
                     }
@@ -457,77 +482,22 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             return proto2;
         }
 
-        private static void splitProtos(SegmentPrototype proto1, SegmentPrototype proto2, LeftTupleNode splitNode) {
-            proto1.setTipNode(splitNode);
-
-            LeftTupleNode[] nodes = proto1.getNodesInSegment();
-
-            MemoryPrototype[] mems = proto1.getMemories();
-
-            int arraySplit = splitNode.getPathIndex() - proto1.getRootNode().getPathIndex() + 1;
-            LeftTupleNode[] proto1Nodes = new LeftTupleNode[arraySplit];
-            LeftTupleNode[] proto2Nodes = new LeftTupleNode[nodes.length - arraySplit];
-            System.arraycopy(nodes, 0, proto1Nodes, 0, proto1Nodes.length);
-            System.arraycopy(nodes, arraySplit, proto2Nodes, 0, proto2Nodes.length);
-            proto1.setNodesInSegment(proto1Nodes);
-            proto2.setNodesInSegment(proto2Nodes);
-
-            setNodeTypes(proto1, proto1Nodes);
-            setNodeTypes(proto2, proto2Nodes);
-
-            // Split the memory protos across proto1 and proto2
-            MemoryPrototype[] proto1Mems = new MemoryPrototype[proto1Nodes.length];
-            MemoryPrototype[] proto2Mems = new MemoryPrototype[proto2Nodes.length];
-            System.arraycopy(mems, 0, proto1Mems, 0, proto1Mems.length);
-            proto1.setMemories(proto1Mems);
-
-            // proto2Mems needs updating, no point in arraycopy, so just use standard for loop to copy
-            int bitPos = 1;
-            for (int i = 0; i < proto2Mems.length; i++ ) {
-                proto2Mems[i] = mems[i+arraySplit];
-                proto2Mems[i].setNodePosMaskBit(bitPos);
-                bitPos = bitPos << 1;
-            }
-
-            proto2.setMemories(proto2Mems);
-            proto1.splitBitMasks(proto2);
-        }
-
-        private static void splitEagerProtos(SegmentPrototype proto1, boolean proto1WasEager, SegmentPrototype proto2, PathEndNode endNode) {
-            if (proto1WasEager) { // if it wasn't eager before, nothing can be eager after
-                SegmentPrototype[] eager = endNode.getEagerSegmentPrototypes();
-                if (proto1.requiresEager() && proto2.requiresEager()) {
-                    // keep proto1 and add proto2
-                    SegmentPrototype[] newEager = new SegmentPrototype[eager.length+1];
-                    System.arraycopy(eager, 0, newEager, 0, eager.length);
-                    newEager[newEager.length-1] = proto2; // I don't think order matters, so just add to the end
-                    endNode.setEagerSegmentPrototypes(newEager);
-                } else if (proto2.requiresEager()) {
-                    // proto2 is no longer eager, find proto1 and swap proto1 with proto2
-                    for ( int i = 0; i < eager.length; i++){
-                        if (eager[i] == proto1) {
-                            eager[i] = proto2;
-                            break;
-                        }
-                    }
-                } // else if ( proto1.requiresEager() && !proto2.requiresEager()) do nothing as proto1 already in the array
-            }
-        }
-
-        private static void addNewPaths(List<Pair> exclBranchRoots, TerminalNode tn,
-                                        Collection<InternalWorkingMemory> wms, InternalRuleBase kBase,
+        private static void addNewPaths(List<Pair> exclBranchRoots,
+                                        TerminalNode tn,
+                                        Collection<InternalWorkingMemory> wms,
+                                        InternalRuleBase kBase,
                                         Set<SegmentMemoryPair> smemsToNotify) {
             // create protos
             BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
 
             // update SegmentProtos with new EndNodes
-            for ( PathEndNode endNode : tn.getPathEndNodes() ) {
+            for (PathEndNode endNode : tn.getPathEndNodes()) {
                 BuildtimeSegmentUtilities.updateSegmentEndNodes(endNode);
             }
 
             // Process the root nodes of each new branch. Not it's important to do this in order of inner subnetwork first.
             for (InternalWorkingMemory wm : wms) {
-                for (PathEndNode endNode : tn.getPathEndNodes() ) {
+                for (PathEndNode endNode : tn.getPathEndNodes()) {
                     if (endNode.getAssociatedTerminalsSize() > 1) {
                         // can only happen on TupleToObjectNodes, and we need to notify, incase they are already linked in
                         Memory mem = wm.getNodeMemories().peekNodeMemory(endNode);
@@ -542,7 +512,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
                     PathMemory pmem = null; // lazy create this on demand, only if there are existing segments
 
-                    for (SegmentPrototype sproto : endNode.getSegmentPrototypes() ) {
+                    for (SegmentPrototype sproto : endNode.getSegmentPrototypes()) {
                         if (!isInsideSubnetwork(endNode, sproto)) {
                             continue;
                         }
@@ -560,7 +530,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                         } else if (pmem != null) {
                             // segment with just the PathEndNode, so create
                             SegmentMemory sm = sproto.shallowNewSegmentMemory();
-                            sm.setNodeMemories( new Memory[]{pmem});
+                            sm.setNodeMemories(new Memory[]{pmem});
                             pmem.setSegmentMemory(sm);
                             RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, sm);
                             notifyImpactedSegments(sm, wm, smemsToNotify);
@@ -572,7 +542,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 // If the parent is a query node, then it's internal data structure needs changing
                 // all right input data must be propagated
                 Set<Integer> visited = new HashSet<>();
-                for (int i = exclBranchRoots.size()-1; i >= 0; i--)  { // last is the most inner
+                for (int i = exclBranchRoots.size() - 1; i >= 0; i--) { // last is the most inner
                     LeftTupleNode child = exclBranchRoots.get(i).child;
                     LeftTupleNode parent = exclBranchRoots.get(i).parent;
 
@@ -594,7 +564,6 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                         correctMemoryOnSplitsChanged(parent, wm);
                     }
 
-
                 }
             }
         }
@@ -605,15 +574,19 @@ public class EagerPhreakBuilder implements PhreakBuilder {
     }
 
     public static class Remove {
-        private static void removeExistingPaths(List<Pair> exclBranchRoots, TerminalNode tn, Collection<InternalWorkingMemory> wms, InternalRuleBase kbase) {
+
+        private static void removeExistingPaths(List<Pair> exclBranchRoots,
+                                                TerminalNode tn,
+                                                Collection<InternalWorkingMemory> wms,
+                                                InternalRuleBase kbase) {
             // update existing SegmentProtos (before removing path branch root) to remove EndNodes
             // for nodes after, just remove them from the cache
-            for ( PathEndNode endNode : tn.getPathEndNodes() ) {
+            for (PathEndNode endNode : tn.getPathEndNodes()) {
                 if (endNode.getAssociatedTerminalsSize() > 1) {
                     // do nothing, this whole subnetwork is still shared
                     continue;
                 }
-                for ( int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
+                for (int i = 0; i < endNode.getSegmentPrototypes().length; i++) {
                     SegmentPrototype smproto = endNode.getSegmentPrototypes()[i];
                     if (smproto.getRootNode().getAssociatedTerminalsSize() > 1) {
                         // update the segments before the branch being removed.
@@ -702,13 +675,17 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
         }
 
-        private static void processMerges(LeftTupleNode splitNode, TerminalNode tn, InternalRuleBase kBase, Collection<InternalWorkingMemory> wms, Set<Integer> visited) {
+        private static void processMerges(LeftTupleNode splitNode,
+                                          TerminalNode tn,
+                                          InternalRuleBase kBase,
+                                          Collection<InternalWorkingMemory> wms,
+                                          Set<Integer> visited) {
             // it's possible for a rule to have multiple exclBranches, pointing to the same parent. So need to ensure it's processed once.
-            if ( !visited.add(splitNode.getId())) {
+            if (!visited.add(splitNode.getId())) {
                 return;
             }
 
-            if ( !BuildtimeSegmentUtilities.isTipNode(splitNode, tn)) {
+            if (!BuildtimeSegmentUtilities.isTipNode(splitNode, tn)) {
                 // with the tn ignored, it's no longer a semgnet tip so it's segment is ready to merge
                 LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(splitNode, tn);
 
@@ -724,7 +701,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                         break;
                     }
                 }
-                if ( ltn == null) {
+                if (ltn == null) {
                     // the excl branch is being removed, but there is no merge. For example see AddRemoveRulesTest.testInsertRemoveFireWith2Nots
                     //return;
                     throw new RuntimeException();
@@ -735,15 +712,18 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
         }
 
-        public static void mergeSegments(SegmentPrototype proto1, SegmentPrototype proto2, InternalRuleBase kbase, Collection<InternalWorkingMemory> wms) {
+        public static void mergeSegments(SegmentPrototype proto1,
+                                         SegmentPrototype proto2,
+                                         InternalRuleBase kbase,
+                                         Collection<InternalWorkingMemory> wms) {
             boolean proto2WasEager = proto2.requiresEager();
 
             LeftTupleNode[] origNodes = proto1.getNodesInSegment();
 
-            mergeProtos(proto1, proto2, origNodes);
+            proto1.mergeProtos(proto2, origNodes);
 
             // Now merge any existing Segments, using the updated Protos
-            for (InternalWorkingMemory wm : wms) {
+            for (ReteEvaluator wm : wms) {
                 Memory mem1 = wm.getNodeMemories().peekNodeMemory(proto1.getRootNode());
                 Memory mem2 = wm.getNodeMemories().peekNodeMemory(proto2.getRootNode());
                 mergeSegment(proto1, mem1, proto2, origNodes, mem2, wm);
@@ -753,7 +733,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             PathEndNode[] endNodes = proto1.getPathEndNodes();
             for (PathEndNode endNode : endNodes) {
                 // process eager changes
-                mergeEagerProtos(proto1, proto2, proto2WasEager, endNode);
+                proto1.mergeEagerProtos(proto2, proto2WasEager, endNode);
                 proto1.setPathEndNodes(proto2.getPathEndNodes());
 
                 // insert the new proto into the segment list
@@ -761,8 +741,8 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 copyWithRemoval(endNode.getSegmentPrototypes(), newList, proto2);
 
                 // If the proto isn't end, copy over the remaining protos and adjust their pos and bit pos
-                if ( proto1.getPos()+1 != newList.length) {
-                    for (int i = proto1.getPos()+1; i <newList.length; i++) {
+                if (proto1.getPos() + 1 != newList.length) {
+                    for (int i = proto1.getPos() + 1; i < newList.length; i++) {
                         newList[i].setPos(i);
                         newList[i].setSegmentPosMaskBit(1 << i);
                     }
@@ -775,54 +755,24 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             kbase.invalidateSegmentPrototype(proto2.getRootNode());
         }
 
-
-        private static void mergeProtos(SegmentPrototype proto1, SegmentPrototype proto2, LeftTupleNode[] origNodes) {
-            proto1.setTipNode(proto2.getTipNode());
-            LeftTupleNode[] nodes = new LeftTupleNode[proto1.getNodesInSegment().length + proto2.getNodesInSegment().length];
-
-            System.arraycopy(proto1.getNodesInSegment(), 0, nodes,
-                             0, proto1.getNodesInSegment().length);
-
-            System.arraycopy(proto2.getNodesInSegment(), 0, nodes,
-                             proto1.getNodesInSegment().length, proto2.getNodesInSegment().length);
-
-            proto1.setNodesInSegment(nodes);
-
-            MemoryPrototype[] protoMems = new MemoryPrototype[proto1.getMemories().length + proto2.getMemories().length];
-
-            System.arraycopy(proto1.getMemories(), 0, protoMems,
-                             0, proto1.getMemories().length);
-
-            System.arraycopy(proto2.getMemories(), 0, protoMems,
-                             proto1.getMemories().length, proto2.getMemories().length);
-
-            proto1.setNodesInSegment(nodes);
-            proto1.setMemories(protoMems);
-
-            int bitPos = 1;
-            for (MemoryPrototype protoMem : protoMems) {
-                protoMem.setNodePosMaskBit(bitPos);
-                bitPos = bitPos << 1;
-            }
-            setNodeTypes(proto1, nodes);
-
-            proto1.mergeBitMasks(proto2, origNodes);
-        }
-
-
-        private static void mergeSegment(SegmentPrototype proto1, Memory m1, SegmentPrototype proto2, LeftTupleNode[] origNodes, Memory m2, InternalWorkingMemory wm) {
+        private static void mergeSegment(SegmentPrototype proto1,
+                                         Memory m1,
+                                         SegmentPrototype proto2,
+                                         LeftTupleNode[] origNodes,
+                                         Memory m2,
+                                         ReteEvaluator wm) {
             SegmentMemory sm1 = (m1 != null) ? m1.getSegmentMemory() : null;
             SegmentMemory sm2 = (m2 != null) ? m2.getSegmentMemory() : null;
-            if ( sm1 == null && sm2 == null) {
+            if (sm1 == null && sm2 == null) {
                 return;
             }
 
-            if ( sm1 == null) {
+            if (sm1 == null) {
                 // To be able to merge sm1 must exist
                 sm1 = RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, proto1.getRootNode());
             }
 
-            if ( sm2 == null) {
+            if (sm2 == null) {
                 // To be able to merge sm2 must exist
                 sm2 = RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, proto2.getRootNode());
             }
@@ -833,7 +783,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
             Memory[] mems = new Memory[mems1.length + mems2.length];
             System.arraycopy(mems1, 0, mems,
-                             0, mems1.length);
+                    0, mems1.length);
 
             // As the segmentMemory needs updating, no point in a separate arraycopy
             for (int i = 0; i < mems2.length; i++) {
@@ -842,8 +792,8 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 mem.setSegmentMemory(sm1);
 
                 // make sure all the mems still reference each other
-                mem.setPrevious(mems[mems1.length + i -1]);
-                mems[mems1.length + i -1].setNext(mem);
+                mem.setPrevious(mems[mems1.length + i - 1]);
+                mems[mems1.length + i - 1].setNext(mem);
 
                 if (mem instanceof SegmentNodeMemory) {
                     ((SegmentNodeMemory) mem).setNodePosMaskBit(proto2.getMemories()[i].getNodePosMaskBit());
@@ -852,72 +802,12 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
             sm1.setNodeMemories(mems);
 
-            mergeSegment(sm1, sm2, proto1, origNodes);
+            sm1.mergeSegment(sm2, proto1, origNodes);
         }
 
-        private static void mergeSegment(SegmentMemory sm1, SegmentMemory sm2, SegmentPrototype proto1, LeftTupleNode[] origNodes) {
-            if (NodeTypeEnums.isLeftInputAdapterNode(sm1.getTipNode()) && !sm2.getStagedLeftTuples().isEmpty()) {
-                // If a rule has not been linked, lia can still have child segments with staged tuples that did not get flushed
-                // these are safe to just move to the parent SegmentMemory
-                sm1.getStagedLeftTuples().addAll(sm2.getStagedLeftTuples());
-            }
-
-            // sm1 may not be linked yet to sm2 because sm2 has been just created
-            if (sm1.contains(sm2)) {
-                sm1.remove(sm2);
-            }
-
-            // add all child sms
-            if (sm2.getFirst() != null) {
-                for (SegmentMemory sm = sm2.getFirst(); sm != null; ) {
-                    SegmentMemory next = sm.getNext();
-                    sm2.remove(sm);
-                    sm1.add(sm);
-                    sm = next;
-                }
-            }
-
-            // preserve values that get changed updateSegmentMemory, for merge
-            long currentLinkedNodeMask = sm1.getLinkedNodeMask();
-            proto1.shallowUpdateSegmentMemory(sm1);
-
-            mergeBitMasks(sm1, sm2, origNodes, currentLinkedNodeMask);
-        }
-
-        private static void mergeBitMasks(SegmentMemory sm1, SegmentMemory sm2, LeftTupleNode[] origNodes, long currentLinkedNodeMask) {
-            // @TODO Haven't made this work for more than 64 nodes, as per SegmentUtilities.nextNodePosMask (mdp)
-            int shiftBits = origNodes.length;
-
-            long linkedBitsToAdd = sm2.getLinkedNodeMask() << shiftBits;
-            long dirtyBitsToAdd = sm2.getDirtyNodeMask() << shiftBits;
-            sm1.setLinkedNodeMask(linkedBitsToAdd | currentLinkedNodeMask);
-            sm1.setDirtyNodeMask(dirtyBitsToAdd | sm1.getDirtyNodeMask());
-        }
-
-        private static void mergeEagerProtos(SegmentPrototype proto1, SegmentPrototype proto2, boolean proto2WasEager, PathEndNode endNode) {
-            if (!proto1.requiresEager() && !proto2.requiresEager()) {
-                return;
-            }
-
-            SegmentPrototype[] eager = endNode.getEagerSegmentPrototypes();
-            if (proto1.requiresEager() && proto2.requiresEager()) {
-                // keep proto1 and remove proto2
-                SegmentPrototype[] newEager = new SegmentPrototype[eager.length-1];
-                copyWithRemoval(eager, newEager, proto2);
-                endNode.setEagerSegmentPrototypes(newEager);
-            }  else if (proto1.requiresEager() && proto2WasEager) {
-                // find proto2 and swap proto2 with proto1
-                for ( int i = 0; i < eager.length; i++){
-                    if (eager[i] == proto2) {
-                        eager[i] = proto1;
-                        break;
-                    }
-                }
-            } // else if ( proto1.requiresEager() && !proto2.requiresEager()) do nothing as proto1 already in the array
-        }
 
         private static void deleteRightInputData(LeftTupleNode node, Memory m, InternalWorkingMemory wm) {
-            BetaNode       bn = (BetaNode) node;
+            BetaNode bn = (BetaNode) node;
             BetaMemory bm;
             if (bn.getType() == NodeTypeEnums.AccumulateNode) {
                 bm = ((AccumulateMemory) m).getBetaMemory();
@@ -925,9 +815,9 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 bm = (BetaMemory) m;
             }
 
-            TupleMemory  rtm = bm.getRightTupleMemory();
-            FastIterator<TupleImpl> it  = rtm.fullFastIterator();
-            for (TupleImpl rightTuple = BetaNode.getFirstTuple(rtm, it); rightTuple != null; ) {
+            TupleMemory rtm = bm.getRightTupleMemory();
+            FastIterator<TupleImpl> it = rtm.fullFastIterator();
+            for (TupleImpl rightTuple = BetaNode.getFirstTuple(rtm, it); rightTuple != null;) {
                 TupleImpl next = it.next(rightTuple);
                 rtm.remove(rightTuple);
                 rightTuple.unlinkFromRightParent();
@@ -963,7 +853,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         }
 
         private static void unlinkRightTuples(TupleImpl rightTuple) {
-            for (TupleImpl rt = rightTuple; rt != null; ) {
+            for (TupleImpl rt = rightTuple; rt != null;) {
                 TupleImpl next = rt.getStagedNext();
                 // this RightTuple could have been already unlinked by the former cycle
                 if (rt.getFactHandle() != null) {
@@ -973,7 +863,9 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
         }
 
-        private static void copyWithRemoval(SegmentPrototype[] orinalProtos, SegmentPrototype[] newProtos, SegmentPrototype protoToRemove) {
+        private static void copyWithRemoval(SegmentPrototype[] orinalProtos,
+                                            SegmentPrototype[] newProtos,
+                                            SegmentPrototype protoToRemove) {
             for (int i = 0, j = 0; i < orinalProtos.length; i++) {
                 if (orinalProtos[i] == protoToRemove) {
                     // j is not increased here.
@@ -987,7 +879,8 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
     private static void correctMemoryOnSplitsChanged(LeftTupleNode splitStart, InternalWorkingMemory wm) {
         if (splitStart.getType() == NodeTypeEnums.QueryElementNode) {
-            QueryElementNode.QueryElementNodeMemory mem = (QueryElementNode.QueryElementNodeMemory) wm.getNodeMemories().peekNodeMemory(splitStart);
+            QueryElementNode.QueryElementNodeMemory mem = (QueryElementNode.QueryElementNodeMemory) wm.getNodeMemories()
+                    .peekNodeMemory(splitStart);
             if (mem != null) {
                 mem.correctMemoryOnSinksChanged(null);
             }
@@ -999,7 +892,10 @@ public class EagerPhreakBuilder implements PhreakBuilder {
      * It traverses to the LiaNode's ObjectTypeNode. It then iterates the LeftTuple chains, where an existing LeftTuple is staged
      * as delete. Or a new LeftTuple is created and staged as an insert.
      */
-    private static void processLeftTuples(LeftTupleNode node, boolean insert, TerminalNode tn, Collection<InternalWorkingMemory> wms) {
+    private static void processLeftTuples(LeftTupleNode node,
+                                          boolean insert,
+                                          TerminalNode tn,
+                                          Collection<InternalWorkingMemory> wms) {
         for (InternalWorkingMemory wm : wms) {
             // *** if you make a fix here, it most likely needs to be in PhreakActivationIteratorToo ***
 
@@ -1043,7 +939,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                         bm = (BetaMemory) wm.getNodeMemories().peekNodeMemory(node);
                         if (bm != null) {
                             FastIterator it = bm.getRightTupleMemory().fullFastIterator(); // done off the RightTupleMemory, as exists only have unblocked tuples on the left side
-                            RightTuple   rt = (RightTuple) BetaNode.getFirstTuple(bm.getRightTupleMemory(), it);
+                            RightTuple rt = (RightTuple) BetaNode.getFirstTuple(bm.getRightTupleMemory(), it);
                             for (; rt != null; rt = (RightTuple) it.next(rt)) {
                                 for (LeftTuple lt = rt.getBlocked(); lt != null; lt = lt.getBlockedNext()) {
                                     visitChild(wm, insert, tn, it, lt);
@@ -1063,8 +959,8 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                     FromMemory fm = (FromMemory) wm.getNodeMemories().peekNodeMemory(node);
                     if (fm != null) {
                         TupleMemory ltm = fm.getBetaMemory().getLeftTupleMemory();
-                        FastIterator it = ltm.fullFastIterator();
-                        for (TupleImpl lt = (TupleImpl) ltm.getFirst(null); lt != null; lt = (TupleImpl) it.next(lt)) {
+                        FastIterator<TupleImpl> it = ltm.fullFastIterator();
+                        for (TupleImpl lt = ltm.getFirst(null); lt != null; lt = it.next(lt)) {
                             visitChild(lt, insert, wm, tn);
                         }
                     }
@@ -1079,17 +975,20 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void processLeftTuplesOnLian( InternalWorkingMemory wm, boolean insert, TerminalNode tn, LeftInputAdapterNode lian ) {
+    private static void processLeftTuplesOnLian(InternalWorkingMemory wm,
+                                                boolean insert,
+                                                TerminalNode tn,
+                                                LeftInputAdapterNode lian) {
         BaseNode os = lian.getObjectSource();
         while (os.getType() != NodeTypeEnums.ObjectTypeNode) {
             os = os.getParent();
         }
 
-        ObjectTypeNode otn  = (ObjectTypeNode) os;
+        ObjectTypeNode otn = (ObjectTypeNode) os;
         Iterator<InternalFactHandle> it = otn.getFactHandlesIterator(wm);
         while (it.hasNext()) {
             InternalFactHandle fh = it.next();
-            fh.forEachLeftTuple( lt -> {
+            fh.forEachLeftTuple(lt -> {
                 TupleImpl nextLt = lt.getHandleNext();
 
                 // Each lt is for a different lian, skip any lian not associated with the rule. Need to use lt parent (souce) not child to check the lian.
@@ -1097,9 +996,9 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                     visitChild(lt, insert, wm, tn);
 
                     if (lt.getHandlePrevious() != null) {
-                        lt.getHandlePrevious().setHandleNext( nextLt );
+                        lt.getHandlePrevious().setHandleNext(nextLt);
                         if (nextLt != null) {
-                            nextLt.setHandlePrevious( lt.getHandlePrevious() );
+                            nextLt.setHandlePrevious(lt.getHandlePrevious());
                         }
                     }
                 }
@@ -1107,7 +1006,11 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void visitChild(InternalWorkingMemory wm, boolean insert, TerminalNode tn, FastIterator<TupleImpl> it, TupleImpl lt) {
+    private static void visitChild(InternalWorkingMemory wm,
+                                   boolean insert,
+                                   TerminalNode tn,
+                                   FastIterator<TupleImpl> it,
+                                   TupleImpl lt) {
         for (; lt != null; lt = it.next(lt)) {
             TupleImpl childLt = lt.getFirstChild();
             while (childLt != null) {
@@ -1123,25 +1026,24 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
         LeftTupleSinkNode sink = (LeftTupleSinkNode) lt.getSink();
 
-        for ( ; sink != null; sink = sink.getNextLeftTupleSinkNode() ) {
-            if ( lt != null ) {
+        for (; sink != null; sink = sink.getNextLeftTupleSinkNode()) {
+            if (lt != null) {
                 if (isAssociatedWith(lt.getSink(), tn)) {
 
                     if (lt.getSink().getAssociatedTerminalsSize() > 1) {
                         if (lt.getFirstChild() != null) {
-                            for ( TupleImpl child = lt.getFirstChild(); child != null; child =  child.getHandleNext() ) {
+                            for (TupleImpl child = lt.getFirstChild(); child != null; child = child.getHandleNext()) {
                                 visitChild(child, insert, wm, tn);
                             }
                         } else if (lt.getSink().getType() == NodeTypeEnums.TupleToObjectNode) {
                             insertPeerRightTuple(lt, wm, tn, insert);
                         }
                     } else if (!insert) {
-                        iterateLeftTuple( lt, wm );
+                        iterateLeftTuple(lt, wm);
                         TupleImpl lt2 = null;
-                        for ( TupleImpl peerLt = lt.getPeer();
-                              peerLt != null && isAssociatedWith(peerLt.getSink(), tn) && peerLt.getSink().getAssociatedTerminalsSize() == 1;
-                              peerLt = peerLt.getPeer() ) {
-                            iterateLeftTuple( peerLt, wm );
+                        for (TupleImpl peerLt = lt.getPeer(); peerLt != null && isAssociatedWith(peerLt.getSink(),
+                                tn) && peerLt.getSink().getAssociatedTerminalsSize() == 1; peerLt = peerLt.getPeer()) {
+                            iterateLeftTuple(peerLt, wm);
                             lt2 = peerLt;
                         }
 
@@ -1160,20 +1062,20 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void insertPeerRightTuple(TupleImpl lt, InternalWorkingMemory wm, TerminalNode tn, boolean insert ) {
+    private static void insertPeerRightTuple(TupleImpl lt, InternalWorkingMemory wm, TerminalNode tn, boolean insert) {
         // There's a shared RightInputAdapterNode, so check if one of its sinks is associated only to the new rule
-        TupleImpl         prevLt = null;
-        TupleToObjectNode tton   = (TupleToObjectNode) lt.getSink();
+        TupleImpl prevLt = null;
+        TupleToObjectNode tton = (TupleToObjectNode) lt.getSink();
 
         for (ObjectSink sink : tton.getObjectSinkPropagator().getSinks()) {
             if (lt != null) {
                 if (prevLt != null && !insert && isAssociatedWith(sink, tn) && sink.getAssociatedTerminalsSize() == 1) {
-                    prevLt.setPeer( null );
+                    prevLt.setPeer(null);
                 }
                 prevLt = lt;
                 lt = lt.getPeer();
             } else if (insert) {
-                BetaNode betaNode = ((RightInputAdapterNode)sink).getBetaNode();
+                BetaNode betaNode = ((RightInputAdapterNode) sink).getBetaNode();
                 BetaMemory bm = (BetaMemory) wm.getNodeMemories().peekNodeMemory(betaNode);
                 if (bm != null) {
                     prevLt = TupleFactory.createPeer(tton, prevLt);
@@ -1187,34 +1089,41 @@ public class EagerPhreakBuilder implements PhreakBuilder {
     /**
      * Create all missing peers
      */
-    private static TupleImpl insertPeerLeftTuple(TupleImpl lt, LeftTupleSinkNode node, InternalWorkingMemory wm, boolean insert) {
+    private static TupleImpl insertPeerLeftTuple(TupleImpl lt,
+                                                 LeftTupleSinkNode node,
+                                                 InternalWorkingMemory wm,
+                                                 boolean insert) {
         TupleImpl peer = TupleFactory.createPeer(node, lt);
 
-        if ( node.getLeftTupleSource().getType() == NodeTypeEnums.AlphaTerminalNode ) {
+        if (node.getLeftTupleSource().getType() == NodeTypeEnums.AlphaTerminalNode) {
             if (insert) {
-                TerminalNode rtn = ( TerminalNode ) node;
+                TerminalNode rtn = (TerminalNode) node;
                 InternalAgenda agenda = wm.getAgenda();
-                RuleAgendaItem agendaItem = AlphaTerminalNode.getRuleAgendaItem( wm, agenda, rtn, insert );
-                PhreakRuleTerminalNode.doLeftTupleInsert( rtn, agendaItem.getRuleExecutor(), agenda, agendaItem, (RuleTerminalNodeLeftTuple) peer );
+                RuleAgendaItem agendaItem = AlphaTerminalNode.getRuleAgendaItem(wm, agenda, rtn, insert);
+                PhreakRuleTerminalNode.doLeftTupleInsert(rtn, agendaItem.getRuleExecutor(), agenda, agendaItem,
+                        (RuleTerminalNodeLeftTuple) peer);
             }
             return peer;
         }
 
         LeftInputAdapterNode.LiaNodeMemory liaMem = null;
-        if ( NodeTypeEnums.isLeftInputAdapterNode(node.getLeftTupleSource())) {
-            liaMem = (LeftInputAdapterNode.LiaNodeMemory) wm.getNodeMemories().peekNodeMemory(node.getLeftTupleSource());
+        if (NodeTypeEnums.isLeftInputAdapterNode(node.getLeftTupleSource())) {
+            liaMem = (LeftInputAdapterNode.LiaNodeMemory) wm.getNodeMemories().peekNodeMemory(node
+                    .getLeftTupleSource());
         }
 
         Memory memory = wm.getNodeMemories().peekNodeMemory(node);
         if (memory == null || memory.getSegmentMemory() == null) {
-            throw new IllegalStateException("Defensive Programming: this should not be possilbe, as the addRule code should init child segments if they are needed ");
+            throw new IllegalStateException(
+                    "Defensive Programming: this should not be possilbe, as the addRule code should init child segments if they are needed ");
         }
 
-        if ( liaMem == null) {
+        if (liaMem == null) {
             memory.getSegmentMemory().getStagedLeftTuples().addInsert(peer);
         } else {
             // If parent is Lian, then this must be called, so that any linking or unlinking can be done.
-            LeftInputAdapterNode.doInsertSegmentMemoryWithFlush(wm, true, liaMem, memory.getSegmentMemory(), peer, node.getLeftTupleSource().isStreamMode());
+            LeftInputAdapterNode.doInsertSegmentMemoryWithFlush(wm, true, liaMem, memory.getSegmentMemory(), peer, node
+                    .getLeftTupleSource().isStreamMode());
         }
 
         return peer;
@@ -1222,22 +1131,23 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
     private static void iterateLeftTuple(TupleImpl lt, InternalWorkingMemory wm) {
         if (NodeTypeEnums.isTerminalNode(lt.getSink())) {
-            PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory( lt.getSink());
+            PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(lt.getSink());
             if (pmem != null) {
-                PhreakRuleTerminalNode.doLeftDelete( pmem.getActualActivationsManager( wm ), pmem.getRuleAgendaItem().getRuleExecutor(), (RuleTerminalNodeLeftTuple) lt );
+                PhreakRuleTerminalNode.doLeftDelete(pmem.getActualActivationsManager(wm), pmem.getRuleAgendaItem()
+                        .getRuleExecutor(), (RuleTerminalNodeLeftTuple) lt);
             }
         } else {
             if (lt.getContextObject() instanceof AccumulateContext) {
-                TupleImpl resultLt = (TupleImpl) (( AccumulateContext ) lt.getContextObject()).getResultLeftTuple();
+                TupleImpl resultLt = (TupleImpl) ((AccumulateContext) lt.getContextObject()).getResultLeftTuple();
                 if (resultLt != null) {
-                    iterateLeftTuple( resultLt, wm );
+                    iterateLeftTuple(resultLt, wm);
                 }
             }
             for (TupleImpl child = lt.getFirstChild(); child != null; child = child.getHandleNext()) {
                 for (TupleImpl peer = child; peer != null; peer = peer.getPeer()) {
                     if (peer.getPeer() == null) {
                         // it's unnnecessary to visit the unshared networks, so only iterate the last peer
-                        iterateLeftTuple( peer, wm );
+                        iterateLeftTuple(peer, wm);
                     }
                 }
             }
@@ -1253,13 +1163,13 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         // And the previous peer will need to point to the peer after removingLt, or removingLt2 if it exists.
 
         boolean isFirstLt = prevLt == null; // is this the first LT in a peer chain chain
-        TupleImpl nextPeerLt    = (removingLt2 == null ) ? removingLt.getPeer() : removingLt2.getPeer(); // if there is a subnetwork, skip to the peer after that
+        TupleImpl nextPeerLt = (removingLt2 == null) ? removingLt.getPeer() : removingLt2.getPeer(); // if there is a subnetwork, skip to the peer after that
 
-        if( !isFirstLt ) {
+        if (!isFirstLt) {
             // This LT is not the first tuple in a peer chain. So just correct the peer chain linked list
-            prevLt.setPeer( nextPeerLt );
+            prevLt.setPeer(nextPeerLt);
         } else {
-            if ( nextPeerLt == null ) {
+            if (nextPeerLt == null) {
                 removingLt.unlinkFromLeftParent();
                 removingLt.unlinkFromRightParent();
                 return;
@@ -1270,12 +1180,12 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             // This is the first LT in a peer chain. Only this LT is hooked into the left and right parent LT and RT and
             // if it's the root (form the lian) it will be hooked itno the FH.
             TupleImpl leftPrevious = removingLt.getHandlePrevious();
-            TupleImpl leftNext     = removingLt.getHandleNext();
+            TupleImpl leftNext = removingLt.getHandleNext();
 
             TupleImpl rightPrevious = removingLt.getRightParentPrevious();
-            TupleImpl rightNext     = removingLt.getRightParentNext();
+            TupleImpl rightNext = removingLt.getRightParentNext();
 
-            TupleImpl leftParent  = removingLt.getLeftParent();
+            TupleImpl leftParent = removingLt.getLeftParent();
             TupleImpl rightParent = removingLt.getRightParent();
 
             // This tuple is the first peer and thus is linked into the left parent LT.
@@ -1305,7 +1215,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
 
             // correct the parent's first/last references
-            if (leftParent!=null) {
+            if (leftParent != null) {
                 nextPeerLt.setLeftParent(leftParent);
 
                 if (leftParent.getFirstChild() == removingLt) {
@@ -1320,11 +1230,11 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 fh.removeLeftTuple(removingLt);
                 if (leftPrevious == null && nextPeerLt.getSink().getAssociatedTerminalsSize() > 0) {
                     // The removed tuple was first in linked list, add the peer at its original position
-                    fh.addFirstLeftTuple( nextPeerLt );
+                    fh.addFirstLeftTuple(nextPeerLt);
                 }
             }
 
-            if ( rightParent != null ) {
+            if (rightParent != null) {
                 // This tuple is the first peer and thus is linked into the right parent RT.
                 nextPeerLt.setRightParent(rightParent);
 
@@ -1342,14 +1252,17 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void updatePaths(SegmentPrototype proto, Collection<InternalWorkingMemory> wms, PathEndNode endNode, SegmentPrototype[] newList) {
+    private static void updatePaths(SegmentPrototype proto,
+                                    Collection<InternalWorkingMemory> wms,
+                                    PathEndNode endNode,
+                                    SegmentPrototype[] newList) {
         PathMemSpec spec = endNode.getPathMemSpec();
         spec.update(BuildtimeSegmentUtilities.getPathAllLinkedMaskTest(endNode.getSegmentPrototypes(), endNode),
-                    endNode.getSegmentPrototypes().length);
+                endNode.getSegmentPrototypes().length);
 
         // Now update the PathMemories array of SegmentMemories.
         // Also update all SegmentMemory after the split.
-        for (WorkingMemory wm : wms) {
+        for (ReteEvaluator wm : wms) {
             PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(endNode);
 
             if (pmem != null) {
@@ -1369,14 +1282,14 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
                         // only update segment after proto
                         if (i > proto.getPos()) {
-                            long currentLinkedNodeMask  = sm.getLinkedNodeMask();
-                            smproto.shallowUpdateSegmentMemory(sm);
+                            long currentLinkedNodeMask = sm.getLinkedNodeMask();
+                            sm.updateFromPrototype(smproto);
                             sm.setLinkedNodeMask(currentLinkedNodeMask);
                         }
 
                         // update link mask status on pmem for all segments from proto1 onwards
                         if (i >= proto.getPos()) {
-                            if (sm.getAllLinkedMaskTest() > 0 && sm.isSegmentLinked() ) {
+                            if (sm.getAllLinkedMaskTest() > 0 && sm.isSegmentLinked()) {
                                 pmem.setLinkedSegmentMask(pmem.getLinkedSegmentMask() | sm.getSegmentPosMaskBit());
                             } else {
                                 pmem.setLinkedSegmentMask(pmem.getLinkedSegmentMask() & ~sm.getSegmentPosMaskBit());
@@ -1384,20 +1297,12 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                         }
                     } else {
                         // ensure the pmem is unset for this position, can happen if the segment that set this before shifted up
-                        pmem.setLinkedSegmentMask(pmem.getLinkedSegmentMask() & ~(1 << i ));
+                        pmem.setLinkedSegmentMask(pmem.getLinkedSegmentMask() & ~(1 << i));
                     }
                 }
                 pmem.setSegmentMemories(newSmems);
             }
         }
-    }
-
-    private static void setNodeTypes(SegmentPrototype proto, LeftTupleNode[] protoNodes) {
-        int nodeTypesInSegment = 0;
-        for ( LeftTupleNode node : protoNodes) {
-            nodeTypesInSegment = BuildtimeSegmentUtilities.updateNodeTypesMask(node, nodeTypesInSegment);
-        }
-        proto.setNodeTypesInSegment(nodeTypesInSegment);
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -146,7 +146,8 @@ class LazyPhreakBuilder implements PhreakBuilder {
                 Map<PathMemory, SegmentMemory[]> prevSmemsLookup = reInitPathMemories(tnms.otherPmems, null);
 
                 // must collect all visited SegmentMemories, for link notification
-                Set<SegmentMemory> smemsToNotify = handleExistingPaths(wm, tn, prevSmemsLookup, tnms.otherPmems, ExistingPathStrategy.ADD_STRATEGY);
+                Set<SegmentMemory> smemsToNotify = handleExistingPaths(wm, tn, prevSmemsLookup, tnms.otherPmems,
+                        ExistingPathStrategy.ADD_STRATEGY);
 
                 addNewPaths(wm, smemsToNotify, tnms.subjectPmems);
 
@@ -157,7 +158,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
 
         if (hasWms) {
-            insertFacts( pathEndNodes, wms );
+            insertFacts(pathEndNodes, wms);
         } else {
             for (PathEndNode node : pathEndNodes.otherEndNodes) {
                 node.resetPathMemSpec(null);
@@ -170,7 +171,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
      * For remove tuples are processed before the segments and pmems have been adjusted
      */
     @Override
-    public void removeRule( TerminalNode tn, Collection<InternalWorkingMemory> wms, InternalRuleBase kBase) {
+    public void removeRule(TerminalNode tn, Collection<InternalWorkingMemory> wms, InternalRuleBase kBase) {
         if (log.isTraceEnabled()) {
             log.trace("Removing Rule {}", tn.getRule().getName());
         }
@@ -182,7 +183,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
             return;
         }
 
-        RuleImpl      rule       = tn.getRule();
+        RuleImpl rule = tn.getRule();
         LeftTupleNode firstSplit = getNetworkSplitPoint(tn);
         PathEndNodes pathEndNodes = getPathEndNodes(kBase, firstSplit, tn, rule, hasProtos, hasWms);
 
@@ -191,7 +192,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
             PathEndNodeMemories tnms = getPathEndMemories(wm, pathEndNodes);
 
-            if ( !tnms.subjectPmems.isEmpty() ) {
+            if (!tnms.subjectPmems.isEmpty()) {
                 if (NodeTypeEnums.isLeftInputAdapterNode(firstSplit) && firstSplit.getAssociatedTerminalsSize() == 1) {
                     if (tnms.subjectPmem != null) {
                         flushStagedTuples(wm, firstSplit, tnms.subjectPmem);
@@ -210,13 +211,15 @@ class LazyPhreakBuilder implements PhreakBuilder {
                     Map<PathMemory, SegmentMemory[]> prevSmemsLookup = reInitPathMemories(tnms.otherPmems, tn);
 
                     // must collect all visited SegmentMemories, for link notification
-                    Set<SegmentMemory> smemsToNotify = handleExistingPaths(wm, tn, prevSmemsLookup, tnms.otherPmems, ExistingPathStrategy.REMOVE_STRATEGY);
+                    Set<SegmentMemory> smemsToNotify = handleExistingPaths(wm, tn, prevSmemsLookup, tnms.otherPmems,
+                            ExistingPathStrategy.REMOVE_STRATEGY);
 
                     notifySegments(wm, smemsToNotify);
                 }
             }
 
-            if (tnms.subjectPmem != null && tnms.subjectPmem.isInitialized() && tnms.subjectPmem.getRuleAgendaItem().isQueued()) {
+            if (tnms.subjectPmem != null && tnms.subjectPmem.isInitialized() && tnms.subjectPmem.getRuleAgendaItem()
+                    .isQueued()) {
                 // SubjectPmem can be null, if it was never initialized
                 tnms.subjectPmem.getRuleAgendaItem().dequeue();
             }
@@ -230,24 +233,38 @@ class LazyPhreakBuilder implements PhreakBuilder {
     }
 
     public interface ExistingPathStrategy {
+
         ExistingPathStrategy ADD_STRATEGY = new AddExistingPaths();
         ExistingPathStrategy REMOVE_STRATEGY = new RemoveExistingPaths();
 
         SegmentMemory[] getSegmenMemories(PathMemory pmem);
 
-        void adjustSegment(InternalWorkingMemory wm, Set<SegmentMemory> smemsToNotify, SegmentMemory smem, int smemSplitAdjustAmount);
+        void adjustSegment(InternalWorkingMemory wm,
+                           Set<SegmentMemory> smemsToNotify,
+                           SegmentMemory smem,
+                           int smemSplitAdjustAmount);
 
-        void handleSplit(PathMemory pmem, SegmentMemory[] prevSmems, SegmentMemory[] smems, int smemIndex, int prevSmemIndex,
-                         LeftTupleNode parentNode, LeftTupleNode node, TerminalNode tn,
-                         Set<LeftTupleNode> visited, Set<SegmentMemory> smemsToNotify, Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap,
+        void handleSplit(PathMemory pmem,
+                         SegmentMemory[] prevSmems,
+                         SegmentMemory[] smems,
+                         int smemIndex,
+                         int prevSmemIndex,
+                         LeftTupleNode parentNode,
+                         LeftTupleNode node,
+                         TerminalNode tn,
+                         Set<LeftTupleNode> visited,
+                         Set<SegmentMemory> smemsToNotify,
+                         Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap,
                          InternalWorkingMemory wm);
 
         void processSegmentMemories(SegmentMemory[] smems, PathMemory pmem);
 
         int incSmemIndex1(int smemIndex);
+
         int incSmemIndex2(int smemIndex);
 
         int incPrevSmemIndex1(int prevSmemIndex);
+
         int incPrevSmemIndex2(int prevSmemIndex);
     }
 
@@ -259,16 +276,27 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
 
         @Override
-        public void adjustSegment(InternalWorkingMemory wm, Set<SegmentMemory> smemsToNotify, SegmentMemory smem, int smemSplitAdjustAmount) {
+        public void adjustSegment(InternalWorkingMemory wm,
+                                  Set<SegmentMemory> smemsToNotify,
+                                  SegmentMemory smem,
+                                  int smemSplitAdjustAmount) {
             smemsToNotify.add(smem);
             smem.unlinkSegment(wm);
             smem.correctSegmentMemoryAfterSplitOnAdd(smemSplitAdjustAmount);
         }
 
         @Override
-        public void handleSplit(PathMemory pmem, SegmentMemory[] prevSmems, SegmentMemory[] smems, int smemIndex, int prevSmemIndex,
-                                LeftTupleNode parentNode, LeftTupleNode node, TerminalNode tn,
-                                Set<LeftTupleNode> visited, Set<SegmentMemory> smemsToNotify, Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap,
+        public void handleSplit(PathMemory pmem,
+                                SegmentMemory[] prevSmems,
+                                SegmentMemory[] smems,
+                                int smemIndex,
+                                int prevSmemIndex,
+                                LeftTupleNode parentNode,
+                                LeftTupleNode node,
+                                TerminalNode tn,
+                                Set<LeftTupleNode> visited,
+                                Set<SegmentMemory> smemsToNotify,
+                                Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap,
                                 InternalWorkingMemory wm) {
             if (smems[smemIndex - 1] != null) {
                 SegmentMemory sm2 = nodeToSegmentMap.get(node);
@@ -292,9 +320,8 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
         @Override
         public int incSmemIndex1(int smemIndex) {
-            return smemIndex+1;
+            return smemIndex + 1;
         }
-
 
         @Override
         public int incPrevSmemIndex1(int prevSmemIndex) {
@@ -308,7 +335,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
         @Override
         public int incPrevSmemIndex2(int prevSmemIndex) {
-            return prevSmemIndex+1;
+            return prevSmemIndex + 1;
         }
     }
 
@@ -316,20 +343,31 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
         @Override
         public SegmentMemory[] getSegmenMemories(PathMemory pmem) {
-            return new SegmentMemory[ pmem.getSegmentMemories().length ];
+            return new SegmentMemory[pmem.getSegmentMemories().length];
         }
 
         @Override
-        public void adjustSegment(InternalWorkingMemory wm, Set<SegmentMemory> smemsToNotify, SegmentMemory smem, int smemSplitAdjustAmount) {
+        public void adjustSegment(InternalWorkingMemory wm,
+                                  Set<SegmentMemory> smemsToNotify,
+                                  SegmentMemory smem,
+                                  int smemSplitAdjustAmount) {
             smemsToNotify.add(smem);
             smem.unlinkSegment(wm);
             smem.correctSegmentMemoryAfterSplitOnRemove(smemSplitAdjustAmount);
         }
 
         @Override
-        public void handleSplit(PathMemory pmem, SegmentMemory[] prevSmems, SegmentMemory[] smems, int smemIndex, int prevSmemIndex,
-                                LeftTupleNode parentNode, LeftTupleNode node, TerminalNode tn,
-                                Set<LeftTupleNode> visited, Set<SegmentMemory> smemsToNotify, Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap,
+        public void handleSplit(PathMemory pmem,
+                                SegmentMemory[] prevSmems,
+                                SegmentMemory[] smems,
+                                int smemIndex,
+                                int prevSmemIndex,
+                                LeftTupleNode parentNode,
+                                LeftTupleNode node,
+                                TerminalNode tn,
+                                Set<LeftTupleNode> visited,
+                                Set<SegmentMemory> smemsToNotify,
+                                Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap,
                                 InternalWorkingMemory wm) {
             if (visited.contains(node)) {
                 return;
@@ -344,7 +382,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                 // Temporarily remove the terminal node of the rule to be removed from the rete network to avoid that
                 // its path memory could be added to an existing segment memory during the merge of 2 segments
                 LeftTupleSource removedTerminalSource = tn.getLeftTupleSource();
-                removedTerminalSource.removeTupleSink( tn );
+                removedTerminalSource.removeTupleSink(tn);
 
                 if (sm1 == null) {
                     sm1 = createChildSegment(wm, parentNode);
@@ -356,7 +394,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                     sm1.add(sm2);
                 }
 
-                mergeSegment(sm1, sm2);
+                sm1.mergeSegment(sm2);
                 smemsToNotify.add(sm1);
                 sm1.unlinkSegment(wm);
                 sm2.unlinkSegment(wm);
@@ -364,7 +402,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
                 // Add back the the terminal node of the rule to be removed into the rete network to permit the network
                 // traversal up from it and the removal of all the nodes exclusively belonging to the removed rule
-                removedTerminalSource.addTupleSink( tn );
+                removedTerminalSource.addTupleSink(tn);
             }
         }
 
@@ -372,7 +410,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         public void processSegmentMemories(SegmentMemory[] smems, PathMemory pmem) {
             for (int i = 0; i < smems.length; i++) {
                 if (smems[i] != null) {
-                    pmem.setSegmentMemory( smems[i].getPos(), smems[i] );
+                    pmem.setSegmentMemory(smems[i].getPos(), smems[i]);
                 }
             }
         }
@@ -384,12 +422,12 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
         @Override
         public int incPrevSmemIndex1(int prevSmemIndex) {
-            return prevSmemIndex+1;
+            return prevSmemIndex + 1;
         }
 
         @Override
         public int incSmemIndex2(int smemIndex) {
-            return smemIndex+1;
+            return smemIndex + 1;
         }
 
         @Override
@@ -398,10 +436,13 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static Set<SegmentMemory> handleExistingPaths(InternalWorkingMemory wm, TerminalNode tn,
-                                                          Map<PathMemory, SegmentMemory[]> prevSmemsLookup, List<PathMemory> pmems, ExistingPathStrategy strategy) {
-        Set<SegmentMemory>                smemsToNotify    = new HashSet<>();
-        Set<SegmentMemory>                visitedSegments  = new HashSet<>();
+    private static Set<SegmentMemory> handleExistingPaths(InternalWorkingMemory wm,
+                                                          TerminalNode tn,
+                                                          Map<PathMemory, SegmentMemory[]> prevSmemsLookup,
+                                                          List<PathMemory> pmems,
+                                                          ExistingPathStrategy strategy) {
+        Set<SegmentMemory> smemsToNotify = new HashSet<>();
+        Set<SegmentMemory> visitedSegments = new HashSet<>();
         Set<LeftTupleNode> visitedNodes = new HashSet<>();
         Map<LeftTupleNode, SegmentMemory> nodeToSegmentMap = new HashMap<>();
 
@@ -409,14 +450,14 @@ class LazyPhreakBuilder implements PhreakBuilder {
             LeftTupleNode[] nodes = pmem.getPathEndNode().getPathNodes();
 
             SegmentMemory[] prevSmems = prevSmemsLookup.get(pmem);
-            SegmentMemory[] smems     = strategy.getSegmenMemories(pmem);
+            SegmentMemory[] smems = strategy.getSegmenMemories(pmem);
 
             LeftTupleNode node;
-            int           prevSmemIndex         = 0;
-            int           smemIndex             = 0;
-            int           smemSplitAdjustAmount = 0;
-            int           nodeIndex             = 0;
-            int           nodeTypesInSegment    = 0;
+            int prevSmemIndex = 0;
+            int smemIndex = 0;
+            int smemSplitAdjustAmount = 0;
+            int nodeIndex = 0;
+            int nodeTypesInSegment = 0;
 
             // excluding the rule just added iterate while not split (i.e. find the next split, prior to this rule being added)
             // note it's checking for when the parent is the split, and thus node is the next root root.
@@ -425,7 +466,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
             do {
                 node = nodes[nodeIndex++];
                 LeftTupleSource parentNode = node.getLeftTupleSource();
-                nodeTypesInSegment = BuildtimeSegmentUtilities.updateNodeTypesMask( parentNode, nodeTypesInSegment );
+                nodeTypesInSegment = BuildtimeSegmentUtilities.updateNodeTypesMask(parentNode, nodeTypesInSegment);
                 if (isSplit(parentNode)) {
                     smemIndex = strategy.incSmemIndex1(smemIndex);
                     prevSmemIndex = strategy.incPrevSmemIndex1(prevSmemIndex);
@@ -433,8 +474,9 @@ class LazyPhreakBuilder implements PhreakBuilder {
                         smemIndex = strategy.incSmemIndex2(smemIndex);
                         prevSmemIndex = strategy.incPrevSmemIndex2(prevSmemIndex);
                         smems[smemIndex] = prevSmems[prevSmemIndex];
-                        if ( smems[smemIndex] != null && smemSplitAdjustAmount > 0 && visitedSegments.add(smems[smemIndex])) {
-                            strategy.adjustSegment( wm, smemsToNotify, smems[smemIndex], smemSplitAdjustAmount );
+                        if (smems[smemIndex] != null && smemSplitAdjustAmount > 0 && visitedSegments.add(
+                                smems[smemIndex])) {
+                            strategy.adjustSegment(wm, smemsToNotify, smems[smemIndex], smemSplitAdjustAmount);
                         }
                     } else {
                         strategy.handleSplit(pmem, prevSmems, smems, smemIndex, prevSmemIndex,
@@ -442,7 +484,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                                 smemsToNotify, nodeToSegmentMap, wm);
                         smemSplitAdjustAmount++;
                     }
-                    checkEagerSegmentCreation(wm, parentNode, nodeTypesInSegment );
+                    checkEagerSegmentCreation(wm, parentNode, nodeTypesInSegment);
                     nodeTypesInSegment = 0;
                 }
             } while (!NodeTypeEnums.isEndNode(node));
@@ -451,52 +493,55 @@ class LazyPhreakBuilder implements PhreakBuilder {
         return smemsToNotify;
     }
 
-    private static void addNewPaths(InternalWorkingMemory wm, Set<SegmentMemory> smemsToNotify, List<PathMemory> pmems) {
+    private static void addNewPaths(InternalWorkingMemory wm,
+                                    Set<SegmentMemory> smemsToNotify,
+                                    List<PathMemory> pmems) {
         // Multiple paths may be renetrant, in the case of a second subnetwork on the same rule.
         // Must make sure we don't duplicate the child smem, and when found, just update it with new pmem.
         Set<LeftTupleNode> visited = new HashSet<>();
         for (PathMemory pmem : pmems) {
             LeftTupleSink tipNode = pmem.getPathEndNode();
 
-            LeftTupleNode child  = tipNode;
+            LeftTupleNode child = tipNode;
             LeftTupleNode parent = tipNode.getLeftTupleSource();
 
             while (true) {
                 if (visited.add(child)) {
-                    if ( parent != null && parent.getAssociatedTerminalsSize() != 1 && child.getAssociatedTerminalsSize() == 1 ) {
+                    if (parent != null && parent.getAssociatedTerminalsSize() != 1 && child
+                            .getAssociatedTerminalsSize() == 1) {
                         // This is the split point that the new path enters an existing path.
                         // If the parent has other child SegmentMemorys then it must create a new child SegmentMemory
                         // If the parent is a query node, then it's internal data structure needs changing
                         // all right input data must be propagated
-                        Memory mem = wm.getNodeMemories().peekNodeMemory( parent );
-                        if ( mem != null && mem.getSegmentMemory() != null ) {
+                        Memory mem = wm.getNodeMemories().peekNodeMemory(parent);
+                        if (mem != null && mem.getSegmentMemory() != null) {
                             SegmentMemory sm = mem.getSegmentMemory();
-                            if ( sm.getFirst() != null && sm.size() < parent.getSinkPropagator().size()) {
+                            if (sm.getFirst() != null && sm.size() < parent.getSinkPropagator().size()) {
                                 LeftTupleSink[] sinks = parent.getSinkPropagator().getSinks();
                                 for (int i = sm.size(); i < sinks.length; i++) {
-                                    SegmentMemory childSmem = createChildSegment( wm, sinks[i] );
-                                    sm.add( childSmem );
-                                    pmem.setSegmentMemory( childSmem.getPos(), childSmem );
-                                    smemsToNotify.add( childSmem );
+                                    SegmentMemory childSmem = createChildSegment(wm, sinks[i]);
+                                    sm.add(childSmem);
+                                    pmem.setSegmentMemory(childSmem.getPos(), childSmem);
+                                    smemsToNotify.add(childSmem);
                                 }
                             }
-                            correctMemoryOnSplitsChanged( wm, parent, null );
+                            correctMemoryOnSplitsChanged(wm, parent, null);
                         }
                     } else {
-                        Memory mem = wm.getNodeMemories().peekNodeMemory( child );
+                        Memory mem = wm.getNodeMemories().peekNodeMemory(child);
                         // The root of each segment
-                        if ( mem != null ) {
+                        if (mem != null) {
                             SegmentMemory sm = mem.getSegmentMemory();
-                            if ( sm != null && !sm.getPathMemories().contains( pmem ) ) {
+                            if (sm != null && !sm.getPathMemories().contains(pmem)) {
                                 RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, sm);
-                                sm.notifyRuleLinkSegment( wm, pmem );
+                                sm.notifyRuleLinkSegment(wm, pmem);
                             }
                         }
                     }
                 } else {
-                    Memory mem = wm.getNodeMemories().peekNodeMemory( child );
-                    if ( mem != null ) {
-                        mem.getSegmentMemory().notifyRuleLinkSegment( wm, pmem );
+                    Memory mem = wm.getNodeMemories().peekNodeMemory(child);
+                    if (mem != null) {
+                        mem.getSegmentMemory().notifyRuleLinkSegment(wm, pmem);
                     }
                 }
 
@@ -510,13 +555,12 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
     }
 
-
     private static void removeNewPaths(InternalWorkingMemory wm, List<PathMemory> pmems) {
         Set<Integer> visitedNodes = new HashSet<>();
         for (PathMemory pmem : pmems) {
             LeftTupleSink tipNode = pmem.getPathEndNode();
 
-            LeftTupleNode child  = tipNode;
+            LeftTupleNode child = tipNode;
             LeftTupleNode parent = tipNode.getLeftTupleSource();
 
             while (true) {
@@ -525,18 +569,19 @@ class LazyPhreakBuilder implements PhreakBuilder {
                     deleteRightInputData(wm, (LeftTupleSink) child);
                 }
 
-                if (parent != null && parent.getAssociatedTerminalsSize() != 1 && child.getAssociatedTerminalsSize() == 1) {
+                if (parent != null && parent.getAssociatedTerminalsSize() != 1 && child
+                        .getAssociatedTerminalsSize() == 1) {
                     // This is the split point that the new path enters an existing path.
                     // If the parent has other child SegmentMemorys then it must create a new child SegmentMemory
                     // If the parent is a query node, then it's internal data structure needs changing
                     // all right input data must be propagated
-                    if (!visitedNodes.contains( child.getId() )) {
-                        Memory mem = wm.getNodeMemories().peekNodeMemory( parent );
-                        if ( mem != null && mem.getSegmentMemory() != null ) {
+                    if (!visitedNodes.contains(child.getId())) {
+                        Memory mem = wm.getNodeMemories().peekNodeMemory(parent);
+                        if (mem != null && mem.getSegmentMemory() != null) {
                             SegmentMemory sm = mem.getSegmentMemory();
-                            if ( sm.getFirst() != null ) {
-                                SegmentMemory childSm = wm.getNodeMemories().peekNodeMemory( child ).getSegmentMemory();
-                                sm.remove( childSm );
+                            if (sm.getFirst() != null) {
+                                SegmentMemory childSm = wm.getNodeMemories().peekNodeMemory(child).getSegmentMemory();
+                                sm.remove(childSm);
                             }
                         }
                     }
@@ -545,7 +590,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                     // The root of each segment
                     if (mem != null) {
                         SegmentMemory sm = mem.getSegmentMemory();
-                        if (sm != null && sm.getPathMemories().contains( pmem )) {
+                        if (sm != null && sm.getPathMemories().contains(pmem)) {
                             mem.getSegmentMemory().removePathMemory(pmem);
                         }
                     }
@@ -567,10 +612,11 @@ class LazyPhreakBuilder implements PhreakBuilder {
     }
 
     private static boolean isSplit(LeftTupleNode node, TerminalNode removingTN) {
-        return node != null && BuildtimeSegmentUtilities.isTipNode( node, removingTN );
+        return node != null && BuildtimeSegmentUtilities.isTipNode(node, removingTN);
     }
 
     public static class Flushed {
+
         SegmentMemory segmentMemory;
         PathMemory pathMemory;
 
@@ -580,9 +626,12 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    public static void flushStagedTuples(InternalWorkingMemory wm, TerminalNode tn, PathMemory pmem, List<LeftTupleNode> splits) {
+    public static void flushStagedTuples(InternalWorkingMemory wm,
+                                         TerminalNode tn,
+                                         PathMemory pmem,
+                                         List<LeftTupleNode> splits) {
         // first flush the subject rule, then flush any staging lists that are part of a merge
-        if ( pmem.isInitialized() ) {
+        if (pmem.isInitialized()) {
             RuleNetworkEvaluator.INSTANCE.evaluateNetwork(wm, pmem.getRuleAgendaItem().getRuleExecutor(), pmem);
         }
 
@@ -594,15 +643,17 @@ class LazyPhreakBuilder implements PhreakBuilder {
         for (LeftTupleNode node : splits) {
             if (!isSplit(node, tn)) { // check if the split is there even without the processed rule
                 Memory mem = wm.getNodeMemories().peekNodeMemory(node);
-                if ( mem != null) {
+                if (mem != null) {
                     SegmentMemory smem = mem.getSegmentMemory();
 
-                    if ( !smem.isEmpty() ) {
-                        for ( SegmentMemory childSmem = smem.getFirst(); childSmem != null; childSmem = childSmem.getNext() ) {
-                            if ( !childSmem.getStagedLeftTuples().isEmpty() ) {
+                    if (!smem.isEmpty()) {
+                        for (SegmentMemory childSmem = smem.getFirst(); childSmem != null; childSmem = childSmem
+                                .getNext()) {
+                            if (!childSmem.getStagedLeftTuples().isEmpty()) {
                                 PathMemory childPmem = childSmem.getPathMemories().get(0);
-                                flushed.add( new Flushed(childSmem, childPmem));
-                                forceFlushLeftTuple(childPmem, childSmem, wm, childSmem.getStagedLeftTuples().takeAll());
+                                flushed.add(new Flushed(childSmem, childPmem));
+                                forceFlushLeftTuple(childPmem, childSmem, wm, childSmem.getStagedLeftTuples()
+                                        .takeAll());
                             }
                         }
                     }
@@ -614,27 +665,28 @@ class LazyPhreakBuilder implements PhreakBuilder {
         while (!flushed.isEmpty() && flushCount != 0) {
             flushCount = 0;
             for (Flushed path : flushed) {
-                if ( !path.segmentMemory.getStagedLeftTuples().isEmpty() ) {
+                if (!path.segmentMemory.getStagedLeftTuples().isEmpty()) {
                     flushCount++;
-                    forceFlushLeftTuple(pmem, path.segmentMemory, wm, path.segmentMemory.getStagedLeftTuples().takeAll());
+                    forceFlushLeftTuple(pmem, path.segmentMemory, wm, path.segmentMemory.getStagedLeftTuples()
+                            .takeAll());
                 }
             }
         }
     }
 
     private static void flushStagedTuples(InternalWorkingMemory wm, LeftTupleNode splitStartNode, PathMemory pmem) {
-        if ( !pmem.isInitialized() ) {
+        if (!pmem.isInitialized()) {
             // The rule has never been linked in and evaluated, so there will be nothing to flush.
             return;
         }
-        int             smemIndex = getSegmentPos(splitStartNode); // index before the segments are merged
-        SegmentMemory[] smems     = pmem.getSegmentMemories();
+        int smemIndex = getSegmentPos(splitStartNode); // index before the segments are merged
+        SegmentMemory[] smems = pmem.getSegmentMemories();
 
-        SegmentMemory   sm        = null;
+        SegmentMemory sm = null;
 
         // If there is no sharing, then there will not be any staged tuples in later segemnts, and thus no need to search for them if the current sm is empty.
         int length = smems.length;
-        if ( splitStartNode.getAssociatedTerminalsSize() == 1 ) {
+        if (splitStartNode.getAssociatedTerminalsSize() == 1) {
             length = 1;
         }
 
@@ -646,13 +698,14 @@ class LazyPhreakBuilder implements PhreakBuilder {
             smemIndex++;
         }
 
-        if ( smemIndex < length ) {
+        if (smemIndex < length) {
             // it only found a SM that needed flushing, if smemIndex < length
             forceFlushLeftTuple(pmem, sm, wm, sm.getStagedLeftTuples().takeAll());
         }
     }
 
-    private static Map<PathMemory, SegmentMemory[]> reInitPathMemories(List<PathMemory> pathMems, TerminalNode removingTN) {
+    private static Map<PathMemory, SegmentMemory[]> reInitPathMemories(List<PathMemory> pathMems,
+                                                                       TerminalNode removingTN) {
         Map<PathMemory, SegmentMemory[]> previousSmems = new HashMap<>();
         for (PathMemory pmem : pathMems) {
             // Re initialise all the PathMemories
@@ -671,15 +724,17 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void correctMemoryOnSplitsChanged(InternalWorkingMemory wm, LeftTupleNode splitStart, TerminalNode removingTN) {
+    private static void correctMemoryOnSplitsChanged(InternalWorkingMemory wm,
+                                                     LeftTupleNode splitStart,
+                                                     TerminalNode removingTN) {
         if (splitStart.getType() == NodeTypeEnums.QueryElementNode) {
-            QueryElementNode.QueryElementNodeMemory mem = (QueryElementNode.QueryElementNodeMemory) wm.getNodeMemories().peekNodeMemory(splitStart);
+            QueryElementNode.QueryElementNodeMemory mem = (QueryElementNode.QueryElementNodeMemory) wm.getNodeMemories()
+                    .peekNodeMemory(splitStart);
             if (mem != null) {
                 mem.correctMemoryOnSinksChanged(removingTN);
             }
         }
     }
-
 
     private static int getSegmentPos(LeftTupleNode lts) {
         int counter = 0;
@@ -695,26 +750,27 @@ class LazyPhreakBuilder implements PhreakBuilder {
     private static void insertLiaFacts(InternalWorkingMemory wm, LeftTupleNode startNode) {
         // rule added with no sharing
         PropagationContextFactory pctxFactory = RuntimeComponentFactory.get().getPropagationContextFactory();
-        final PropagationContext  pctx        = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(), PropagationContext.Type.RULE_ADDITION, null, null, null);
-        LeftInputAdapterNode      lian        = (LeftInputAdapterNode) startNode;
+        final PropagationContext pctx = pctxFactory.createPropagationContext(wm.getNextPropagationIdCounter(),
+                PropagationContext.Type.RULE_ADDITION, null, null, null);
+        LeftInputAdapterNode lian = (LeftInputAdapterNode) startNode;
         attachAdapterAndPropagate(wm, lian, pctx);
     }
 
     private static void insertFacts(PathEndNodes endNodes, Collection<InternalWorkingMemory> wms) {
         Set<LeftTupleNode> visited = new HashSet<>();
 
-        for ( PathEndNode endNode : endNodes.subjectEndNodes ) {
-            LeftTupleNode[]  nodes = endNode.getPathNodes();
-            for ( int i = 0; i < nodes.length; i++ ) {
+        for (PathEndNode endNode : endNodes.subjectEndNodes) {
+            LeftTupleNode[] nodes = endNode.getPathNodes();
+            for (int i = 0; i < nodes.length; i++) {
                 LeftTupleNode node = nodes[i];
-                if  ( NodeTypeEnums.isBetaNode(node) && node.getAssociatedTerminalsSize() == 1 ) {
-                    if (!visited.add( node )) {
+                if (NodeTypeEnums.isBetaNode(node) && node.getAssociatedTerminalsSize() == 1) {
+                    if (!visited.add(node)) {
                         continue;// this is to avoid rentering a path, and processing nodes twice. This can happen for nested subnetworks.
                     }
                     BetaNode bn = (BetaNode) node;
 
                     if (!bn.getRightInput().inputIsTupleToObjectNode()) {
-                        for ( InternalWorkingMemory wm : wms ) {
+                        for (InternalWorkingMemory wm : wms) {
                             attachAdapterAndPropagate(wm, bn);
                         }
                     }
@@ -725,7 +781,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
     private static void deleteRightInputData(InternalWorkingMemory wm, LeftTupleSink node) {
         if (wm.getNodeMemories().peekNodeMemory(node) != null) {
-            BetaNode       bn = (BetaNode) node;
+            BetaNode bn = (BetaNode) node;
             BetaMemory bm;
             if (bn.getType() == NodeTypeEnums.AccumulateNode) {
                 bm = ((AccumulateMemory) wm.getNodeMemory(bn)).getBetaMemory();
@@ -733,9 +789,9 @@ class LazyPhreakBuilder implements PhreakBuilder {
                 bm = (BetaMemory) wm.getNodeMemory(bn);
             }
 
-            TupleMemory  rtm = bm.getRightTupleMemory();
-            FastIterator<TupleImpl> it  = rtm.fullFastIterator();
-            for (TupleImpl rightTuple = BetaNode.getFirstTuple(rtm, it); rightTuple != null; ) {
+            TupleMemory rtm = bm.getRightTupleMemory();
+            FastIterator<TupleImpl> it = rtm.fullFastIterator();
+            for (TupleImpl rightTuple = BetaNode.getFirstTuple(rtm, it); rightTuple != null;) {
                 TupleImpl next = it.next(rightTuple);
                 rtm.remove(rightTuple);
                 rightTuple.unlinkFromRightParent();
@@ -760,7 +816,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         if (source.getType() == NodeTypeEnums.WindowNode) {
             WindowNode.WindowMemory memory = wm.getNodeMemory(((WindowNode) source));
             for (DefaultEventHandle factHandle : memory.getFactHandles()) {
-                factHandle.forEachRightTuple( rt -> {
+                factHandle.forEachRightTuple(rt -> {
                     if (source.equals(rt.getSink())) {
                         rt.unlinkFromRightParent();
                     }
@@ -770,7 +826,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
     }
 
     private static void unlinkRightTuples(TupleImpl rightTuple) {
-        for (TupleImpl rt = rightTuple; rt != null; ) {
+        for (TupleImpl rt = rightTuple; rt != null;) {
             TupleImpl next = rt.getStagedNext();
             // this RightTuple could have been already unlinked by the former cycle
             if (rt.getFactHandle() != null) {
@@ -791,8 +847,8 @@ class LazyPhreakBuilder implements PhreakBuilder {
         // Must iterate up until a node with memory is found, this can be followed to find the LeftTuples
         // which provide the potential peer of the tuple being added or removed
 
-        if ( node.getType() == NodeTypeEnums.AlphaTerminalNode) {
-            processLeftTuplesOnLian( wm, insert, rule, (LeftInputAdapterNode) node );
+        if (node.getType() == NodeTypeEnums.AlphaTerminalNode) {
+            processLeftTuplesOnLian(wm, insert, rule, (LeftInputAdapterNode) node);
             return;
         }
 
@@ -806,15 +862,15 @@ class LazyPhreakBuilder implements PhreakBuilder {
         while (!NodeTypeEnums.isLeftInputAdapterNode(node)) {
 
             if (NodeTypeEnums.isBetaNode(node)) {
-                BetaMemory    bm;
+                BetaMemory bm;
                 if (NodeTypeEnums.AccumulateNode == node.getType()) {
                     AccumulateMemory am = (AccumulateMemory) memory;
                     bm = am.getBetaMemory();
                     FastIterator it = bm.getLeftTupleMemory().fullFastIterator();
-                    Tuple        lt = BetaNode.getFirstTuple(bm.getLeftTupleMemory(), it);
+                    Tuple lt = BetaNode.getFirstTuple(bm.getLeftTupleMemory(), it);
                     for (; lt != null; lt = (TupleImpl) it.next(lt)) {
                         AccumulateContext accctx = (AccumulateContext) lt.getContextObject();
-                        visitChild( wm, rule, (TupleImpl) accctx.getResultLeftTuple(), insert);
+                        visitChild(wm, rule, (TupleImpl) accctx.getResultLeftTuple(), insert);
                     }
                 } else if (NodeTypeEnums.ExistsNode == node.getType() && !node.inputIsTupleToObjectNode()) { // do not process exists with subnetworks
                     // If there is a subnetwork, then there is no populated RTM, but the LTM is populated,
@@ -822,24 +878,26 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
                     bm = (BetaMemory) wm.getNodeMemory((MemoryFactory) node);
                     FastIterator it = bm.getRightTupleMemory().fullFastIterator(); // done off the RightTupleMemory, as exists only have unblocked tuples on the left side
-                    for (RightTuple rt = (RightTuple) BetaNode.getFirstTuple(bm.getRightTupleMemory(), it); rt != null; rt = (RightTuple) it.next(rt)) {
+                    for (RightTuple rt = (RightTuple) BetaNode.getFirstTuple(bm.getRightTupleMemory(),
+                            it); rt != null; rt = (RightTuple) it.next(rt)) {
                         for (LeftTuple lt = rt.getBlocked(); lt != null; lt = lt.getBlockedNext()) {
                             visitLeftTuple(wm, rule, lt, insert);
                         }
                     }
                 } else {
                     bm = (BetaMemory) wm.getNodeMemory((MemoryFactory) node);
-                    FastIterator it = bm.getLeftTupleMemory().fullFastIterator();
-                    for (TupleImpl lt = (TupleImpl)BetaNode.getFirstTuple(bm.getLeftTupleMemory(), it); lt != null; lt = (TupleImpl) it.next(lt)) {
+                    FastIterator<TupleImpl> it = bm.getLeftTupleMemory().fullFastIterator();
+                    for (TupleImpl lt = BetaNode.getFirstTuple(bm.getLeftTupleMemory(), it); lt != null; lt = it.next(
+                            lt)) {
                         visitLeftTuple(wm, rule, lt, insert);
                     }
                 }
                 return;
             } else if (NodeTypeEnums.FromNode == node.getType()) {
-                FromMemory   fm  = (FromMemory) wm.getNodeMemory((MemoryFactory) node);
-                TupleMemory  ltm = fm.getBetaMemory().getLeftTupleMemory();
-                FastIterator it  = ltm.fullFastIterator();
-                for (TupleImpl lt = ltm.getFirst(null); lt != null; lt = (TupleImpl) it.next(lt)) {
+                FromMemory fm = (FromMemory) wm.getNodeMemory((MemoryFactory) node);
+                TupleMemory ltm = fm.getBetaMemory().getLeftTupleMemory();
+                FastIterator<TupleImpl> it = ltm.fullFastIterator();
+                for (TupleImpl lt = ltm.getFirst(null); lt != null; lt = it.next(lt)) {
                     visitChild(wm, rule, lt, insert);
                 }
                 return;
@@ -852,20 +910,23 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
         // No beta or from nodes, so must retrieve LeftTuples from the LiaNode.
         // This is done by scanning all the LeftTuples referenced from the FactHandles in the ObjectTypeNode
-        processLeftTuplesOnLian( wm, insert, rule, (LeftInputAdapterNode) node );
+        processLeftTuplesOnLian(wm, insert, rule, (LeftInputAdapterNode) node);
     }
 
-    private static void processLeftTuplesOnLian( InternalWorkingMemory wm, boolean insert, Rule rule, LeftInputAdapterNode lian ) {
+    private static void processLeftTuplesOnLian(InternalWorkingMemory wm,
+                                                boolean insert,
+                                                Rule rule,
+                                                LeftInputAdapterNode lian) {
         BaseNode os = lian.getObjectSource();
         while (os.getType() != NodeTypeEnums.ObjectTypeNode) {
             os = os.getParent();
         }
 
-        ObjectTypeNode otn  = (ObjectTypeNode) os;
+        ObjectTypeNode otn = (ObjectTypeNode) os;
         Iterator<InternalFactHandle> it = otn.getFactHandlesIterator(wm);
         while (it.hasNext()) {
             InternalFactHandle fh = it.next();
-            fh.forEachLeftTuple( lt -> {
+            fh.forEachLeftTuple(lt -> {
                 TupleImpl nextLt = lt.getHandleNext();
 
                 // Each lt is for a different lian, skip any lian not associated with the rule. Need to use lt parent (souce) not child to check the lian.
@@ -873,8 +934,8 @@ class LazyPhreakBuilder implements PhreakBuilder {
                     visitChild(wm, rule, lt, insert);
 
                     if (lt.getHandlePrevious() != null && nextLt != null) {
-                        lt.getHandlePrevious().setHandleNext( nextLt );
-                        nextLt.setHandlePrevious( lt.getHandlePrevious() );
+                        lt.getHandlePrevious().setHandleNext(nextLt);
+                        nextLt.setHandlePrevious(lt.getHandlePrevious());
                     }
                 }
             });
@@ -894,26 +955,26 @@ class LazyPhreakBuilder implements PhreakBuilder {
         TupleImpl prevLt = null;
         LeftTupleSinkNode sink = (LeftTupleSinkNode) lt.getSink();
 
-        for ( ; sink != null; sink = sink.getNextLeftTupleSinkNode() ) {
+        for (; sink != null; sink = sink.getNextLeftTupleSinkNode()) {
 
-            if ( lt != null ) {
+            if (lt != null) {
                 if (lt.getSink().isAssociatedWith(rule)) {
 
                     if (lt.getSink().getAssociatedTerminalsSize() > 1) {
                         if (lt.getFirstChild() != null) {
-                            for ( TupleImpl child = lt.getFirstChild(); child != null; child =  child.getHandleNext() ) {
+                            for (TupleImpl child = lt.getFirstChild(); child != null; child = child.getHandleNext()) {
                                 visitChild(wm, rule, child, insert);
                             }
                         } else if (lt.getSink().getType() == NodeTypeEnums.TupleToObjectNode) {
-                            insertPeerRightTuple( wm, rule, lt, insert);
+                            insertPeerRightTuple(wm, rule, lt, insert);
                         }
                     } else if (!insert) {
-                        iterateLeftTuple( wm, lt );
+                        iterateLeftTuple(wm, lt);
                         TupleImpl lt2 = null;
-                        for ( TupleImpl peerLt = lt.getPeer();
-                              peerLt != null && peerLt.getSink().isAssociatedWith(rule) && peerLt.getSink().getAssociatedTerminalsSize() == 1;
-                              peerLt = peerLt.getPeer() ) {
-                            iterateLeftTuple( wm, peerLt );
+                        for (TupleImpl peerLt = lt.getPeer(); peerLt != null && peerLt.getSink().isAssociatedWith(
+                                rule) && peerLt.getSink().getAssociatedTerminalsSize() == 1; peerLt = peerLt
+                                        .getPeer()) {
+                            iterateLeftTuple(wm, peerLt);
                             lt2 = peerLt;
                         }
 
@@ -932,15 +993,16 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void insertPeerRightTuple( InternalWorkingMemory wm, Rule rule, TupleImpl lt, boolean insert ) {
+    private static void insertPeerRightTuple(InternalWorkingMemory wm, Rule rule, TupleImpl lt, boolean insert) {
         // There's a shared RightInputAdaterNode, so check if one of its sinks is associated only to the new rule
-        TupleImpl         prevLt = null;
-        TupleToObjectNode tton   = (TupleToObjectNode) lt.getSink();
+        TupleImpl prevLt = null;
+        TupleToObjectNode tton = (TupleToObjectNode) lt.getSink();
 
         for (ObjectSink sink : tton.getObjectSinkPropagator().getSinks()) {
             if (lt != null) {
-                if (prevLt != null && !insert && sink.isAssociatedWith(rule) && sink.getAssociatedTerminalsSize() == 1) {
-                    prevLt.setPeer( null );
+                if (prevLt != null && !insert && sink.isAssociatedWith(rule) && sink
+                        .getAssociatedTerminalsSize() == 1) {
+                    prevLt.setPeer(null);
                 }
                 prevLt = lt;
                 lt = lt.getPeer();
@@ -948,7 +1010,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                 BetaNode bn = ((RightInputAdapterNode) sink).getBetaNode();
                 BetaMemory bm = (BetaMemory) wm.getNodeMemory(bn);
                 prevLt = TupleFactory.createPeer(tton, prevLt);
-                bm.linkNode( bn, wm );
+                bm.linkNode(bn, wm);
                 bm.getStagedRightTuples().addInsert(prevLt);
             }
         }
@@ -957,34 +1019,40 @@ class LazyPhreakBuilder implements PhreakBuilder {
     /**
      * Create all missing peers
      */
-    private static TupleImpl insertPeerLeftTuple(InternalWorkingMemory wm, LeftTupleSinkNode node, TupleImpl lt, boolean insert) {
+    private static TupleImpl insertPeerLeftTuple(InternalWorkingMemory wm,
+                                                 LeftTupleSinkNode node,
+                                                 TupleImpl lt,
+                                                 boolean insert) {
         TupleImpl peer = TupleFactory.createPeer(node, lt);
 
-        if ( node.getLeftTupleSource().getType() == NodeTypeEnums.AlphaTerminalNode ) {
+        if (node.getLeftTupleSource().getType() == NodeTypeEnums.AlphaTerminalNode) {
             if (insert) {
-                TerminalNode rtn = ( TerminalNode ) node;
+                TerminalNode rtn = (TerminalNode) node;
                 InternalAgenda agenda = wm.getAgenda();
-                RuleAgendaItem agendaItem = AlphaTerminalNode.getRuleAgendaItem( wm, agenda, rtn, insert );
-                PhreakRuleTerminalNode.doLeftTupleInsert( rtn, agendaItem.getRuleExecutor(), agenda, agendaItem, (RuleTerminalNodeLeftTuple) peer );
+                RuleAgendaItem agendaItem = AlphaTerminalNode.getRuleAgendaItem(wm, agenda, rtn, insert);
+                PhreakRuleTerminalNode.doLeftTupleInsert(rtn, agendaItem.getRuleExecutor(), agenda, agendaItem,
+                        (RuleTerminalNodeLeftTuple) peer);
             }
             return peer;
         }
 
         LeftInputAdapterNode.LiaNodeMemory liaMem = null;
-        if ( NodeTypeEnums.isLeftInputAdapterNode(node.getLeftTupleSource())) {
+        if (NodeTypeEnums.isLeftInputAdapterNode(node.getLeftTupleSource())) {
             liaMem = wm.getNodeMemory(((LeftInputAdapterNode) node.getLeftTupleSource()));
         }
 
         Memory memory = wm.getNodeMemories().peekNodeMemory(node);
         if (memory == null || memory.getSegmentMemory() == null) {
-            throw new IllegalStateException("Defensive Programming: this should not be possilbe, as the addRule code should init child segments if they are needed ");
+            throw new IllegalStateException(
+                    "Defensive Programming: this should not be possilbe, as the addRule code should init child segments if they are needed ");
         }
 
-        if ( liaMem == null) {
+        if (liaMem == null) {
             memory.getSegmentMemory().getStagedLeftTuples().addInsert(peer);
         } else {
             // If parent is Lian, then this must be called, so that any linking or unlinking can be done.
-            LeftInputAdapterNode.doInsertSegmentMemoryWithFlush(wm, true, liaMem, memory.getSegmentMemory(), peer, node.getLeftTupleSource().isStreamMode());
+            LeftInputAdapterNode.doInsertSegmentMemoryWithFlush(wm, true, liaMem, memory.getSegmentMemory(), peer, node
+                    .getLeftTupleSource().isStreamMode());
         }
 
         return peer;
@@ -992,22 +1060,23 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
     private static void iterateLeftTuple(InternalWorkingMemory wm, TupleImpl lt) {
         if (NodeTypeEnums.isTerminalNode(lt.getSink())) {
-            PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory( lt.getSink());
+            PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(lt.getSink());
             if (pmem != null) {
-                PhreakRuleTerminalNode.doLeftDelete( pmem.getActualActivationsManager( wm ), pmem.getRuleAgendaItem().getRuleExecutor(), (RuleTerminalNodeLeftTuple) lt );
+                PhreakRuleTerminalNode.doLeftDelete(pmem.getActualActivationsManager(wm), pmem.getRuleAgendaItem()
+                        .getRuleExecutor(), (RuleTerminalNodeLeftTuple) lt);
             }
         } else {
             if (lt.getContextObject() instanceof AccumulateContext) {
-                TupleImpl resultLt = (TupleImpl) (( AccumulateContext ) lt.getContextObject()).getResultLeftTuple();
+                TupleImpl resultLt = (TupleImpl) ((AccumulateContext) lt.getContextObject()).getResultLeftTuple();
                 if (resultLt != null) {
-                    iterateLeftTuple( wm, resultLt );
+                    iterateLeftTuple(wm, resultLt);
                 }
             }
             for (TupleImpl child = lt.getFirstChild(); child != null; child = child.getHandleNext()) {
                 for (TupleImpl peer = child; peer != null; peer = peer.getPeer()) {
                     if (peer.getPeer() == null) {
                         // it's unnnecessary to visit the unshared networks, so only iterate the last peer
-                        iterateLeftTuple( wm, peer );
+                        iterateLeftTuple(wm, peer);
                     }
                 }
             }
@@ -1026,76 +1095,9 @@ class LazyPhreakBuilder implements PhreakBuilder {
         // create new segment, starting after split
         LeftTupleNode childNode = splitNode.getSinkPropagator().getFirstLeftTupleSink();
         SegmentMemory sm2 = new SegmentMemory(childNode); // we know there is only one sink
-        wm.getNodeMemories().peekNodeMemory( childNode ).setSegmentMemory( sm2 );
+        wm.getNodeMemories().peekNodeMemory(childNode).setSegmentMemory(sm2);
 
-        // Move the children of sm1 to sm2
-        if (sm1.getFirst() != null) {
-            for (SegmentMemory sm = sm1.getFirst(); sm != null; ) {
-                SegmentMemory next = sm.getNext();
-                sm1.remove(sm);
-                sm2.add(sm);
-                sm = next;
-            }
-        }
-
-        sm1.add(sm2);
-
-        sm2.setPos(sm1.getPos());  // clone for now, it's corrected later
-        sm2.setSegmentPosMaskBit(sm1.getSegmentPosMaskBit()); // clone for now, it's corrected later
-        sm2.setLinkedNodeMask(sm1.getLinkedNodeMask());  // clone for now, it's corrected later
-
-        sm2.mergePathMemories(sm1);
-
-        // re-assigned tip nodes
-        sm2.setTipNode(sm1.getTipNode());
-        sm1.setTipNode(splitNode); // splitNode is now tip of original segment
-
-        if (NodeTypeEnums.isLeftInputAdapterNode(sm1.getTipNode())) {
-            if (!sm1.getStagedLeftTuples().isEmpty()) {
-                // Segments with only LiaNode's cannot have staged LeftTuples, so move them down to the new Segment
-                sm2.getStagedLeftTuples().addAll(sm1.getStagedLeftTuples());
-            }
-        }
-
-        // find the pos of the node in the segment
-        int pos = sm1.nodeSegmentPosition(splitNode);
-
-        
-        sm1.splitNodeMemories(sm2, pos);
-
-        sm1.splitBitMasks(sm2, pos);
-
-        sm2.correctSegmentMemoryAfterSplitOnAdd(1);
-
-        return sm2;
-    }
-
-    private static void mergeSegment(SegmentMemory sm1, SegmentMemory sm2) {
-        if (NodeTypeEnums.isLeftInputAdapterNode(sm1.getTipNode()) && !sm2.getStagedLeftTuples().isEmpty()) {
-            // If a rule has not been linked, lia can still have child segments with staged tuples that did not get flushed
-            // these are safe to just move to the parent SegmentMemory
-            sm1.getStagedLeftTuples().addAll(sm2.getStagedLeftTuples());
-        }
-
-        // sm1 may not be linked yet to sm2 because sm2 has been just created
-        if (sm1.contains(sm2)) {
-            sm1.remove(sm2);
-        }
-
-        if (sm2.getFirst() != null) {
-            for (SegmentMemory sm = sm2.getFirst(); sm != null; ) {
-                SegmentMemory next = sm.getNext();
-                sm2.remove(sm);
-                sm1.add(sm);
-                sm = next;
-            }
-        }
-        // re-assigned tip nodes
-        sm1.setTipNode(sm2.getTipNode());
-
-        sm1.mergeNodeMemories(sm2);
-
-        sm1.mergeBitMasks(sm2);
+        return sm1.splitSegmentOn(sm2, splitNode);
     }
 
     private static PathEndNodeMemories getPathEndMemories(InternalWorkingMemory wm,
@@ -1119,7 +1121,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         tnMems.subjectPmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(pathEndNodes.subjectEndNode);
         if (tnMems.subjectPmem == null && !tnMems.otherPmems.isEmpty()) {
             // If "other pmem's are initialized, then the subject needs to be initialized too.
-            tnMems.subjectPmem = wm.getNodeMemory( pathEndNodes.subjectEndNode);
+            tnMems.subjectPmem = wm.getNodeMemory(pathEndNodes.subjectEndNode);
         }
 
         for (LeftTupleNode node : pathEndNodes.subjectEndNodes) {
@@ -1143,6 +1145,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
     }
 
     private static class PathEndNodeMemories {
+
         PathMemory subjectPmem;
         List<PathMemory> subjectPmems = new ArrayList<>();
         List<PathMemory> otherPmems = new ArrayList<>();
@@ -1163,7 +1166,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
 
         if (hasProtos) {
-            invalidateRootNode( kBase, lt );
+            invalidateRootNode(kBase, lt);
         }
 
         collectPathEndNodes(kBase, lt, endNodes, tn, processedRule, hasProtos, hasWms, hasProtos && isSplit(lt));
@@ -1181,19 +1184,20 @@ class LazyPhreakBuilder implements PhreakBuilder {
                                             boolean isBelowNewSplit) {
         // Traverses the sinks in reverse order in order to collect PathEndNodes so that
         // the outermost (sub)network are evaluated before the innermost one
-        for (LeftTupleSinkNode sink = lt.getSinkPropagator().getLastLeftTupleSink(); sink != null; sink = sink.getPreviousLeftTupleSinkNode()) {
+        for (LeftTupleSinkNode sink = lt.getSinkPropagator().getLastLeftTupleSink(); sink != null; sink = sink
+                .getPreviousLeftTupleSinkNode()) {
             if (sink == tn) {
                 continue;
             }
             if (hasProtos) {
                 if (isBelowNewSplit) {
-                    if ( isRootNode( sink, null )) {
-                        kBase.invalidateSegmentPrototype( sink );
+                    if (isRootNode(sink, null)) {
+                        kBase.invalidateSegmentPrototype(sink);
                     }
                 } else {
                     isBelowNewSplit = isSplit(sink);
                     if (isBelowNewSplit) {
-                        invalidateRootNode( kBase, sink );
+                        invalidateRootNode(kBase, sink);
                     }
                 }
             }
@@ -1208,11 +1212,11 @@ class LazyPhreakBuilder implements PhreakBuilder {
             } else if (NodeTypeEnums.isTerminalNode(sink)) {
                 endNodes.otherEndNodes.add((PathEndNode) sink);
             } else if (NodeTypeEnums.TupleToObjectNode == sink.getType()) {
-                if (sink.isAssociatedWith( processedRule )) {
-                    endNodes.subjectEndNodes.add( (PathEndNode) sink );
+                if (sink.isAssociatedWith(processedRule)) {
+                    endNodes.subjectEndNodes.add((PathEndNode) sink);
                 }
                 if (sink.getAssociatedTerminalsSize() > 1 || !sink.isAssociatedWith(processedRule)) {
-                    endNodes.otherEndNodes.add( (PathEndNode) sink );
+                    endNodes.otherEndNodes.add((PathEndNode) sink);
                 }
             } else {
                 throw new RuntimeException("Error: Unknown Node. Defensive programming test..");
@@ -1221,18 +1225,19 @@ class LazyPhreakBuilder implements PhreakBuilder {
     }
 
     private static void invalidateRootNode(InternalRuleBase kBase, LeftTupleNode lt) {
-        while (!isRootNode( lt, null )) {
+        while (!isRootNode(lt, null)) {
             lt = lt.getLeftTupleSource();
         }
-        kBase.invalidateSegmentPrototype( lt );
+        kBase.invalidateSegmentPrototype(lt);
     }
 
     private static class PathEndNodes {
-        PathEndNode   subjectEndNode;
+
+        PathEndNode subjectEndNode;
         LeftTupleNode subjectSplit;
-        List<PathEndNode>   subjectEndNodes = new ArrayList<>();
-        List<LeftTupleNode> subjectSplits   = new ArrayList<>();
-        List<PathEndNode>   otherEndNodes   = new ArrayList<>();
+        List<PathEndNode> subjectEndNodes = new ArrayList<>();
+        List<LeftTupleNode> subjectSplits = new ArrayList<>();
+        List<PathEndNode> otherEndNodes = new ArrayList<>();
     }
 
     static SegmentMemory createChildSegment(ReteEvaluator reteEvaluator, LeftTupleNode node) {
@@ -1240,7 +1245,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         if (memory.getSegmentMemory() == null) {
             if (NodeTypeEnums.isEndNode(node)) {
                 // RTNS and TupleToObjectNode's have their own segment, if they are the child of a split.
-                createChildSegmentForTerminalNode( node, memory );
+                createChildSegmentForTerminalNode(node, memory);
             } else {
                 createSegmentMemory(reteEvaluator, (LeftTupleSource) node);
             }
@@ -1251,21 +1256,21 @@ class LazyPhreakBuilder implements PhreakBuilder {
     static SegmentMemory createSegmentMemory(ReteEvaluator reteEvaluator, LeftTupleNode segmentRoot) {
         if (NodeTypeEnums.isTerminalNode(segmentRoot)) {
             Memory memory = reteEvaluator.getNodeMemory((MemoryFactory) segmentRoot);
-            return createChildSegmentForTerminalNode(segmentRoot, memory );
+            return createChildSegmentForTerminalNode(segmentRoot, memory);
         }
         return createSegmentMemory(reteEvaluator, (LeftTupleSource) segmentRoot);
     }
 
-    private static SegmentMemory createChildSegmentForTerminalNode( LeftTupleNode node, Memory memory ) {
-        SegmentMemory childSmem = new SegmentMemory( node ); // rtns or TupleToObjectNodes don't need a queue
+    private static SegmentMemory createChildSegmentForTerminalNode(LeftTupleNode node, Memory memory) {
+        SegmentMemory childSmem = new SegmentMemory(node); // rtns or TupleToObjectNodes don't need a queue
         PathMemory pmem = (PathMemory) memory;
 
-        childSmem.setPos( pmem.getSegmentMemories().length - 1 );
+        childSmem.setPos(pmem.getSegmentMemories().length - 1);
         pmem.setSegmentMemory(childSmem);
         RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, childSmem);
 
         childSmem.setTipNode(node);
-        childSmem.setNodeMemories(new Memory[] {memory});
+        childSmem.setNodeMemories(new Memory[]{memory});
         return childSmem;
     }
 
@@ -1277,31 +1282,35 @@ class LazyPhreakBuilder implements PhreakBuilder {
         // allLinkedTestMask is the resulting mask used to test if all nodes are linked in
         long nodePosMask = 1;
         long allLinkedTestMask = 0;
-        boolean updateNodeBit = true;  // nodes after a branch CE can notify, but they cannot impact linking
+        boolean updateNodeBit = true; // nodes after a branch CE can notify, but they cannot impact linking
 
         int nodeTypesInSegment = 0;
         List<Memory> memories = new ArrayList<>();
         while (true) {
             nodeTypesInSegment = updateNodeTypesMask(tupleSource, nodeTypesInSegment);
             if (NodeTypeEnums.isBetaNode(tupleSource)) {
-                allLinkedTestMask = processBetaNode(reteEvaluator, (BetaNode)tupleSource, smem, memories, nodePosMask, allLinkedTestMask, updateNodeBit);
+                allLinkedTestMask = processBetaNode(reteEvaluator, (BetaNode) tupleSource, smem, memories, nodePosMask,
+                        allLinkedTestMask, updateNodeBit);
             } else {
                 switch (tupleSource.getType()) {
                     case NodeTypeEnums.LeftInputAdapterNode:
                     case NodeTypeEnums.AlphaTerminalNode:
-                        allLinkedTestMask = processLiaNode(reteEvaluator, (LeftInputAdapterNode) tupleSource, smem, memories, nodePosMask, allLinkedTestMask);
+                        allLinkedTestMask = processLiaNode(reteEvaluator, (LeftInputAdapterNode) tupleSource, smem,
+                                memories, nodePosMask, allLinkedTestMask);
                         break;
                     case NodeTypeEnums.EvalConditionNode:
                         processEvalNode(reteEvaluator, (EvalConditionNode) tupleSource, smem, memories);
                         break;
                     case NodeTypeEnums.ConditionalBranchNode:
-                        updateNodeBit = processBranchNode(reteEvaluator, (ConditionalBranchNode) tupleSource, smem, memories);
+                        updateNodeBit = processBranchNode(reteEvaluator, (ConditionalBranchNode) tupleSource, smem,
+                                memories);
                         break;
                     case NodeTypeEnums.FromNode:
                         processFromNode(reteEvaluator, (FromNode) tupleSource, smem, memories);
                         break;
                     case NodeTypeEnums.ReactiveFromNode:
-                        processReactiveFromNode(reteEvaluator, (MemoryFactory) tupleSource, smem, memories, nodePosMask);
+                        processReactiveFromNode(reteEvaluator, (MemoryFactory) tupleSource, smem, memories,
+                                nodePosMask);
                         break;
                     case NodeTypeEnums.TimerConditionNode:
                         processTimerNode(reteEvaluator, (TimerNode) tupleSource, smem, memories, nodePosMask);
@@ -1310,10 +1319,12 @@ class LazyPhreakBuilder implements PhreakBuilder {
                         processAsyncSendNode(reteEvaluator, (AsyncSendNode) tupleSource, smem, memories);
                         break;
                     case NodeTypeEnums.AsyncReceiveNode:
-                        processAsyncReceiveNode(reteEvaluator, (AsyncReceiveNode) tupleSource, smem, memories, nodePosMask);
+                        processAsyncReceiveNode(reteEvaluator, (AsyncReceiveNode) tupleSource, smem, memories,
+                                nodePosMask);
                         break;
                     case NodeTypeEnums.QueryElementNode:
-                        updateNodeBit = processQueryNode(reteEvaluator, (QueryElementNode) tupleSource, segmentRoot, smem, memories, nodePosMask);
+                        updateNodeBit = processQueryNode(reteEvaluator, (QueryElementNode) tupleSource, segmentRoot,
+                                smem, memories, nodePosMask);
                         break;
                 }
             }
@@ -1330,18 +1341,18 @@ class LazyPhreakBuilder implements PhreakBuilder {
                     // we don't use createNodeMemory, as these may already have been created by, but not added, by the method updateTupleToObjectAndTerminalMemory
                     Memory memory = reteEvaluator.getNodeMemory((MemoryFactory) sink);
                     if (sink.getType() == NodeTypeEnums.TupleToObjectNode) {
-                        PathMemory subnMem = (SubnetworkPathMemory)memory;
-                        memories.add( subnMem );
+                        PathMemory subnMem = (SubnetworkPathMemory) memory;
+                        memories.add(subnMem);
 
-                        TupleToObjectNode tton  = (TupleToObjectNode) sink;
-                        ObjectSink[]      nodes = tton.getObjectSinkPropagator().getSinks();
-                        for ( ObjectSink node : nodes ) {
-                            if ( NodeTypeEnums.isLeftTupleSource(node) )  {
-                                getOrCreateSegmentMemory( reteEvaluator, (LeftTupleSource) node );
+                        TupleToObjectNode tton = (TupleToObjectNode) sink;
+                        ObjectSink[] nodes = tton.getObjectSinkPropagator().getSinks();
+                        for (ObjectSink node : nodes) {
+                            if (NodeTypeEnums.isLeftTupleSource(node)) {
+                                getOrCreateSegmentMemory(reteEvaluator, (LeftTupleSource) node);
                             }
                         }
                     } else if (NodeTypeEnums.isTerminalNode(sink)) {
-                        memories.add( memory );
+                        memories.add(memory);
                     }
                     memory.setSegmentMemory(smem);
                     smem.setTipNode(sink);
@@ -1384,12 +1395,18 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
         updateSubnetworkAndTerminalMemory(reteEvaluator, tupleSource, tupleSource, smem, false, nodeTypesInSegment);
 
-        reteEvaluator.getKnowledgeBase().registerSegmentPrototype(segmentRoot, smem.getSegmentPrototype().initFromSegmentMemory(smem));
+        reteEvaluator.getKnowledgeBase().registerSegmentPrototype(segmentRoot, smem.getSegmentPrototype()
+                .initFromSegmentMemory(smem));
 
         return smem;
     }
 
-    private static boolean processQueryNode(ReteEvaluator reteEvaluator, QueryElementNode queryNode, LeftTupleSource segmentRoot, SegmentMemory smem, List<Memory> memories, long nodePosMask) {
+    private static boolean processQueryNode(ReteEvaluator reteEvaluator,
+                                            QueryElementNode queryNode,
+                                            LeftTupleSource segmentRoot,
+                                            SegmentMemory smem,
+                                            List<Memory> memories,
+                                            long nodePosMask) {
         // Initialize the QueryElementNode and have it's memory reference the actual query SegmentMemory
         SegmentMemory querySmem = getQuerySegmentMemory(reteEvaluator, queryNode);
         QueryElementNode.QueryElementNodeMemory queryNodeMem = smem.createNodeMemory(queryNode, reteEvaluator);
@@ -1397,36 +1414,53 @@ class LazyPhreakBuilder implements PhreakBuilder {
         queryNodeMem.setQuerySegmentMemory(querySmem);
         queryNodeMem.setSegmentMemory(smem);
         memories.add(queryNodeMem);
-        return ! queryNode.getQueryElement().isAbductive();
+        return !queryNode.getQueryElement().isAbductive();
     }
 
-    private static void processFromNode(ReteEvaluator reteEvaluator, MemoryFactory tupleSource, SegmentMemory smem, List<Memory> memories) {
+    private static void processFromNode(ReteEvaluator reteEvaluator,
+                                        MemoryFactory tupleSource,
+                                        SegmentMemory smem,
+                                        List<Memory> memories) {
         Memory mem = smem.createNodeMemory(tupleSource, reteEvaluator);
         memories.add(mem);
         mem.setSegmentMemory(smem);
     }
 
-    private static void processAsyncSendNode(ReteEvaluator reteEvaluator, MemoryFactory tupleSource, SegmentMemory smem, List<Memory> memories) {
+    private static void processAsyncSendNode(ReteEvaluator reteEvaluator,
+                                             MemoryFactory tupleSource,
+                                             SegmentMemory smem,
+                                             List<Memory> memories) {
         Memory mem = smem.createNodeMemory(tupleSource, reteEvaluator);
         mem.setSegmentMemory(smem);
         memories.add(mem);
     }
 
-    private static void processAsyncReceiveNode(ReteEvaluator reteEvaluator, AsyncReceiveNode tupleSource, SegmentMemory smem, List<Memory> memories, long nodePosMask) {
-        AsyncReceiveNode.AsyncReceiveMemory tnMem = smem.createNodeMemory( tupleSource, reteEvaluator );
+    private static void processAsyncReceiveNode(ReteEvaluator reteEvaluator,
+                                                AsyncReceiveNode tupleSource,
+                                                SegmentMemory smem,
+                                                List<Memory> memories,
+                                                long nodePosMask) {
+        AsyncReceiveNode.AsyncReceiveMemory tnMem = smem.createNodeMemory(tupleSource, reteEvaluator);
         memories.add(tnMem);
         tnMem.setNodePosMaskBit(nodePosMask);
         tnMem.setSegmentMemory(smem);
     }
 
-    private static void processReactiveFromNode(ReteEvaluator reteEvaluator, MemoryFactory tupleSource, SegmentMemory smem, List<Memory> memories, long nodePosMask) {
+    private static void processReactiveFromNode(ReteEvaluator reteEvaluator,
+                                                MemoryFactory tupleSource,
+                                                SegmentMemory smem,
+                                                List<Memory> memories,
+                                                long nodePosMask) {
         FromNode.FromMemory mem = ((FromNode.FromMemory) smem.createNodeMemory(tupleSource, reteEvaluator));
         memories.add(mem);
         mem.setSegmentMemory(smem);
         mem.setNodePosMaskBit(nodePosMask);
     }
 
-    private static boolean processBranchNode(ReteEvaluator reteEvaluator, ConditionalBranchNode tupleSource, SegmentMemory smem, List<Memory> memories) {
+    private static boolean processBranchNode(ReteEvaluator reteEvaluator,
+                                             ConditionalBranchNode tupleSource,
+                                             SegmentMemory smem,
+                                             List<Memory> memories) {
         ConditionalBranchNode.ConditionalBranchMemory branchMem = smem.createNodeMemory(tupleSource, reteEvaluator);
         memories.add(branchMem);
         branchMem.setSegmentMemory(smem);
@@ -1434,20 +1468,32 @@ class LazyPhreakBuilder implements PhreakBuilder {
         return false;
     }
 
-    private static void processEvalNode(ReteEvaluator reteEvaluator, EvalConditionNode tupleSource, SegmentMemory smem, List<Memory> memories) {
+    private static void processEvalNode(ReteEvaluator reteEvaluator,
+                                        EvalConditionNode tupleSource,
+                                        SegmentMemory smem,
+                                        List<Memory> memories) {
         EvalConditionNode.EvalMemory evalMem = smem.createNodeMemory(tupleSource, reteEvaluator);
         memories.add(evalMem);
         evalMem.setSegmentMemory(smem);
     }
 
-    private static void processTimerNode(ReteEvaluator reteEvaluator, TimerNode tupleSource, SegmentMemory smem, List<Memory> memories, long nodePosMask) {
-        TimerNode.TimerNodeMemory tnMem = smem.createNodeMemory( tupleSource, reteEvaluator );
+    private static void processTimerNode(ReteEvaluator reteEvaluator,
+                                         TimerNode tupleSource,
+                                         SegmentMemory smem,
+                                         List<Memory> memories,
+                                         long nodePosMask) {
+        TimerNode.TimerNodeMemory tnMem = smem.createNodeMemory(tupleSource, reteEvaluator);
         memories.add(tnMem);
         tnMem.setNodePosMaskBit(nodePosMask);
         tnMem.setSegmentMemory(smem);
     }
 
-    private static long processLiaNode(ReteEvaluator reteEvaluator, LeftInputAdapterNode tupleSource, SegmentMemory smem, List<Memory> memories, long nodePosMask, long allLinkedTestMask) {
+    private static long processLiaNode(ReteEvaluator reteEvaluator,
+                                       LeftInputAdapterNode tupleSource,
+                                       SegmentMemory smem,
+                                       List<Memory> memories,
+                                       long nodePosMask,
+                                       long allLinkedTestMask) {
         LeftInputAdapterNode.LiaNodeMemory liaMemory = smem.createNodeMemory(tupleSource, reteEvaluator);
         memories.add(liaMemory);
         liaMemory.setSegmentMemory(smem);
@@ -1456,10 +1502,17 @@ class LazyPhreakBuilder implements PhreakBuilder {
         return allLinkedTestMask;
     }
 
-    private static long processBetaNode(ReteEvaluator reteEvaluator, BetaNode betaNode, SegmentMemory smem, List<Memory> memories, long nodePosMask, long allLinkedTestMask, boolean updateNodeBit) {
+    private static long processBetaNode(ReteEvaluator reteEvaluator,
+                                        BetaNode betaNode,
+                                        SegmentMemory smem,
+                                        List<Memory> memories,
+                                        long nodePosMask,
+                                        long allLinkedTestMask,
+                                        boolean updateNodeBit) {
         BetaMemory bm;
         if (NodeTypeEnums.AccumulateNode == betaNode.getType()) {
-            AccumulateNode.AccumulateMemory accMemory = ((AccumulateNode.AccumulateMemory) smem.createNodeMemory(betaNode, reteEvaluator));
+            AccumulateNode.AccumulateMemory accMemory = ((AccumulateNode.AccumulateMemory) smem.createNodeMemory(
+                    betaNode, reteEvaluator));
             memories.add(accMemory);
             accMemory.setSegmentMemory(smem);
 
@@ -1516,7 +1569,8 @@ class LazyPhreakBuilder implements PhreakBuilder {
         PathMemory pmem = null;
         for (LeftTupleSink sink : lt.getSinkPropagator().getSinks()) {
             if (NodeTypeEnums.isLeftTupleSource(sink)) {
-                nodeTypesInSegment = updateSubnetworkAndTerminalMemory(reteEvaluator, (LeftTupleSource) sink, originalLt, smem, fromPrototype, nodeTypesInSegment);
+                nodeTypesInSegment = updateSubnetworkAndTerminalMemory(reteEvaluator, (LeftTupleSource) sink,
+                        originalLt, smem, fromPrototype, nodeTypesInSegment);
             } else if (sink.getType() == NodeTypeEnums.TupleToObjectNode) {
                 // Even though we don't add the pmem and smem together, all pmem's for all pathend nodes must be initialized
                 SubnetworkPathMemory subnMem = (SubnetworkPathMemory) reteEvaluator.getNodeMemory((MemoryFactory) sink);
@@ -1526,18 +1580,19 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
                     if (fromPrototype) {
                         ObjectSink[] nodes = ((TupleToObjectNode) sink).getObjectSinkPropagator().getSinks();
-                        for ( ObjectSink node : nodes ) {
+                        for (ObjectSink node : nodes) {
                             // check if the SegmentMemory has been already created by the BetaNode and if so avoid to build it twice
-                            if ( NodeTypeEnums.isLeftTupleSource(node) && reteEvaluator.getNodeMemory((MemoryFactory) node).getSegmentMemory() == null )  {
+                            if (NodeTypeEnums.isLeftTupleSource(node) && reteEvaluator.getNodeMemory(
+                                    (MemoryFactory) node).getSegmentMemory() == null) {
                                 restoreSegmentFromPrototype(reteEvaluator, (LeftTupleSource) node, nodeTypesInSegment);
                             }
                         }
-                    } else if ( ( pmem.getAllLinkedMaskTest() & ( 1L << pmem.getSegmentMemories().length ) ) == 0 ) {
+                    } else if ((pmem.getAllLinkedMaskTest() & (1L << pmem.getSegmentMemories().length)) == 0) {
                         // must eagerly initialize child segment memories
                         ObjectSink[] nodes = ((TupleToObjectNode) sink).getObjectSinkPropagator().getSinks();
-                        for ( ObjectSink node : nodes ) {
-                            if ( NodeTypeEnums.isLeftTupleSource(node) )  {
-                                getOrCreateSegmentMemory( reteEvaluator, (LeftTupleSource) node );
+                        for (ObjectSink node : nodes) {
+                            if (NodeTypeEnums.isLeftTupleSource(node)) {
+                                getOrCreateSegmentMemory(reteEvaluator, (LeftTupleSource) node);
                             }
                         }
                     }
@@ -1560,22 +1615,23 @@ class LazyPhreakBuilder implements PhreakBuilder {
         return nodeTypesInSegment;
     }
 
-    private static void restoreSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleSource segmentRoot, int nodeTypesInSegment) {
+    private static void restoreSegmentFromPrototype(ReteEvaluator reteEvaluator,
+                                                    LeftTupleSource segmentRoot,
+                                                    int nodeTypesInSegment) {
         SegmentMemory smem = reteEvaluator.getKnowledgeBase().createSegmentFromPrototype(reteEvaluator, segmentRoot);
-        if ( smem != null ) {
+        if (smem != null) {
             updateSubnetworkAndTerminalMemory(reteEvaluator, segmentRoot, segmentRoot, smem, true, nodeTypesInSegment);
         }
     }
 
     private static int checkSegmentBoundary(ReteEvaluator reteEvaluator, LeftTupleSource lt, int nodeTypesInSegment) {
-        if ( isRootNode( lt, null ) )  {
+        if (isRootNode(lt, null)) {
             // we are in a new child segment
             checkEagerSegmentCreation(reteEvaluator, lt.getLeftTupleSource(), nodeTypesInSegment);
             nodeTypesInSegment = 0;
         }
         return updateNodeTypesMask(lt, nodeTypesInSegment);
     }
-
 
     /**
      * Is the LeftTupleSource a node in the sub network for the RightInputAdapterNode
@@ -1596,11 +1652,13 @@ class LazyPhreakBuilder implements PhreakBuilder {
         return false;
     }
 
-    public static void checkEagerSegmentCreation(ReteEvaluator reteEvaluator, LeftTupleSource lt, int nodeTypesInSegment) {
+    public static void checkEagerSegmentCreation(ReteEvaluator reteEvaluator,
+                                                 LeftTupleSource lt,
+                                                 int nodeTypesInSegment) {
         // A Not node has to be eagerly initialized unless in its segment there is at least a join node
-        if ( isSet(nodeTypesInSegment, NOT_NODE_BIT) &&
-                !isSet(nodeTypesInSegment, JOIN_NODE_BIT) &&
-                !isSet(nodeTypesInSegment, REACTIVE_EXISTS_NODE_BIT) ) {
+        if (isSet(nodeTypesInSegment, NOT_NODE_BIT) &&
+            !isSet(nodeTypesInSegment, JOIN_NODE_BIT) &&
+            !isSet(nodeTypesInSegment, REACTIVE_EXISTS_NODE_BIT)) {
             getOrCreateSegmentMemory(reteEvaluator, lt);
         }
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -652,7 +652,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                             if (!childSmem.getStagedLeftTuples().isEmpty()) {
                                 PathMemory childPmem = childSmem.getPathMemories().get(0);
                                 flushed.add(new Flushed(childPmem, childSmem));
-                                forceFlushLeftTuple(childPmem, childSmem, wm, childSmem.getStagedLeftTuples()
+                                forceFlushLeftTuple(wm, childPmem, childSmem, childSmem.getStagedLeftTuples()
                                         .takeAll());
                             }
                         }
@@ -667,7 +667,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
             for (Flushed path : flushed) {
                 if (!path.segmentMemory.getStagedLeftTuples().isEmpty()) {
                     flushCount++;
-                    forceFlushLeftTuple(pmem, path.segmentMemory, wm, path.segmentMemory.getStagedLeftTuples()
+                    forceFlushLeftTuple(wm, pmem, path.segmentMemory, path.segmentMemory.getStagedLeftTuples()
                             .takeAll());
                 }
             }
@@ -700,7 +700,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
         if (smemIndex < length) {
             // it only found a SM that needed flushing, if smemIndex < length
-            forceFlushLeftTuple(pmem, sm, wm, sm.getStagedLeftTuples().takeAll());
+            forceFlushLeftTuple(wm, pmem, sm, sm.getStagedLeftTuples().takeAll());
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBuilder.java
@@ -36,8 +36,8 @@ public interface PhreakBuilder {
         return Holder.EAGER_SEGMENT_CREATION;
     }
 
-    void addRule(TerminalNode tn, Collection<InternalWorkingMemory> wms, InternalRuleBase kBase);
-    void removeRule(TerminalNode tn, Collection<InternalWorkingMemory> wms, InternalRuleBase kBase);
+    void addRule(InternalRuleBase kBase, Collection<InternalWorkingMemory> wms, TerminalNode tn);
+    void removeRule(InternalRuleBase kBase, Collection<InternalWorkingMemory> wms, TerminalNode tn);
 
     class Holder {
         private static final boolean EAGER_SEGMENT_CREATION = Boolean.parseBoolean(getConfig("drools.useEagerSegmentCreation", "true"));

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -537,6 +537,7 @@ public class RuleNetworkEvaluator {
                                  TupleSets srcTuples,
                                  TupleSets stagedLeftTuples,
                                  boolean processSubnetwork) {
+
         BetaNode betaNode = (BetaNode) node;
         BetaMemory bm;
         AccumulateMemory am = null;

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -537,7 +537,6 @@ public class RuleNetworkEvaluator {
                                  TupleSets srcTuples,
                                  TupleSets stagedLeftTuples,
                                  boolean processSubnetwork) {
-
         BetaNode betaNode = (BetaNode) node;
         BetaMemory bm;
         AccumulateMemory am = null;

--- a/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
@@ -48,15 +48,18 @@ public class RuntimeSegmentUtilities {
      * Initialises the NodeSegment memory for all nodes in the segment.
      */
     public static SegmentMemory getOrCreateSegmentMemory(ReteEvaluator reteEvaluator, LeftTupleNode node) {
-        return getOrCreateSegmentMemory(reteEvaluator, node, reteEvaluator.getNodeMemory((MemoryFactory<? extends Memory>) node));
+        return getOrCreateSegmentMemory(reteEvaluator, node, reteEvaluator.getNodeMemory(
+                (MemoryFactory<? extends Memory>) node));
     }
 
     /**
      * Initialises the NodeSegment memory for all nodes in the segment.
      */
-    public static SegmentMemory getOrCreateSegmentMemory(ReteEvaluator reteEvaluator, LeftTupleNode node, Memory memory) {
+    public static SegmentMemory getOrCreateSegmentMemory(ReteEvaluator reteEvaluator,
+                                                         LeftTupleNode node,
+                                                         Memory memory) {
         SegmentMemory smem = memory.getSegmentMemory();
-        if ( smem != null ) {
+        if (smem != null) {
             return smem;
         }
 
@@ -64,7 +67,7 @@ public class RuntimeSegmentUtilities {
         LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(node);
 
         smem = restoreSegmentFromPrototype(reteEvaluator, segmentRoot);
-        if ( smem != null ) {
+        if (smem != null) {
             if (NodeTypeEnums.isBetaNode(segmentRoot) && segmentRoot.inputIsTupleToObjectNode()) {
                 createSubnetworkSegmentMemory(reteEvaluator, (BetaNode) segmentRoot);
             }
@@ -81,7 +84,7 @@ public class RuntimeSegmentUtilities {
             return null;
         }
 
-        LeftTupleNode lastNode = proto.getNodesInSegment()[proto.getNodesInSegment().length-1];
+        LeftTupleNode lastNode = proto.getNodesInSegment()[proto.getNodesInSegment().length - 1];
 
         if (NodeTypeEnums.isTerminalNode(lastNode)) {
             // If the last node is a tn and it's pmem does not exist, instantiate it separately to avoid a recursive smem/pmem creation.
@@ -120,7 +123,7 @@ public class RuntimeSegmentUtilities {
 
         LeftTupleSource subnetworkLts = tton.getStartTupleSource();
 
-        Memory rootSubNetwokrMem = reteEvaluator.getNodeMemory( (MemoryFactory) subnetworkLts );
+        Memory rootSubNetwokrMem = reteEvaluator.getNodeMemory((MemoryFactory) subnetworkLts);
         SegmentMemory subNetworkSegmentMemory = rootSubNetwokrMem.getSegmentMemory();
         if (subNetworkSegmentMemory == null) {
             // we need to stop recursion here
@@ -129,14 +132,16 @@ public class RuntimeSegmentUtilities {
         return tton;
     }
 
-    public static void createChildSegments(ReteEvaluator reteEvaluator, LeftTupleSinkPropagator sinkProp, SegmentMemory smem) {
-        if ( !smem.isEmpty() ) {
-              return; // this can happen when multiple threads are trying to initialize the segment
+    public static void createChildSegments(ReteEvaluator reteEvaluator,
+                                           LeftTupleSinkPropagator sinkProp,
+                                           SegmentMemory smem) {
+        if (!smem.isEmpty()) {
+            return; // this can happen when multiple threads are trying to initialize the segment
         }
-        for (LeftTupleSinkNode sink = sinkProp.getFirstLeftTupleSink(); sink != null; sink = sink.getNextLeftTupleSinkNode()) {
-            SegmentMemory childSmem = PhreakBuilder.isEagerSegmentCreation() ?
-                    createChildSegment(reteEvaluator, sink) :
-                    LazyPhreakBuilder.createChildSegment(reteEvaluator, sink);
+        for (LeftTupleSinkNode sink = sinkProp.getFirstLeftTupleSink(); sink != null; sink = sink
+                .getNextLeftTupleSinkNode()) {
+            SegmentMemory childSmem = PhreakBuilder.isEagerSegmentCreation() ? createChildSegment(reteEvaluator, sink)
+                    : LazyPhreakBuilder.createChildSegment(reteEvaluator, sink);
             smem.add(childSmem);
         }
     }
@@ -171,9 +176,10 @@ public class RuntimeSegmentUtilities {
             if (pmem != null) {
                 RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem);
             } else {
-                pmem = reteEvaluator.getNodeMemories().getNodeMemory((MemoryFactory<? extends PathMemory>) endNode, reteEvaluator);
-                RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem);  // this needs to be set before init, to avoid recursion during eager segment initialisation
-                pmem.setSegmentMemory( smem.getPos(), smem );
+                pmem = reteEvaluator.getNodeMemories().getNodeMemory((MemoryFactory<? extends PathMemory>) endNode,
+                        reteEvaluator);
+                RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem); // this needs to be set before init, to avoid recursion during eager segment initialisation
+                pmem.setSegmentMemory(smem.getPos(), smem);
                 initializePathMemory(reteEvaluator, endNode, pmem);
             }
 
@@ -201,7 +207,7 @@ public class RuntimeSegmentUtilities {
     public static void initializePathMemory(ReteEvaluator reteEvaluator, PathEndNode pathEndNode, PathMemory pmem) {
         if (pathEndNode.getEagerSegmentPrototypes() != null) {
             for (SegmentPrototype eager : pathEndNode.getEagerSegmentPrototypes()) {
-                if ( pmem.getSegmentMemories()[eager.getPos()] == null) {
+                if (pmem.getSegmentMemories()[eager.getPos()] == null) {
                     getOrCreateSegmentMemory(reteEvaluator, eager.getRootNode());
                 }
             }

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentPropagator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentPropagator.java
@@ -59,7 +59,7 @@ public class SegmentPropagator {
                     // skip flushing segments that have only inserts staged and the path is not linked
                     continue;
                 }
-                forceFlushLeftTuple(dataDrivenPmem, smem, reteEvaluator, smem.getStagedLeftTuples());
+                forceFlushLeftTuple(reteEvaluator, dataDrivenPmem, smem, smem.getStagedLeftTuples());
                 forceFlushWhenSubnetwork(reteEvaluator, dataDrivenPmem);
             }
         }

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -245,7 +245,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
     public static List<PathMemory> doInsertSegmentMemory(ReteEvaluator reteEvaluator, boolean linkOrNotify, LiaNodeMemory lm, SegmentMemory sm, TupleImpl leftTuple, boolean streamMode) {
         PathMemory pmem = findPathToFlush(sm, leftTuple, streamMode);
         if ( pmem != null ) {
-            forceFlushLeftTuple( pmem, sm, reteEvaluator, createLeftTupleTupleSets(leftTuple, Tuple.INSERT) );
+            forceFlushLeftTuple( reteEvaluator, pmem, sm, createLeftTupleTupleSets(leftTuple, Tuple.INSERT) );
             if ( linkOrNotify ) {
                 lm.setNodeDirty( reteEvaluator );
             }

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSource.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSource.java
@@ -195,7 +195,7 @@ public abstract class LeftTupleSource extends BaseNode implements LeftTupleNode 
         }
 
         for ( LeftTupleSink sink : this.sink.getSinks()) {
-            if ( !BuildtimeSegmentUtilities.sinkNotExclusivelyAssociatedWithTerminal(removingTn, sink)) {
+            if ( !BuildtimeSegmentUtilities.sinkNotExclusivelyAssociatedWithTerminal(sink, removingTn)) {
                 // skip this node as it's being removed;
                 continue;
             }

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
@@ -104,7 +104,7 @@ public class ReteooBuilder
      * @throws InvalidPatternException
      */
     public synchronized List<TerminalNode> addRule(final RuleImpl rule, Collection<InternalWorkingMemory> workingMemories) {
-        final List<TerminalNode> terminals = this.ruleBuilder.addRule( rule, this.kBase, workingMemories );
+        final List<TerminalNode> terminals = this.ruleBuilder.addRule( this.kBase, workingMemories, rule );
 
         TerminalNode[] nodes = terminals.toArray( new TerminalNode[terminals.size()] );
         this.rules.put( rule.getFullyQualifiedName(), nodes );
@@ -116,11 +116,11 @@ public class ReteooBuilder
     }
 
     public void addEntryPoint( String id, Collection<InternalWorkingMemory> workingMemories ) {
-        this.ruleBuilder.addEntryPoint( id, this.kBase, workingMemories );
+        this.ruleBuilder.addEntryPoint( this.kBase, workingMemories, id );
     }
 
     public synchronized void addNamedWindow( WindowDeclaration window, Collection<InternalWorkingMemory> workingMemories ) {
-        final WindowNode wnode = this.ruleBuilder.addWindowNode( window, this.kBase, workingMemories );
+        final WindowNode wnode = this.ruleBuilder.addWindowNode( this.kBase, workingMemories, window );
 
         this.namedWindows.put( window.getName(), wnode );
     }
@@ -188,7 +188,7 @@ public class ReteooBuilder
 
     public void removeTerminalNode(RuleRemovalContext context, TerminalNode tn, Collection<InternalWorkingMemory> workingMemories)  {
         context.setSubRuleIndex(tn.getSubruleIndex());
-        PhreakBuilder.get().removeRule( tn, workingMemories, kBase );
+        PhreakBuilder.get().removeRule( kBase, workingMemories, tn );
 
         tn.visitLeftTupleNodes(n -> n.removeAssociatedTerminal(tn));
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleBuilder.java
@@ -29,9 +29,9 @@ import org.drools.core.impl.InternalRuleBase;
 
 public interface RuleBuilder {
 
-    List<TerminalNode> addRule(RuleImpl rule, InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories);
+    List<TerminalNode> addRule(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, RuleImpl rule);
 
-    void addEntryPoint(String id, InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories);
+    void addEntryPoint(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, String id);
 
-    WindowNode addWindowNode(WindowDeclaration window, InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories);
+    WindowNode addWindowNode(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, WindowDeclaration window);
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
@@ -101,16 +101,15 @@ public class ReteooRuleBuilder implements RuleBuilder {
     /**
      * Creates the corresponting Rete network for the given <code>Rule</code> and adds it to
      * the given rule base.
-     * 
-     * @param rule
-     *            The rule to add.
      * @param kBase
      *            The rulebase to add the rule to.
-     *            
+     * @param rule
+     *            The rule to add.
+     * 
      * @return a List<BaseNode> of terminal nodes for the rule             
      * @throws InvalidPatternException
      */
-    public List<TerminalNode> addRule(RuleImpl rule, InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories) throws InvalidPatternException {
+    public List<TerminalNode> addRule(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, RuleImpl rule) throws InvalidPatternException {
 
         // the list of terminal nodes
         final List<TerminalNode> termNodes = new ArrayList<>();
@@ -219,7 +218,7 @@ public class ReteooRuleBuilder implements RuleBuilder {
 
         if (!PhreakBuilder.isEagerSegmentCreation() || context.getRuleBase().hasSegmentPrototypes()) {
             // only need to process this, if segment protos exist
-            PhreakBuilder.get().addRule(terminalNode, context.getWorkingMemories(), context.getRuleBase());
+            PhreakBuilder.get().addRule(context.getRuleBase(), context.getWorkingMemories(), terminalNode);
         }
     }
 
@@ -256,7 +255,7 @@ public class ReteooRuleBuilder implements RuleBuilder {
                           pattern );
     }
 
-    public void addEntryPoint(final String id, final InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories) {
+    public void addEntryPoint(final InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, final String id) {
         // creates a clean build context for each subrule
         final BuildContext context = new BuildContext( kBase, workingMemories );
         EntryPointId ep = new EntryPointId( id );
@@ -264,7 +263,7 @@ public class ReteooRuleBuilder implements RuleBuilder {
         builder.build(context, utils, ep);
     }
 
-    public WindowNode addWindowNode(WindowDeclaration window, InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories) {
+    public WindowNode addWindowNode(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, WindowDeclaration window) {
 
         // creates a clean build context for each subrule
         BuildContext context = new BuildContext( kBase, workingMemories );

--- a/drools-core/src/test/java/org/drools/core/reteoo/builder/ReteooRuleBuilderTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/builder/ReteooRuleBuilderTest.java
@@ -92,7 +92,7 @@ public class ReteooRuleBuilderTest {
 
         rule.setConsequence( consequence );
 
-        final List terminals = this.builder.addRule( rule, this.rulebase, Collections.emptyList() );
+        final List terminals = this.builder.addRule( this.rulebase, Collections.emptyList(), rule );
 
         assertThat(terminals.size()).as("Rule must have a single terminal node").isEqualTo(1);
 

--- a/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
@@ -198,7 +198,7 @@ public class NodeSegmentUnlinkingTest {
         for (TerminalNode tn : new TerminalNode[] {rtn1, rtn2, rtn3}) {
             tn.setPathEndNodes( new PathEndNode[] {tn});
             tn.resetPathMemSpec(null);
-            BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
         }
     }
 
@@ -254,13 +254,13 @@ public class NodeSegmentUnlinkingTest {
         n5.attach(buildContext);
 
         StatefulKnowledgeSessionImpl ksession = (StatefulKnowledgeSessionImpl)kBase.newKieSession();
-        SegmentPrototype[] protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(n3, null, kBase);
+        SegmentPrototype[] protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(kBase, n3, null);
         Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
 
-        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(n4, null, kBase);
+        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(kBase, n4, null);
         Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
 
-        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(n5, null, kBase);
+        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(kBase, n5, null);
         Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
         createSegmentMemory( n2, ksession );
 

--- a/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingTest.java
@@ -194,7 +194,7 @@ public class RuleUnlinkingTest {
         for (TerminalNode tn : new TerminalNode[] {rtn1, rtn2, rtn3}) {
             tn.setPathEndNodes( new PathEndNode[] {tn});
             tn.resetPathMemSpec(null);
-            BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
         }
         
     }
@@ -381,7 +381,7 @@ public class RuleUnlinkingTest {
         for (TerminalNode tn : new TerminalNode[] {rtn1, rtn2, rtn3}) {
             tn.setPathEndNodes( new PathEndNode[] {tn});
             tn.resetPathMemSpec(null);
-            BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
         }
     }
 

--- a/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingWithSegmentMemoryTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingWithSegmentMemoryTest.java
@@ -191,7 +191,7 @@ public class RuleUnlinkingWithSegmentMemoryTest {
         for (TerminalNode tn : new TerminalNode[] {rtn1, rtn2, rtn3}) {
             tn.setPathEndNodes( new PathEndNode[] {tn});
             tn.resetPathMemSpec(null);
-            BuildtimeSegmentUtilities.createPathProtoMemories(tn, null, kBase);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
         }
     }
     

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
@@ -113,7 +113,7 @@ public class AddRuleTest {
         assertThat(smemProto0.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT);
 
         SegmentPrototype[] oldSmemProtos = endNode.getSegmentPrototypes();
-        SegmentPrototype smemProto1 = Add.processSplit(cbeta, kbase1, Collections.singletonList(wm), new HashSet<>());
+        SegmentPrototype smemProto1 = Add.processSplit(kbase1, Collections.singletonList(wm), cbeta, new HashSet<>());
 
         assertSegmentsLengthAndPos(endNode, 2, oldSmemProtos, smemProto1, wm);
         assertThat(endNode.getSegmentPrototypes()[0]).isSameAs(smemProto0);
@@ -161,7 +161,7 @@ public class AddRuleTest {
         assertThat(smemProto0.getAllLinkedMaskTest()).isEqualTo(31);
         assertThat(smemProto0.getLinkedNodeMask()).isEqualTo(10); // nots must be linked in
         assertThat(smemProto0.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT | BuildtimeSegmentUtilities.NOT_NODE_BIT);
-        SegmentPrototype smemProto1 = Add.processSplit(cbeta, kbase1, Collections.singletonList(wm), new HashSet<>());
+        SegmentPrototype smemProto1 = Add.processSplit(kbase1, Collections.singletonList(wm), cbeta, new HashSet<>());
 
         assertThat(smemProto0.getAllLinkedMaskTest()).isEqualTo(7);
         assertThat(smemProto0.getLinkedNodeMask()).isEqualTo(2);
@@ -207,7 +207,7 @@ public class AddRuleTest {
         assertThat(smemProtoX.getPos()).isEqualTo(1);
 
         SegmentPrototype[] oldSmemProtos = endNode1.getSegmentPrototypes();
-        SegmentPrototype smemProtoE2 = Add.processSplit(ebeta3, kbase1, Collections.singletonList(wm), new HashSet<>());
+        SegmentPrototype smemProtoE2 = Add.processSplit(kbase1, Collections.singletonList(wm), ebeta3, new HashSet<>());
         assertSegmentsLengthAndPos(endNode0, 3, wm);
         assertSegmentsLengthAndPos(endNode1, 2, oldSmemProtos, smemProtoE2, wm);
 
@@ -262,7 +262,7 @@ public class AddRuleTest {
         assertSegmentsLengthAndPos(endNode1, 2, wm);
 
         // processSplit should return null, as it's alreayd split and this does nothing.
-        assertThat(Add.processSplit(cbeta, kbase1, Collections.singletonList(wm), new HashSet<>())).isNull();
+        assertThat(Add.processSplit(kbase1, Collections.singletonList(wm), cbeta, new HashSet<>())).isNull();
 
         // now add a rule at the given split, so we can check paths were all updated correctly
         addRuleAtGivenSplit(kbase1, wm, cbeta, yotn);
@@ -295,7 +295,7 @@ public class AddRuleTest {
         rtn.setPathEndNodes(new PathEndNode[]{rtn});
         rtn.doAttach(buildContext);
         Arrays.stream(rtn.getPathNodes()).forEach( n -> {n.addAssociatedTerminal(rtn); ((BaseNode)n).addAssociation(rule, null);});
-        new EagerPhreakBuilder().addRule(rtn, Collections.singletonList(wm), kbase1);
+        new EagerPhreakBuilder().addRule(kbase1, Collections.singletonList(wm), rtn);
     }
 
     @ParameterizedTest(name = "KieBase type={0}")
@@ -330,7 +330,7 @@ public class AddRuleTest {
         assertThat(smemProtoEV.getAllLinkedMaskTest()).isEqualTo(12); // first two are evals, so each is 0
 
         SegmentPrototype[] oldSmemProtos = endNode1.getSegmentPrototypes();
-        SegmentPrototype smemProtoE4 = Add.processSplit(ebeta3, kbase1, Collections.singletonList(wm), new HashSet<>());
+        SegmentPrototype smemProtoE4 = Add.processSplit(kbase1, Collections.singletonList(wm), ebeta3, new HashSet<>());
 
         assertSegmentsLengthAndPos(endNode1, 2, oldSmemProtos, smemProtoE4, wm);
 
@@ -369,7 +369,7 @@ public class AddRuleTest {
         assertSegmentsLengthAndPos(endNode0, 3, wm);
 
         SegmentPrototype[] oldSmemProtos = endNode0.getSegmentPrototypes();
-        SegmentPrototype smemProto1 = Add.processSplit(bbeta, kbase1, Collections.singletonList(wm), new HashSet<>());
+        SegmentPrototype smemProto1 = Add.processSplit(kbase1, Collections.singletonList(wm), bbeta, new HashSet<>());
 
         assertSegmentsLengthAndPos(endNode0, 4, oldSmemProtos, smemProto1, wm);
         assertThat(endNode0.getPathMemSpec().allLinkedTestMask()).isEqualTo(15);


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

More progress in the cleanup of the drl engine code. This is mostly related to phreak code.

- I have moved a number of statich methods to SegmentMemory and SegmentPrototype. This has made the code cleaner
- I have reordered the parameters in a number of methods following a more sensible approach - namely first global objects like RuleBase, ReteEvaluator and the likes, then Path/Segment memories, then nodes, then tuples, and finally flags. It was not always clean and easy to do, so you will find possibly still something not perfect, but still.
- I have reformetted the code with the drools formatter. Code is now a bit cleaner and more uniform as you look at it.

@mariofusco please can you look at org.drools.core.reteoo.SegmentMemory.mergeBitMasks(SegmentMemory). The code is copy pasted from the corresponding code in LazyPhreakBuilder, but it seems wrong.
