### PR TITLE
[incubator-kie-issues #203] Cleanup Phreak code - Make ConcurrentNodeMemories use ReteEvaluator internally

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/NodeMemories.java
+++ b/drools-core/src/main/java/org/drools/core/common/NodeMemories.java
@@ -21,14 +21,13 @@ package org.drools.core.common;
 
 import org.drools.base.common.NetworkNode;
 import org.drools.base.reteoo.NodeTypeEnums;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 /**
  * An interface for node memories implementation
  */
 public interface NodeMemories {
 
-    <T extends Memory> T getNodeMemory(MemoryFactory<T> node, ReteEvaluator reteEvaluator);
+    <T extends Memory> T getNodeMemory(MemoryFactory<T> node);
 
     void clearNodeMemory( MemoryFactory node );
 
@@ -56,5 +55,5 @@ public interface NodeMemories {
      */
     int length();
 
-    void resetAllMemories(StatefulKnowledgeSession session);
+    void resetAllMemories();
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
@@ -176,8 +176,7 @@ public class RuntimeSegmentUtilities {
             if (pmem != null) {
                 RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem);
             } else {
-                pmem = reteEvaluator.getNodeMemories().getNodeMemory((MemoryFactory<? extends PathMemory>) endNode,
-                        reteEvaluator);
+                pmem = reteEvaluator.getNodeMemories().getNodeMemory((MemoryFactory<? extends PathMemory>) endNode);
                 RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem); // this needs to be set before init, to avoid recursion during eager segment initialisation
                 pmem.setSegmentMemory(smem.getPos(), smem);
                 initializePathMemory(reteEvaluator, endNode, pmem);
@@ -199,7 +198,7 @@ public class RuntimeSegmentUtilities {
     }
 
     public static PathMemory initializePathMemory(ReteEvaluator reteEvaluator, PathEndNode pathEndNode) {
-        PathMemory pmem = reteEvaluator.getNodeMemories().getNodeMemory(pathEndNode, reteEvaluator);
+        PathMemory pmem = reteEvaluator.getNodeMemories().getNodeMemory(pathEndNode);
         initializePathMemory(reteEvaluator, pathEndNode, pmem);
         return pmem;
     }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -335,7 +335,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         this.lastIdleTimestamp = new AtomicLong(-1);
 
-        this.nodeMemories = new ConcurrentNodeMemories(kBase);
+        this.nodeMemories = new ConcurrentNodeMemories(kBase, this);
         registerReceiveNodes(kBase.getReceiveNodes());
 
         RuleBaseConfiguration conf = kBase.getRuleBaseConfiguration();
@@ -836,7 +836,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
     public void reset() {
         if (nodeMemories != null) {
-            nodeMemories.resetAllMemories( this );
+            nodeMemories.resetAllMemories();
         }
 
         this.agenda.reset();
@@ -1340,7 +1340,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
      * @return The node's memory.
      */
     public <T extends Memory> T getNodeMemory(MemoryFactory<T> node) {
-        return nodeMemories.getNodeMemory( node, this );
+        return nodeMemories.getNodeMemory( node );
     }
 
     public void clearNodeMemory(final MemoryFactory node) {

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
@@ -127,7 +127,7 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
         this.sessionConfiguration = sessionConfiguration;
 
         this.handleFactory = knowledgeBase.newFactHandleFactory();
-        this.nodeMemories = new ConcurrentNodeMemories(ruleBase);
+        this.nodeMemories = new ConcurrentNodeMemories(ruleBase, this);
 
         this.activationsManager = new ActivationsManagerImpl(ruleBase, this, handleFactory);
         this.entryPointsManager = RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(ruleBase, this, handleFactory);
@@ -181,7 +181,7 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
 
     @Override
     public <T extends Memory> T getNodeMemory(MemoryFactory<T> node) {
-        return nodeMemories.getNodeMemory( node, this );
+        return nodeMemories.getNodeMemory( node );
     }
 
     @Override

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
@@ -206,7 +206,7 @@ public class NotTest {
 
         StatefulKnowledgeSessionImpl ksessionImpl = (StatefulKnowledgeSessionImpl) ksession;
         NodeMemories                 nodeMemories = ksessionImpl.getNodeMemories();
-        BetaMemory                   betaMemory = (BetaMemory) nodeMemories.getNodeMemory(notNode, ksessionImpl);
+        BetaMemory                   betaMemory = (BetaMemory) nodeMemories.getNodeMemory(notNode);
         TupleMemory                  rightTupleMemory = betaMemory.getRightTupleMemory();
 
         FastIterator<TupleImpl> it = rightTupleMemory.fullFastIterator();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
@@ -153,7 +153,7 @@ public class AddRuleTest {
 
         insertAndFlush(wm);
 
-        SegmentMemory smemLian = wm.getNodeMemories().getNodeMemory(lian, wm).getSegmentMemory();
+        SegmentMemory smemLian = wm.getNodeMemories().getNodeMemory(lian).getSegmentMemory();
         SegmentPrototype smemProto0 = kbase1.getSegmentPrototype(lian);
         assertThat(smemLian.getSegmentPrototype()).isSameAs(smemProto0);
 
@@ -192,7 +192,7 @@ public class AddRuleTest {
 
         insertAndFlush(wm);
 
-        SegmentMemory smem = wm.getNodeMemories().getNodeMemory(lian, wm).getSegmentMemory();
+        SegmentMemory smem = wm.getNodeMemories().getNodeMemory(lian).getSegmentMemory();
         SegmentPrototype smemProto0 = kbase1.getSegmentPrototype(lian);
         assertThat(smem.getSegmentPrototype()).isSameAs(smemProto0);
         PathEndNode endNode0 = smemProto0.getPathEndNodes()[0];
@@ -253,7 +253,7 @@ public class AddRuleTest {
         insertAndFlush(wm);
         wm.fireAllRules();
 
-        SegmentMemory smem = wm.getNodeMemories().getNodeMemory(lian, wm).getSegmentMemory();
+        SegmentMemory smem = wm.getNodeMemories().getNodeMemory(lian).getSegmentMemory();
         SegmentPrototype smemProto0 = kbase1.getSegmentPrototype(lian);
         assertThat(smem.getSegmentPrototype()).isSameAs(smemProto0);
         PathEndNode endNode0 = smemProto0.getPathEndNodes()[0];
@@ -319,7 +319,7 @@ public class AddRuleTest {
 
         insertAndFlush(wm);
 
-        SegmentMemory smem = wm.getNodeMemories().getNodeMemory(lian, wm).getSegmentMemory();
+        SegmentMemory smem = wm.getNodeMemories().getNodeMemory(lian).getSegmentMemory();
         SegmentPrototype smemProto0 = kbase1.getSegmentPrototype(lian);
         PathEndNode endNode1 = smemProto0.getPathEndNodes()[1];
         assertSegmentsLengthAndPos(endNode1, 2, wm);


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

Another step in the direction of making the code of drools core "better" - specifically by reducing the need to pass around ReteEvaluator objects.

Here I have added ReteEvaluator as an instance variable for the ConcurrentNodeMemories. 

This allows us to make the interface of NodeMemories much smaller, and reduces the need to pass around ReteEvaluator.

Eventually I plan to split further the dependencies in this class, so that I can use small objects than ReteEvaluator.


