### PR TITLE
[incubator-kie-issues #203] Cleanup Phreak code - extract segment prototype registry

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
+++ b/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
@@ -70,7 +70,7 @@ public class ConcurrentNodeMemories implements NodeMemories {
 
     private void resetSegmentMemory(SegmentMemory smem) {
         if (smem != null) {
-            smem.reset(ruleBase.getSegmentPrototype(smem));
+            smem.reset(ruleBase.getSegmentPrototypeRegistry().getSegmentPrototype(smem));
             if (smem.isSegmentLinked()) {
                 smem.notifyRuleLinkSegment(reteEvaluator);
             }

--- a/drools-core/src/main/java/org/drools/core/impl/InternalRuleBase.java
+++ b/drools-core/src/main/java/org/drools/core/impl/InternalRuleBase.java
@@ -42,6 +42,7 @@ import org.drools.core.reteoo.Rete;
 import org.drools.core.reteoo.ReteooBuilder;
 import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
+import org.drools.core.reteoo.SegmentPrototypeRegistry;
 import org.drools.core.rule.accessor.FactHandleFactory;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.builder.ReleaseId;
@@ -116,6 +117,8 @@ public interface InternalRuleBase extends RuleBase {
 
 
     ClassFieldAccessorCache getClassFieldAccessorCache();
+    
+    SegmentPrototypeRegistry getSegmentPrototypeRegistry();
 
     void invalidateSegmentPrototype(LeftTupleNode rootNode);
     SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleSource tupleSource);

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -139,7 +139,7 @@ public class KnowledgeBaseImpl implements InternalRuleBase {
     private transient Rete rete;
     private ReteooBuilder reteooBuilder;
 
-    private SegmentPrototypeRegistry protos;
+    private SegmentPrototypeRegistry segmentPrototypeRegistry;
     
     // This is just a hack, so spring can find the list of generated classes
     public List<List<String>> jaxbClasses;
@@ -182,7 +182,7 @@ public class KnowledgeBaseImpl implements InternalRuleBase {
         this.globals = new HashMap<>();
 
         this.classFieldAccessorCache = new ClassFieldAccessorCache(this.rootClassLoader);
-        this.protos = new SegmentPrototypeRegistryImpl(isEagerSegmentCreation());
+        this.segmentPrototypeRegistry = new SegmentPrototypeRegistryImpl(isEagerSegmentCreation());
 
         setupRete();
 
@@ -922,37 +922,37 @@ public class KnowledgeBaseImpl implements InternalRuleBase {
     }
 
     public SegmentPrototypeRegistry getSegmentPrototypeRegistry() {
-        return protos;
+        return segmentPrototypeRegistry;
     }
 
     public boolean hasSegmentPrototypes() {
-        return protos.hasSegmentPrototypes();
+        return segmentPrototypeRegistry.hasSegmentPrototypes();
     }
 
     public void registerSegmentPrototype(LeftTupleNode tupleSource, SegmentPrototype smem) {
-        protos.registerSegmentPrototype(tupleSource, smem);
+        segmentPrototypeRegistry.registerSegmentPrototype(tupleSource, smem);
     }
 
     public void invalidateSegmentPrototype(LeftTupleNode rootNode) {
-        protos.invalidateSegmentPrototype(rootNode);
+        segmentPrototypeRegistry.invalidateSegmentPrototype(rootNode);
     }
 
     @Override
     public SegmentPrototype getSegmentPrototype(LeftTupleNode node) {
-        return protos.getSegmentPrototype(node);
+        return segmentPrototypeRegistry.getSegmentPrototype(node);
     }
 
     @Override
     public SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleSource tupleSource) {
-        return protos.createSegmentFromPrototype(reteEvaluator, tupleSource);
+        return segmentPrototypeRegistry.createSegmentFromPrototype(reteEvaluator, tupleSource);
     }
 
     public SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, SegmentPrototype proto) {
-        return protos.createSegmentFromPrototype(reteEvaluator, proto);
+        return segmentPrototypeRegistry.createSegmentFromPrototype(reteEvaluator, proto);
     }
 
     public SegmentPrototype getSegmentPrototype(SegmentMemory segment) {
-        return protos.getSegmentPrototype(segment);
+        return segmentPrototypeRegistry.getSegmentPrototype(segment);
     }
 
     private static class TypeDeclarationCandidate {

--- a/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.drools.base.common.NetworkNode;
 import org.drools.base.reteoo.NodeTypeEnums;
-import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.reteoo.AsyncReceiveNode;
 import org.drools.core.reteoo.AsyncSendNode;
 import org.drools.core.reteoo.BetaNode;
@@ -57,6 +56,7 @@ import org.drools.core.reteoo.SegmentMemory.RightInputAdapterPrototype;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 import org.drools.core.reteoo.SegmentMemory.TerminalPrototype;
 import org.drools.core.reteoo.SegmentMemory.TimerMemoryPrototype;
+import org.drools.core.reteoo.SegmentPrototypeRegistry;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.reteoo.TimerNode;
 
@@ -119,11 +119,11 @@ public class BuildtimeSegmentUtilities {
         return allLinkedMaskTest;
     }
 
-    public static SegmentPrototype[] createPathProtoMemories(InternalRuleBase rbase,
+    public static SegmentPrototype[] createPathProtoMemories(SegmentPrototypeRegistry segmentProtos,
                                                              TerminalNode tn,
                                                              TerminalNode removingTn) {
         // Will initialise all segments in a path
-        SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(rbase, tn, removingTn);
+        SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(segmentProtos, tn, removingTn);
 
         // smems are empty, if there is no beta network. Which means it has an AlphaTerminalNode
         if (smems.length > 0) {
@@ -133,7 +133,7 @@ public class BuildtimeSegmentUtilities {
         return smems;
     }
 
-    public static SegmentPrototype[] createLeftTupleNodeProtoMemories(InternalRuleBase rbase,
+    public static SegmentPrototype[] createLeftTupleNodeProtoMemories(SegmentPrototypeRegistry segmentProtos,
                                                                       LeftTupleNode lts,
                                                                       TerminalNode removingTn) {
         LeftTupleNode segmentRoot = lts;
@@ -151,10 +151,10 @@ public class BuildtimeSegmentUtilities {
             }
 
             // Store all nodes for the main path in reverse order (we're starting from the terminal node).
-            SegmentPrototype smem = rbase.getSegmentPrototype(segmentRoot);
+            SegmentPrototype smem = segmentProtos.getSegmentPrototype(segmentRoot);
             if (smem == null) {
                 start = segmentRoot.getPathIndex(); // we want counter to start from the new segment proto only
-                smem = createSegmentMemory(rbase, segmentRoot, segmentTip, removingTn, recordBefore);
+                smem = createSegmentMemory(segmentProtos,  segmentRoot, segmentTip, removingTn, recordBefore);
             }
             smems.add(0, smem);
 
@@ -194,7 +194,7 @@ public class BuildtimeSegmentUtilities {
     /**
      * Initialises the NodeSegment memory for all nodes in the segment.
      */
-    public static SegmentPrototype createSegmentMemory(InternalRuleBase rbase,
+    private static SegmentPrototype createSegmentMemory(SegmentPrototypeRegistry prototypeRegistry,
                                                        LeftTupleNode segmentRoot,
                                                        LeftTupleNode segmentTip,
                                                        TerminalNode removingTn,
@@ -216,7 +216,7 @@ public class BuildtimeSegmentUtilities {
             nodeTypesInSegment = updateNodeTypesMask(node, nodeTypesInSegment);
             if (NodeTypeEnums.isBetaNode(node)) {
                 boolean updateAllLinked = node.getPathIndex() < recordBefore && updateNodeBit;
-                allLinkedTestMask = processBetaNode(rbase, (BetaNode) node, removingTn, smem, memories,
+                allLinkedTestMask = processBetaNode(prototypeRegistry, (BetaNode) node, removingTn, smem, memories,
                         nodes, nodePosMask, allLinkedTestMask, updateAllLinked);
             } else {
                 switch (node.getType()) {
@@ -273,7 +273,7 @@ public class BuildtimeSegmentUtilities {
         smem.setMemories(memories.toArray(new MemoryPrototype[memories.size()]));
         smem.setNodeTypesInSegment(nodeTypesInSegment);
 
-        rbase.registerSegmentPrototype(segmentRoot, smem);
+        prototypeRegistry.registerSegmentPrototype(segmentRoot, smem);
 
         return smem;
     }
@@ -391,7 +391,7 @@ public class BuildtimeSegmentUtilities {
         return allLinkedTestMask;
     }
 
-    private static long processBetaNode(InternalRuleBase rbase,
+    private static long processBetaNode(SegmentPrototypeRegistry prototypeRegistry, 
                                         BetaNode betaNode,
                                         TerminalNode removingTn,
                                         SegmentPrototype smem,
@@ -405,7 +405,7 @@ public class BuildtimeSegmentUtilities {
             // there is a subnetwork, so create all it's segment memory prototypes
             tton = (TupleToObjectNode) betaNode.getRightInput().getParent();
 
-            SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(rbase, tton, removingTn);
+            SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(prototypeRegistry, tton, removingTn);
             setSegments(tton, smems);
 
             if (updateNodeBit && canBeDisabled(betaNode) && tton.getPathMemSpec().allLinkedTestMask() > 0) {

--- a/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/BuildtimeSegmentUtilities.java
@@ -119,11 +119,11 @@ public class BuildtimeSegmentUtilities {
         return allLinkedMaskTest;
     }
 
-    public static SegmentPrototype[] createPathProtoMemories(SegmentPrototypeRegistry segmentProtos,
+    public static SegmentPrototype[] createPathProtoMemories(SegmentPrototypeRegistry segmentPrototypeRegistry,
                                                              TerminalNode tn,
                                                              TerminalNode removingTn) {
         // Will initialise all segments in a path
-        SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(segmentProtos, tn, removingTn);
+        SegmentPrototype[] smems = createLeftTupleNodeProtoMemories(segmentPrototypeRegistry, tn, removingTn);
 
         // smems are empty, if there is no beta network. Which means it has an AlphaTerminalNode
         if (smems.length > 0) {
@@ -133,7 +133,7 @@ public class BuildtimeSegmentUtilities {
         return smems;
     }
 
-    public static SegmentPrototype[] createLeftTupleNodeProtoMemories(SegmentPrototypeRegistry segmentProtos,
+    public static SegmentPrototype[] createLeftTupleNodeProtoMemories(SegmentPrototypeRegistry segmentPrototypeRegistry,
                                                                       LeftTupleNode lts,
                                                                       TerminalNode removingTn) {
         LeftTupleNode segmentRoot = lts;
@@ -151,10 +151,10 @@ public class BuildtimeSegmentUtilities {
             }
 
             // Store all nodes for the main path in reverse order (we're starting from the terminal node).
-            SegmentPrototype smem = segmentProtos.getSegmentPrototype(segmentRoot);
+            SegmentPrototype smem = segmentPrototypeRegistry.getSegmentPrototype(segmentRoot);
             if (smem == null) {
                 start = segmentRoot.getPathIndex(); // we want counter to start from the new segment proto only
-                smem = createSegmentMemory(segmentProtos,  segmentRoot, segmentTip, removingTn, recordBefore);
+                smem = createSegmentMemory(segmentPrototypeRegistry,  segmentRoot, segmentTip, removingTn, recordBefore);
             }
             smems.add(0, smem);
 
@@ -194,7 +194,7 @@ public class BuildtimeSegmentUtilities {
     /**
      * Initialises the NodeSegment memory for all nodes in the segment.
      */
-    private static SegmentPrototype createSegmentMemory(SegmentPrototypeRegistry prototypeRegistry,
+    private static SegmentPrototype createSegmentMemory(SegmentPrototypeRegistry segmentPrototypeRegistry,
                                                        LeftTupleNode segmentRoot,
                                                        LeftTupleNode segmentTip,
                                                        TerminalNode removingTn,
@@ -216,7 +216,7 @@ public class BuildtimeSegmentUtilities {
             nodeTypesInSegment = updateNodeTypesMask(node, nodeTypesInSegment);
             if (NodeTypeEnums.isBetaNode(node)) {
                 boolean updateAllLinked = node.getPathIndex() < recordBefore && updateNodeBit;
-                allLinkedTestMask = processBetaNode(prototypeRegistry, (BetaNode) node, removingTn, smem, memories,
+                allLinkedTestMask = processBetaNode(segmentPrototypeRegistry, (BetaNode) node, removingTn, smem, memories,
                         nodes, nodePosMask, allLinkedTestMask, updateAllLinked);
             } else {
                 switch (node.getType()) {
@@ -273,7 +273,7 @@ public class BuildtimeSegmentUtilities {
         smem.setMemories(memories.toArray(new MemoryPrototype[memories.size()]));
         smem.setNodeTypesInSegment(nodeTypesInSegment);
 
-        prototypeRegistry.registerSegmentPrototype(segmentRoot, smem);
+        segmentPrototypeRegistry.registerSegmentPrototype(segmentRoot, smem);
 
         return smem;
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -299,15 +299,15 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             detachedTuples.forEach(d -> d.reattachToRight());
         }
 
-        public static SegmentPrototype processSplit(SegmentPrototypeRegistry prototypeRegistry,
+        public static SegmentPrototype processSplit(SegmentPrototypeRegistry segmentPrototypeRegistry,
                                                     Collection<InternalWorkingMemory> wms,
                                                     LeftTupleNode splitNode,
                                                     Set<SegmentMemoryPair> smemsToNotify) {
             LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(splitNode);
-            SegmentPrototype proto1 = prototypeRegistry.getSegmentPrototype(segmentRoot);
+            SegmentPrototype proto1 = segmentPrototypeRegistry.getSegmentPrototype(segmentRoot);
             if (proto1.getTipNode() != splitNode) {
                 // split does not already exist, add it.
-                return splitSegment(prototypeRegistry, wms, proto1, splitNode, smemsToNotify);
+                return splitSegment(segmentPrototypeRegistry, wms, proto1, splitNode, smemsToNotify);
             }
 
             // split already exists, add it.
@@ -575,7 +575,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
     public static class Remove {
 
-        private static void removeExistingPaths(SegmentPrototypeRegistry prototypeRegistry,
+        private static void removeExistingPaths(SegmentPrototypeRegistry segmentPrototypeRegistry,
                                                 Collection<InternalWorkingMemory> wms,
                                                 List<Pair> exclBranchRoots,
                                                 TerminalNode tn) {
@@ -603,7 +603,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                         smproto.setPathEndNodes(newNodes);
                     } else {
                         // unregister the segments exclusive to the branch being used
-                        prototypeRegistry.invalidateSegmentPrototype(smproto.getRootNode());
+                        segmentPrototypeRegistry.invalidateSegmentPrototype(smproto.getRootNode());
                     }
                 }
             }
@@ -675,7 +675,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             }
         }
 
-        private static void processMerges(SegmentPrototypeRegistry prototypeRegistry,
+        private static void processMerges(SegmentPrototypeRegistry segmentPrototypeRegistry,
                                           Collection<InternalWorkingMemory> wms,
                                           LeftTupleNode splitNode,
                                           TerminalNode tn,
@@ -689,7 +689,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 // with the tn ignored, it's no longer a semgnet tip so it's segment is ready to merge
                 LeftTupleNode segmentRoot = BuildtimeSegmentUtilities.findSegmentRoot(splitNode, tn);
 
-                SegmentPrototype proto1 = prototypeRegistry.getSegmentPrototype(segmentRoot);
+                SegmentPrototype proto1 = segmentPrototypeRegistry.getSegmentPrototype(segmentRoot);
 
                 // find the remaining child and get it's proto
                 LeftTupleNode ltn = null;
@@ -707,12 +707,12 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                     throw new RuntimeException();
                 }
 
-                SegmentPrototype proto2 = prototypeRegistry.getSegmentPrototype(ltn);
-                mergeSegments(prototypeRegistry, wms, proto1, proto2);
+                SegmentPrototype proto2 = segmentPrototypeRegistry.getSegmentPrototype(ltn);
+                mergeSegments(segmentPrototypeRegistry, wms, proto1, proto2);
             }
         }
 
-        public static void mergeSegments(SegmentPrototypeRegistry prototypeRegistry,
+        public static void mergeSegments(SegmentPrototypeRegistry segmentPrototypeRegistry,
                                          Collection<InternalWorkingMemory> wms,
                                          SegmentPrototype proto1,
                                          SegmentPrototype proto2) {
@@ -752,7 +752,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                 updatePaths(wms, newList, proto1, endNode);
             }
 
-            prototypeRegistry.invalidateSegmentPrototype(proto2.getRootNode());
+            segmentPrototypeRegistry.invalidateSegmentPrototype(proto2.getRootNode());
         }
 
         private static void mergeSegment(ReteEvaluator wm,

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -1152,7 +1152,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         List<PathMemory> otherPmems = new ArrayList<>();
     }
 
-    private static PathEndNodes getPathEndNodes(SegmentPrototypeRegistry prototypeRegistry,
+    private static PathEndNodes getPathEndNodes(SegmentPrototypeRegistry segmentPrototypeRegistry,
                                                 Rule processedRule,
                                                 LeftTupleNode lt,
                                                 TerminalNode tn,
@@ -1167,15 +1167,15 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
 
         if (hasProtos) {
-            invalidateRootNode(prototypeRegistry, lt);
+            invalidateRootNode(segmentPrototypeRegistry, lt);
         }
 
-        collectPathEndNodes(prototypeRegistry, processedRule, lt, endNodes, tn, hasProtos, hasWms, hasProtos && isSplit(lt));
+        collectPathEndNodes(segmentPrototypeRegistry, processedRule, lt, endNodes, tn, hasProtos, hasWms, hasProtos && isSplit(lt));
 
         return endNodes;
     }
 
-    private static void collectPathEndNodes(SegmentPrototypeRegistry prototypeRegistry,
+    private static void collectPathEndNodes(SegmentPrototypeRegistry segmentPrototypeRegistry,
                                             Rule processedRule,
                                             LeftTupleNode lt,
                                             PathEndNodes endNodes,
@@ -1193,12 +1193,12 @@ class LazyPhreakBuilder implements PhreakBuilder {
             if (hasProtos) {
                 if (isBelowNewSplit) {
                     if (isRootNode(sink, null)) {
-                        prototypeRegistry.invalidateSegmentPrototype(sink);
+                        segmentPrototypeRegistry.invalidateSegmentPrototype(sink);
                     }
                 } else {
                     isBelowNewSplit = isSplit(sink);
                     if (isBelowNewSplit) {
-                        invalidateRootNode(prototypeRegistry, sink);
+                        invalidateRootNode(segmentPrototypeRegistry, sink);
                     }
                 }
             }
@@ -1209,7 +1209,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                     }
                 }
 
-                collectPathEndNodes(prototypeRegistry, processedRule, sink, endNodes, tn, hasProtos, hasWms, isBelowNewSplit);
+                collectPathEndNodes(segmentPrototypeRegistry, processedRule, sink, endNodes, tn, hasProtos, hasWms, isBelowNewSplit);
             } else if (NodeTypeEnums.isTerminalNode(sink)) {
                 endNodes.otherEndNodes.add((PathEndNode) sink);
             } else if (NodeTypeEnums.TupleToObjectNode == sink.getType()) {
@@ -1225,11 +1225,11 @@ class LazyPhreakBuilder implements PhreakBuilder {
         }
     }
 
-    private static void invalidateRootNode(SegmentPrototypeRegistry prototypeRegistry, LeftTupleNode lt) {
+    private static void invalidateRootNode(SegmentPrototypeRegistry segmentPrototypeRegistry, LeftTupleNode lt) {
         while (!isRootNode(lt, null)) {
             lt = lt.getLeftTupleSource();
         }
-        prototypeRegistry.invalidateSegmentPrototype(lt);
+        segmentPrototypeRegistry.invalidateSegmentPrototype(lt);
     }
 
     private static class PathEndNodes {

--- a/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
@@ -80,8 +80,8 @@ public class RuntimeSegmentUtilities {
     }
 
     private static SegmentMemory restoreSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleNode segmentRoot) {
-        SegmentPrototypeRegistry prototypeRegistry = reteEvaluator.getKnowledgeBase().getSegmentPrototypeRegistry();
-        SegmentPrototype proto = prototypeRegistry.getSegmentPrototype(segmentRoot);
+        SegmentPrototypeRegistry segmentPrototypeRegistry = reteEvaluator.getKnowledgeBase().getSegmentPrototypeRegistry();
+        SegmentPrototype proto = segmentPrototypeRegistry.getSegmentPrototype(segmentRoot);
         if (proto == null || proto.getNodesInSegment() == null) {
             return null;
         }
@@ -102,7 +102,7 @@ public class RuntimeSegmentUtilities {
             }
         }
 
-        SegmentMemory smem = prototypeRegistry.createSegmentFromPrototype(reteEvaluator, proto);
+        SegmentMemory smem = segmentPrototypeRegistry.createSegmentFromPrototype(reteEvaluator, proto);
 
         updateSubnetworkAndTerminalMemory(reteEvaluator, smem, proto);
 

--- a/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
@@ -39,6 +39,7 @@ import org.drools.core.reteoo.QueryElementNode;
 import org.drools.core.reteoo.TupleToObjectNode;
 import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
+import org.drools.core.reteoo.SegmentPrototypeRegistry;
 
 import static org.drools.core.phreak.EagerPhreakBuilder.isInsideSubnetwork;
 
@@ -79,7 +80,8 @@ public class RuntimeSegmentUtilities {
     }
 
     private static SegmentMemory restoreSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleNode segmentRoot) {
-        SegmentPrototype proto = reteEvaluator.getKnowledgeBase().getSegmentPrototype(segmentRoot);
+        SegmentPrototypeRegistry prototypeRegistry = reteEvaluator.getKnowledgeBase().getSegmentPrototypeRegistry();
+        SegmentPrototype proto = prototypeRegistry.getSegmentPrototype(segmentRoot);
         if (proto == null || proto.getNodesInSegment() == null) {
             return null;
         }
@@ -100,7 +102,7 @@ public class RuntimeSegmentUtilities {
             }
         }
 
-        SegmentMemory smem = reteEvaluator.getKnowledgeBase().createSegmentFromPrototype(reteEvaluator, proto);
+        SegmentMemory smem = prototypeRegistry.createSegmentFromPrototype(reteEvaluator, proto);
 
         updateSubnetworkAndTerminalMemory(reteEvaluator, smem, proto);
 
@@ -203,7 +205,7 @@ public class RuntimeSegmentUtilities {
         return pmem;
     }
 
-    public static void initializePathMemory(ReteEvaluator reteEvaluator, PathEndNode pathEndNode, PathMemory pmem) {
+    private static void initializePathMemory(ReteEvaluator reteEvaluator, PathEndNode pathEndNode, PathMemory pmem) {
         if (pathEndNode.getEagerSegmentPrototypes() != null) {
             for (SegmentPrototype eager : pathEndNode.getEagerSegmentPrototypes()) {
                 if (pmem.getSegmentMemories()[eager.getPos()] == null) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
@@ -34,7 +34,6 @@ import org.drools.core.phreak.BuildtimeSegmentUtilities;
 import org.drools.core.phreak.RuntimeSegmentUtilities;
 import org.drools.core.reteoo.AsyncReceiveNode.AsyncReceiveMemory;
 import org.drools.core.reteoo.QueryElementNode.QueryElementNodeMemory;
-import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 import org.drools.core.reteoo.TupleToObjectNode.SubnetworkPathMemory;
 import org.drools.core.reteoo.TimerNode.TimerNodeMemory;
 import org.drools.core.util.LinkedList;
@@ -75,10 +74,6 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
 
     public SegmentMemory(LeftTupleNode rootNode) {
         this.proto = new SegmentPrototype(rootNode, null);
-    }
-
-    public <T extends Memory> T createNodeMemory(MemoryFactory<T> memoryFactory, ReteEvaluator reteEvaluator) {
-        return reteEvaluator.getNodeMemory(memoryFactory);
     }
 
     public LeftTupleNode getRootNode() {

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistry.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistry.java
@@ -1,0 +1,22 @@
+package org.drools.core.reteoo;
+
+import org.drools.core.common.ReteEvaluator;
+import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
+
+public interface SegmentPrototypeRegistry {
+    
+    void invalidateSegmentPrototype(LeftTupleNode rootNode);
+    
+    void registerSegmentPrototype(LeftTupleNode tupleSource, SegmentPrototype smem);
+
+    SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleSource tupleSource);
+
+    SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, SegmentPrototype smem);
+
+    SegmentPrototype getSegmentPrototype(SegmentMemory segment);
+
+    SegmentPrototype getSegmentPrototype(LeftTupleNode node);
+
+    boolean hasSegmentPrototypes();
+
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistry.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistry.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.core.reteoo;
 
 import org.drools.core.common.ReteEvaluator;

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistryImpl.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistryImpl.java
@@ -1,0 +1,50 @@
+package org.drools.core.reteoo;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.drools.core.common.ReteEvaluator;
+import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
+
+
+public class SegmentPrototypeRegistryImpl implements SegmentPrototypeRegistry {
+    
+    private final transient Map<Integer, SegmentPrototype> segmentProtos;
+
+    public SegmentPrototypeRegistryImpl(boolean isEagerCreation) {
+        segmentProtos =  isEagerCreation ? new HashMap<>() : new ConcurrentHashMap<>();
+    }
+    
+    public boolean hasSegmentPrototypes() {
+        return !segmentProtos.isEmpty();
+    }
+
+    public void registerSegmentPrototype(LeftTupleNode tupleSource, SegmentPrototype smem) {
+        segmentProtos.put(tupleSource.getId(), smem);
+    }
+
+    public void invalidateSegmentPrototype(LeftTupleNode rootNode) {
+        segmentProtos.remove(rootNode.getId());
+    }
+
+    @Override
+    public SegmentPrototype getSegmentPrototype(LeftTupleNode node) {
+        return segmentProtos.get(node.getId());
+    }
+
+    @Override
+    public SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleSource tupleSource) {
+        SegmentPrototype proto = segmentProtos.get(tupleSource.getId());
+        return createSegmentFromPrototype(reteEvaluator, proto);
+    }
+
+    public SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, SegmentPrototype proto) {
+        return proto.newSegmentMemory(reteEvaluator);
+    }
+
+    public SegmentPrototype getSegmentPrototype(SegmentMemory segment) {
+        return segmentProtos.get(segment.getRootNode().getId());
+    }
+
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistryImpl.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistryImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.core.reteoo;
 
 import java.util.HashMap;

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
@@ -216,7 +216,7 @@ public class ReteooRuleBuilder implements RuleBuilder {
 
         setPathEndNodes(context, terminalNode);
 
-        if (!PhreakBuilder.isEagerSegmentCreation() || context.getRuleBase().hasSegmentPrototypes()) {
+        if (!PhreakBuilder.isEagerSegmentCreation() || context.getRuleBase().getSegmentPrototypeRegistry().hasSegmentPrototypes()) {
             // only need to process this, if segment protos exist
             PhreakBuilder.get().addRule(context.getRuleBase(), context.getWorkingMemories(), terminalNode);
         }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/rulebase/SessionsAwareKnowledgeBase.java
@@ -46,6 +46,7 @@ import org.drools.core.reteoo.ReteooBuilder;
 import org.drools.core.reteoo.RuntimeComponentFactory;
 import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
+import org.drools.core.reteoo.SegmentPrototypeRegistry;
 import org.drools.core.rule.accessor.FactHandleFactory;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.builder.ReleaseId;
@@ -484,6 +485,10 @@ public class SessionsAwareKnowledgeBase implements InternalKnowledgeBase {
         return delegate.getMemoryCount();
     }
 
+    public SegmentPrototypeRegistry getSegmentPrototypeRegistry() {
+        return delegate.getSegmentPrototypeRegistry();
+    }
+    
     @Override
     public void invalidateSegmentPrototype(LeftTupleNode rootNode) {
         delegate.invalidateSegmentPrototype(rootNode);

--- a/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
@@ -198,7 +198,7 @@ public class NodeSegmentUnlinkingTest {
         for (TerminalNode tn : new TerminalNode[] {rtn1, rtn2, rtn3}) {
             tn.setPathEndNodes( new PathEndNode[] {tn});
             tn.resetPathMemSpec(null);
-            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase.getSegmentPrototypeRegistry(), tn, null);
         }
     }
 
@@ -254,13 +254,13 @@ public class NodeSegmentUnlinkingTest {
         n5.attach(buildContext);
 
         StatefulKnowledgeSessionImpl ksession = (StatefulKnowledgeSessionImpl)kBase.newKieSession();
-        SegmentPrototype[] protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(kBase, n3, null);
+        SegmentPrototype[] protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(kBase.getSegmentPrototypeRegistry(), n3, null);
         Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
 
-        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(kBase, n4, null);
+        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(kBase.getSegmentPrototypeRegistry(), n4, null);
         Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
 
-        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(kBase, n5, null);
+        protos = BuildtimeSegmentUtilities.createLeftTupleNodeProtoMemories(kBase.getSegmentPrototypeRegistry(), n5, null);
         Arrays.stream(protos).forEach( p -> p.setPathEndNodes( new PathEndNode[0]));
         createSegmentMemory( n2, ksession );
 

--- a/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingTest.java
@@ -194,7 +194,7 @@ public class RuleUnlinkingTest {
         for (TerminalNode tn : new TerminalNode[] {rtn1, rtn2, rtn3}) {
             tn.setPathEndNodes( new PathEndNode[] {tn});
             tn.resetPathMemSpec(null);
-            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase.getSegmentPrototypeRegistry(), tn, null);
         }
         
     }
@@ -381,7 +381,7 @@ public class RuleUnlinkingTest {
         for (TerminalNode tn : new TerminalNode[] {rtn1, rtn2, rtn3}) {
             tn.setPathEndNodes( new PathEndNode[] {tn});
             tn.resetPathMemSpec(null);
-            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase.getSegmentPrototypeRegistry(), tn, null);
         }
     }
 

--- a/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingWithSegmentMemoryTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingWithSegmentMemoryTest.java
@@ -191,7 +191,7 @@ public class RuleUnlinkingWithSegmentMemoryTest {
         for (TerminalNode tn : new TerminalNode[] {rtn1, rtn2, rtn3}) {
             tn.setPathEndNodes( new PathEndNode[] {tn});
             tn.resetPathMemSpec(null);
-            BuildtimeSegmentUtilities.createPathProtoMemories(kBase, tn, null);
+            BuildtimeSegmentUtilities.createPathProtoMemories(kBase.getSegmentPrototypeRegistry(), tn, null);
         }
     }
     

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
@@ -113,7 +113,7 @@ public class AddRuleTest {
         assertThat(smemProto0.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT);
 
         SegmentPrototype[] oldSmemProtos = endNode.getSegmentPrototypes();
-        SegmentPrototype smemProto1 = Add.processSplit(kbase1, Collections.singletonList(wm), cbeta, new HashSet<>());
+        SegmentPrototype smemProto1 = Add.processSplit(kbase1.getSegmentPrototypeRegistry(), Collections.singletonList(wm), cbeta, new HashSet<>());
 
         assertSegmentsLengthAndPos(endNode, 2, oldSmemProtos, smemProto1, wm);
         assertThat(endNode.getSegmentPrototypes()[0]).isSameAs(smemProto0);
@@ -161,7 +161,7 @@ public class AddRuleTest {
         assertThat(smemProto0.getAllLinkedMaskTest()).isEqualTo(31);
         assertThat(smemProto0.getLinkedNodeMask()).isEqualTo(10); // nots must be linked in
         assertThat(smemProto0.getNodeTypesInSegment()).isEqualTo(BuildtimeSegmentUtilities.JOIN_NODE_BIT | BuildtimeSegmentUtilities.NOT_NODE_BIT);
-        SegmentPrototype smemProto1 = Add.processSplit(kbase1, Collections.singletonList(wm), cbeta, new HashSet<>());
+        SegmentPrototype smemProto1 = Add.processSplit(kbase1.getSegmentPrototypeRegistry(), Collections.singletonList(wm), cbeta, new HashSet<>());
 
         assertThat(smemProto0.getAllLinkedMaskTest()).isEqualTo(7);
         assertThat(smemProto0.getLinkedNodeMask()).isEqualTo(2);
@@ -207,7 +207,7 @@ public class AddRuleTest {
         assertThat(smemProtoX.getPos()).isEqualTo(1);
 
         SegmentPrototype[] oldSmemProtos = endNode1.getSegmentPrototypes();
-        SegmentPrototype smemProtoE2 = Add.processSplit(kbase1, Collections.singletonList(wm), ebeta3, new HashSet<>());
+        SegmentPrototype smemProtoE2 = Add.processSplit(kbase1.getSegmentPrototypeRegistry(), Collections.singletonList(wm), ebeta3, new HashSet<>());
         assertSegmentsLengthAndPos(endNode0, 3, wm);
         assertSegmentsLengthAndPos(endNode1, 2, oldSmemProtos, smemProtoE2, wm);
 
@@ -262,7 +262,7 @@ public class AddRuleTest {
         assertSegmentsLengthAndPos(endNode1, 2, wm);
 
         // processSplit should return null, as it's alreayd split and this does nothing.
-        assertThat(Add.processSplit(kbase1, Collections.singletonList(wm), cbeta, new HashSet<>())).isNull();
+        assertThat(Add.processSplit(kbase1.getSegmentPrototypeRegistry(), Collections.singletonList(wm), cbeta, new HashSet<>())).isNull();
 
         // now add a rule at the given split, so we can check paths were all updated correctly
         addRuleAtGivenSplit(kbase1, wm, cbeta, yotn);
@@ -330,7 +330,7 @@ public class AddRuleTest {
         assertThat(smemProtoEV.getAllLinkedMaskTest()).isEqualTo(12); // first two are evals, so each is 0
 
         SegmentPrototype[] oldSmemProtos = endNode1.getSegmentPrototypes();
-        SegmentPrototype smemProtoE4 = Add.processSplit(kbase1, Collections.singletonList(wm), ebeta3, new HashSet<>());
+        SegmentPrototype smemProtoE4 = Add.processSplit(kbase1.getSegmentPrototypeRegistry(), Collections.singletonList(wm), ebeta3, new HashSet<>());
 
         assertSegmentsLengthAndPos(endNode1, 2, oldSmemProtos, smemProtoE4, wm);
 
@@ -369,7 +369,7 @@ public class AddRuleTest {
         assertSegmentsLengthAndPos(endNode0, 3, wm);
 
         SegmentPrototype[] oldSmemProtos = endNode0.getSegmentPrototypes();
-        SegmentPrototype smemProto1 = Add.processSplit(kbase1, Collections.singletonList(wm), bbeta, new HashSet<>());
+        SegmentPrototype smemProto1 = Add.processSplit(kbase1.getSegmentPrototypeRegistry(), Collections.singletonList(wm), bbeta, new HashSet<>());
 
         assertSegmentsLengthAndPos(endNode0, 4, oldSmemProtos, smemProto1, wm);
         assertThat(endNode0.getPathMemSpec().allLinkedTestMask()).isEqualTo(15);


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

More cleanup for the rule engine. 

This time I have separated the SegmentPrototype map into a separate registry

The code depend directly on the SegmentPrototypeRegisty interface, not the InternalRuleBase interface.

This interface is much smaller and more self contained.

This is a good step to eventually break the code into smaller, more manageable parts.


