### PR TITLE
[incubator-kie-issues #203] Cleanup Phreak code - Remove ReteEvaluator dep from PathMemory methods.

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/ActivationsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/ActivationsManager.java
@@ -93,7 +93,7 @@ public interface ActivationsManager {
 
     default void stageLeftTuple(RuleAgendaItem ruleAgendaItem, InternalMatch justified) {
         if (!ruleAgendaItem.isQueued()) {
-            ruleAgendaItem.getRuleExecutor().getPathMemory().queueRuleAgendaItem(this);
+            ruleAgendaItem.getRuleExecutor().getPathMemory().queueRuleAgendaItem();
         }
         ruleAgendaItem.getRuleExecutor().modifyActiveTuple((RuleTerminalNodeLeftTuple) justified.getTuple() );
     }

--- a/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
+++ b/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
@@ -72,7 +72,7 @@ public class ConcurrentNodeMemories implements NodeMemories {
         if (smem != null) {
             smem.reset(ruleBase.getSegmentPrototypeRegistry().getSegmentPrototype(smem));
             if (smem.isSegmentLinked()) {
-                smem.notifyRuleLinkSegment(reteEvaluator);
+                smem.notifyRuleLinkSegment();
             }
         }
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -123,7 +123,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             Add.insertFacts(wm, tn, visited, false);
         }
 
-        smemsToNotify.forEach(pair -> pair.sm.notifyRuleLinkSegment(pair.wm));
+        smemsToNotify.forEach(pair -> pair.sm.notifyRuleLinkSegment());
     }
 
     /**
@@ -554,7 +554,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                         SegmentMemory sm = parentMem.getSegmentMemory();
                         SegmentMemory childSmem = RuntimeSegmentUtilities.createChildSegment(wm, child);
                         sm.add(childSmem);
-                        sm.notifyRuleLinkSegment(wm);
+                        sm.notifyRuleLinkSegment();
                         notifyImpactedSegments(wm, sm, smemsToNotify);
                         notifyImpactedSegments(wm, childSmem, smemsToNotify);
                     }
@@ -1132,7 +1132,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         if (NodeTypeEnums.isTerminalNode(lt.getSink())) {
             PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(lt.getSink());
             if (pmem != null) {
-                PhreakRuleTerminalNode.doLeftDelete(pmem.getActualActivationsManager(wm), pmem.getRuleAgendaItem()
+                PhreakRuleTerminalNode.doLeftDelete(pmem.getActualActivationsManager(), pmem.getRuleAgendaItem()
                         .getRuleExecutor(), (RuleTerminalNodeLeftTuple) lt);
             }
         } else {

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -633,7 +633,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                                          List<LeftTupleNode> splits) {
         // first flush the subject rule, then flush any staging lists that are part of a merge
         if (pmem.isInitialized()) {
-            RuleNetworkEvaluator.INSTANCE.evaluateNetwork(wm, pmem.getRuleAgendaItem().getRuleExecutor(), pmem);
+            RuleNetworkEvaluator.INSTANCE.evaluateNetwork(pmem.getRuleAgendaItem().getRuleExecutor(), pmem);
         }
 
         // With the removing rules being flushed, we need to check any splits that will be merged, to see if they need flushing

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -154,7 +154,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
                 processLeftTuples(wm, rule, firstSplit, true);
 
-                notifySegments(wm, smemsToNotify);
+                notifySegments(smemsToNotify);
             }
         }
 
@@ -215,7 +215,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                     Set<SegmentMemory> smemsToNotify = handleExistingPaths(wm, tn, prevSmemsLookup, tnms.otherPmems,
                             ExistingPathStrategy.REMOVE_STRATEGY);
 
-                    notifySegments(wm, smemsToNotify);
+                    notifySegments(smemsToNotify);
                 }
             }
 
@@ -282,7 +282,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                                   SegmentMemory smem,
                                   int smemSplitAdjustAmount) {
             smemsToNotify.add(smem);
-            smem.unlinkSegment(wm);
+            smem.unlinkSegment();
             smem.correctSegmentMemoryAfterSplitOnAdd(smemSplitAdjustAmount);
         }
 
@@ -353,7 +353,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                                   SegmentMemory smem,
                                   int smemSplitAdjustAmount) {
             smemsToNotify.add(smem);
-            smem.unlinkSegment(wm);
+            smem.unlinkSegment();
             smem.correctSegmentMemoryAfterSplitOnRemove(smemSplitAdjustAmount);
         }
 
@@ -397,8 +397,8 @@ class LazyPhreakBuilder implements PhreakBuilder {
 
                 sm1.mergeSegment(sm2);
                 smemsToNotify.add(sm1);
-                sm1.unlinkSegment(wm);
-                sm2.unlinkSegment(wm);
+                sm1.unlinkSegment();
+                sm2.unlinkSegment();
                 visited.add(node);
 
                 // Add back the the terminal node of the rule to be removed into the rete network to permit the network
@@ -535,14 +535,14 @@ class LazyPhreakBuilder implements PhreakBuilder {
                             SegmentMemory sm = mem.getSegmentMemory();
                             if (sm != null && !sm.getPathMemories().contains(pmem)) {
                                 RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, sm);
-                                sm.notifyRuleLinkSegment(wm, pmem);
+                                sm.notifyRuleLinkSegment(pmem);
                             }
                         }
                     }
                 } else {
                     Memory mem = wm.getNodeMemories().peekNodeMemory(child);
                     if (mem != null) {
-                        mem.getSegmentMemory().notifyRuleLinkSegment(wm, pmem);
+                        mem.getSegmentMemory().notifyRuleLinkSegment(pmem);
                     }
                 }
 
@@ -719,9 +719,9 @@ class LazyPhreakBuilder implements PhreakBuilder {
         return previousSmems;
     }
 
-    private static void notifySegments(InternalWorkingMemory wm, Set<SegmentMemory> smems) {
+    private static void notifySegments(Set<SegmentMemory> smems) {
         for (SegmentMemory sm : smems) {
-            sm.notifyRuleLinkSegment(wm);
+            sm.notifyRuleLinkSegment();
         }
     }
 
@@ -1063,7 +1063,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
         if (NodeTypeEnums.isTerminalNode(lt.getSink())) {
             PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(lt.getSink());
             if (pmem != null) {
-                PhreakRuleTerminalNode.doLeftDelete(pmem.getActualActivationsManager(wm), pmem.getRuleAgendaItem()
+                PhreakRuleTerminalNode.doLeftDelete(pmem.getActualActivationsManager(), pmem.getRuleAgendaItem()
                         .getRuleExecutor(), (RuleTerminalNodeLeftTuple) lt);
             }
         } else {
@@ -1606,7 +1606,7 @@ class LazyPhreakBuilder implements PhreakBuilder {
                 RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem);
                 if (smem.isSegmentLinked()) {
                     // not's can cause segments to be linked, and the rules need to be notified for evaluation
-                    smem.notifyRuleLinkSegment(reteEvaluator);
+                    smem.notifyRuleLinkSegment();
                 }
                 checkEagerSegmentCreation(reteEvaluator, sink.getLeftTupleSource(), nodeTypesInSegment);
                 pmem = null;

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
@@ -154,8 +154,7 @@ public class PhreakNotNode {
 
         // this must be processed here, rather than initial insert, as we need to link the blocker
         unlinkNotNodeOnRightInsert(notNode,
-                                   bm,
-                                   reteEvaluator);
+                                   bm);
 
         for (RightTuple rightTuple = (RightTuple) srcRightTuples.getInsertFirst(); rightTuple != null; ) {
             RightTuple next = (RightTuple) rightTuple.getStagedNext();
@@ -206,12 +205,11 @@ public class PhreakNotNode {
     }
 
     public static void unlinkNotNodeOnRightInsert(NotNode notNode,
-                                                  BetaMemory bm,
-                                                  ReteEvaluator reteEvaluator) {
+                                                  BetaMemory bm) {
         if (bm.getSegmentMemory().isSegmentLinked() && notNode.isEmptyBetaConstraints()) {
             // this must be processed here, rather than initial insert, as we need to link the blocker
             // @TODO this could be more efficient, as it means the entire StagedLeftTuples for all previous nodes where evaluated, needlessly.
-            bm.unlinkNode(reteEvaluator);
+            bm.unlinkNode();
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryTerminalNode.java
@@ -73,7 +73,7 @@ public class PhreakQueryTerminalNode {
             DroolsQueryImpl dquery = (DroolsQueryImpl) rootEntry.getFactHandle().getObject();
             dquery.setQuery(qtnNode.getQuery());
             if (dquery.getStackEntry() != null) {
-                checkAndTriggerQueryReevaluation(activationsManager, stack, rootEntry, dquery);
+                checkAndTriggerQueryReevaluation(stack, rootEntry, dquery);
             }
 
             // Add results to the adapter
@@ -101,7 +101,7 @@ public class PhreakQueryTerminalNode {
             DroolsQueryImpl dquery = (DroolsQueryImpl) rootEntry.getFactHandle().getObject();
             dquery.setQuery(qtnNode.getQuery());
             if (dquery.getStackEntry() != null) {
-                checkAndTriggerQueryReevaluation(activationsManager, stack, rootEntry, dquery);
+                checkAndTriggerQueryReevaluation(stack, rootEntry, dquery);
             }
 
             // Add results to the adapter
@@ -131,7 +131,7 @@ public class PhreakQueryTerminalNode {
             dquery.setQuery(qtnNode.getQuery());
 
             if (dquery.getStackEntry() != null) {
-                checkAndTriggerQueryReevaluation(activationsManager, stack, rootEntry, dquery);
+                checkAndTriggerQueryReevaluation(stack, rootEntry, dquery);
             }
 
             // Add results to the adapter
@@ -145,7 +145,7 @@ public class PhreakQueryTerminalNode {
     }
 
 
-    public static void checkAndTriggerQueryReevaluation(ActivationsManager activationsManager, LinkedList<StackEntry> stack, Tuple rootEntry, DroolsQueryImpl dquery) {
+    public static void checkAndTriggerQueryReevaluation(LinkedList<StackEntry> stack, Tuple rootEntry, DroolsQueryImpl dquery) {
         StackEntry stackEntry = dquery.getStackEntry();
         if (!isAdded(stack, stackEntry)) {
             // Ignore unless stackEntry is not added to stack
@@ -165,7 +165,7 @@ public class PhreakQueryTerminalNode {
                     // reactivity comes form within the query, so need to notify parent rules to evaluate the results
                     for (int i = 0, length = pmems.size(); i < length; i++) {
                         PathMemory pmem = pmems.get(i);
-                        pmem.doLinkRule(activationsManager); // method already ignores is rule is activated and on agenda
+                        pmem.doLinkRule(); // method already ignores is rule is activated and on agenda
                     }
                 }
             }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -182,7 +182,7 @@ public class PhreakTimerNode {
                     // a expire clashes with insert or update, allow it to propagate once, will handle the expire the second time around
                     doPropagateChildLeftTuple( sink, trgLeftTuples, stagedLeftTuples, leftTuple );
                     tm.getDeleteLeftTuples().add( leftTuple );
-                    pmem.doLinkRule( activationsManager ); // make sure it's dirty, so it'll evaluate again
+                    pmem.doLinkRule( ); // make sure it's dirty, so it'll evaluate again
                     if ( log.isTraceEnabled() ) {
                         log.trace( "Timer Postponed Delete {}", leftTuple );
                     }
@@ -415,8 +415,8 @@ public class PhreakTimerNode {
                     // if the corresponding rule has been removed avoid to link and notify this pmem
                     continue;
                 }
-                ActivationsManager activationsManager = pmem.getActualActivationsManager( reteEvaluator );
-                pmem.doLinkRule( activationsManager );
+                ActivationsManager activationsManager = pmem.getActualActivationsManager( );
+                pmem.doLinkRule( );
 
                 if (needEvaluation && filter.accept(new Rule[]{pmem.getRule()})) {
                     evaluateAndFireRule( pmem, activationsManager );

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -77,8 +77,8 @@ public class RuleExecutor {
                                        AgendaFilter filter,
                                        int fireCount,
                                        int fireLimit ) {
-        evaluateNetworkIfDirty( reteEvaluator );
-        return fire(reteEvaluator, pmem.getActualActivationsManager( reteEvaluator ), filter, fireCount, fireLimit);
+        evaluateNetworkIfDirty( );
+        return fire(reteEvaluator, pmem.getActualActivationsManager( ), filter, fireCount, fireLimit);
     }
 
     public int evaluateNetworkAndFire( ActivationsManager activationsManager, AgendaFilter filter, int fireCount, int fireLimit ) {
@@ -185,7 +185,7 @@ public class RuleExecutor {
             }
         }
 
-        removeRuleAgendaItemWhenEmpty(reteEvaluator);
+        removeRuleAgendaItemWhenEmpty();
 
         fireExitedEarly = false;
         return localFireCount;
@@ -212,16 +212,16 @@ public class RuleExecutor {
         return pmem;
     }
 
-    public void removeRuleAgendaItemWhenEmpty(ReteEvaluator reteEvaluator) {
+    public void removeRuleAgendaItemWhenEmpty() {
         if (!dirty && activeMatches.isEmpty()) {
             if (log.isTraceEnabled()) {
                 log.trace("Removing RuleAgendaItem " + ruleAgendaItem);
             }
             ruleAgendaItem.remove();
             if ( ruleAgendaItem.getRule().isQuery() ) {
-                pmem.getActualActivationsManager( reteEvaluator ).removeQueryAgendaItem( ruleAgendaItem );
+                pmem.getActualActivationsManager( ).removeQueryAgendaItem( ruleAgendaItem );
             } else if ( ruleAgendaItem.getRule().isEager() ) {
-                pmem.getActualActivationsManager( reteEvaluator ).removeEagerRuleAgendaItem(ruleAgendaItem);
+                pmem.getActualActivationsManager( ).removeEagerRuleAgendaItem(ruleAgendaItem);
             }
         }
     }
@@ -231,8 +231,8 @@ public class RuleExecutor {
         setDirty( false );
     }
 
-    public void evaluateNetworkIfDirty(ReteEvaluator reteEvaluator) {
-        evaluateNetworkIfDirty(pmem.getActualActivationsManager( reteEvaluator ));
+    public void evaluateNetworkIfDirty() {
+        evaluateNetworkIfDirty(pmem.getActualActivationsManager( ));
     }
 
     public void evaluateNetworkIfDirty(ActivationsManager activationsManager) {

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -108,8 +108,7 @@ public class RuleNetworkEvaluator {
 
     private RuleNetworkEvaluator() { }
 
-    public void evaluateNetwork(ReteEvaluator reteEvaluator,
-                                RuleExecutor executor,
+    public void evaluateNetwork(RuleExecutor executor,
                                 PathMemory pmem) {
         evaluateNetwork(pmem.getActualActivationsManager(), executor, pmem);
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -111,7 +111,7 @@ public class RuleNetworkEvaluator {
     public void evaluateNetwork(ReteEvaluator reteEvaluator,
                                 RuleExecutor executor,
                                 PathMemory pmem) {
-        evaluateNetwork(pmem.getActualActivationsManager(reteEvaluator), executor, pmem);
+        evaluateNetwork(pmem.getActualActivationsManager(), executor, pmem);
     }
 
     public void evaluateNetwork(ActivationsManager activationsManager,

--- a/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuntimeSegmentUtilities.java
@@ -186,7 +186,7 @@ public class RuntimeSegmentUtilities {
 
             if (smem.getAllLinkedMaskTest() > 0 && smem.isSegmentLinked()) {
                 // not's can cause segments to be linked, and the rules need to be notified for evaluation
-                smem.notifyRuleLinkSegment(reteEvaluator);
+                smem.notifyRuleLinkSegment();
             }
         }
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/TupleEvaluationUtil.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/TupleEvaluationUtil.java
@@ -136,9 +136,8 @@ public class TupleEvaluationUtil {
         PathMemory rtnPmem = NodeTypeEnums.isTerminalNode(pmem.getPathEndNode()) ? pmem : reteEvaluator.getNodeMemory(
                 (AbstractTerminalNode) pmem.getPathEndNode().getPathEndNodes()[0]);
 
-        ActivationsManager activationsManager = pmem.getActualActivationsManager(reteEvaluator);
-        RuleNetworkEvaluator.INSTANCE.outerEval(activationsManager, rtnPmem.getOrCreateRuleAgendaItem(
-                activationsManager).getRuleExecutor(), pmem, smems, sm.getPos(), bit, mem, node,
+        ActivationsManager activationsManager = pmem.getActualActivationsManager();
+        RuleNetworkEvaluator.INSTANCE.outerEval(activationsManager, rtnPmem.getOrCreateRuleAgendaItem().getRuleExecutor(), pmem, smems, sm.getPos(), bit, mem, node,
                 leftTupleSets,
                 true);
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
@@ -114,7 +114,7 @@ public class AlphaTerminalNode extends LeftInputAdapterNode {
     public static RuleAgendaItem getRuleAgendaItem(ReteEvaluator reteEvaluator, ActivationsManager activationsManager, TerminalNode rtn, boolean linkPmem ) {
         PathMemory pathMemory = reteEvaluator.getNodeMemory( rtn );
         if (linkPmem) {
-            pathMemory.doLinkRule( activationsManager );
+            pathMemory.doLinkRule( );
         }
         return pathMemory.getRuleAgendaItem();
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/AsyncReceiveNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AsyncReceiveNode.java
@@ -131,7 +131,7 @@ public class AsyncReceiveNode extends LeftTupleSource
                     // if the corresponding rule has been removed avoid to link and notify this pmem
                     continue;
                 }
-                pmem.doLinkRule( reteEvaluator );
+                pmem.doLinkRule();
             }
         }
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaMemory.java
@@ -92,12 +92,12 @@ public class BetaMemory<C> extends AbstractLinkedListNode<Memory> implements Seg
             segmentMemory = getOrCreateSegmentMemory( tupleSource, reteEvaluator );
         }
         return notify ?
-               segmentMemory.linkNode(nodePosMaskBit, reteEvaluator) :
+               segmentMemory.linkNode(nodePosMaskBit) :
                segmentMemory.linkNodeWithoutRuleNotify(nodePosMaskBit);
     }
 
-    public boolean unlinkNode(ReteEvaluator reteEvaluator) {
-        return segmentMemory.unlinkNode(nodePosMaskBit, reteEvaluator);
+    public boolean unlinkNode() {
+        return segmentMemory.unlinkNode(nodePosMaskBit);
     }
 
     public int getNodeType() {
@@ -145,7 +145,7 @@ public class BetaMemory<C> extends AbstractLinkedListNode<Memory> implements Seg
             segmentMemory = getOrCreateSegmentMemory( tupleSource, reteEvaluator );
         }
         return notify ?
-               segmentMemory.notifyRuleLinkSegment(reteEvaluator, nodePosMaskBit) :
+               segmentMemory.notifyRuleLinkSegment(nodePosMaskBit) :
                segmentMemory.linkSegmentWithoutRuleNotify(nodePosMaskBit);
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -195,7 +195,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
             // if there is no left memory, then there is no linking or notification
             if ( linkOrNotify ) {
                 // link and notify
-                lm.linkNode( reteEvaluator );
+                lm.linkNode( );
             } else {
                 // link without notify, when driven by a query, as we don't want it, placed on the agenda
                 lm.linkNodeWithoutRuleNotify();
@@ -247,7 +247,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
         if ( pmem != null ) {
             forceFlushLeftTuple( reteEvaluator, pmem, sm, createLeftTupleTupleSets(leftTuple, Tuple.INSERT) );
             if ( linkOrNotify ) {
-                lm.setNodeDirty( reteEvaluator );
+                lm.setNodeDirty( );
             }
             return findPathsToFlushFromSubnetwork(reteEvaluator, pmem);
         }
@@ -257,7 +257,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
 
         if ( stagedInsertWasEmpty && linkOrNotify  ) {
             // staged is empty, so notify rule, to force re-evaluation.
-            lm.setNodeDirty(reteEvaluator);
+            lm.setNodeDirty();
         }
         return Collections.emptyList();
     }
@@ -296,7 +296,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
 
         if ( lm.getAndDecreaseCounter() == 1 ) {
             if ( linkOrNotify ) {
-                lm.unlinkNode( reteEvaluator );
+                lm.unlinkNode( );
             } else {
                 lm.unlinkNodeWithoutRuleNotify();
             }
@@ -308,7 +308,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
         leftTuple.setPropagationContext( pctx );
         if ( flushLeftTupleIfNecessary( reteEvaluator, sm, leftTuple, streamMode, Tuple.DELETE ) ) {
             if ( linkOrNotify ) {
-                lm.setNodeDirty( reteEvaluator );
+                lm.setNodeDirty( );
             }
             return;
         }
@@ -318,7 +318,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
 
         if (  stagedDeleteWasEmpty && linkOrNotify ) {
             // staged is empty, so notify rule, to force re-evaluation
-            lm.setNodeDirty(reteEvaluator);
+            lm.setNodeDirty();
         }
     }
 
@@ -360,7 +360,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
         if ( leftTuple.getStagedType() == LeftTuple.NONE ) {
             if ( flushLeftTupleIfNecessary( reteEvaluator, sm, leftTuple, streamMode, Tuple.UPDATE ) ) {
                 if ( linkOrNotify ) {
-                    lm.setNodeDirty( reteEvaluator );
+                    lm.setNodeDirty( );
                 }
                 return;
             }
@@ -370,7 +370,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
 
             if ( stagedUpdateWasEmpty  && linkOrNotify ) {
                 // staged is empty, so notify rule, to force re-evaluation
-                lm.setNodeDirty(reteEvaluator);
+                lm.setNodeDirty();
             }
         }
     }
@@ -572,12 +572,12 @@ public class LeftInputAdapterNode extends LeftTupleSource
             segmentMemory.linkNodeWithoutRuleNotify(nodePosMaskBit);
         }
 
-        public void linkNode(ReteEvaluator reteEvaluator) {
-            segmentMemory.linkNode(nodePosMaskBit, reteEvaluator);
+        public void linkNode() {
+            segmentMemory.linkNode(nodePosMaskBit);
         }
 
-        public boolean unlinkNode(ReteEvaluator reteEvaluator) {
-            return segmentMemory.unlinkNode(nodePosMaskBit, reteEvaluator);
+        public boolean unlinkNode() {
+            return segmentMemory.unlinkNode(nodePosMaskBit);
         }
 
         public void unlinkNodeWithoutRuleNotify() {
@@ -588,8 +588,8 @@ public class LeftInputAdapterNode extends LeftTupleSource
             return NodeTypeEnums.LeftInputAdapterNode;
         }
 
-        public void setNodeDirty(ReteEvaluator reteEvaluator) {
-            segmentMemory.notifyRuleLinkSegment(reteEvaluator, nodePosMaskBit);
+        public void setNodeDirty() {
+            segmentMemory.notifyRuleLinkSegment(nodePosMaskBit);
         }
 
         public void reset() {

--- a/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
@@ -33,34 +33,38 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PathMemory extends AbstractLinkedListNode<Memory>
-        implements
-        Serializable, Memory {
+                        implements
+                        Serializable, Memory {
 
     protected static final Logger log = LoggerFactory.getLogger(PathMemory.class);
     protected static final boolean isLogTraceEnabled = log.isTraceEnabled();
 
-    private          long              linkedSegmentMask;
-    private          long              allLinkedMaskTest;
-    private final    PathEndNode       pathEndNode;
-    private          RuleAgendaItem    agendaItem;
-    private          SegmentMemory[]   segmentMemories;
-    private          SegmentMemory     segmentMemory;
+    private long linkedSegmentMask;
+    private long allLinkedMaskTest;
+    private final PathEndNode pathEndNode;
+    private RuleAgendaItem agendaItem;
+    private SegmentMemory[] segmentMemories;
+    private SegmentMemory segmentMemory;
 
-    public  final    boolean           dataDriven;
+    public final boolean dataDriven;
+
+    private ActivationsManager activationsManager;
 
     public PathMemory(PathEndNode pathEndNode, ReteEvaluator reteEvaluator) {
         this.pathEndNode = pathEndNode;
         this.linkedSegmentMask = 0L;
-        this.dataDriven = initDataDriven( reteEvaluator );
+        this.dataDriven = initDataDriven(reteEvaluator);
+        this.activationsManager = reteEvaluator.getActivationsManager().getPartitionedAgendaForNode(getPathEndNode());
     }
 
-    protected boolean initDataDriven( ReteEvaluator reteEvaluator ) {
-        return isRuleDataDriven( reteEvaluator, getRule() );
+    protected boolean initDataDriven(ReteEvaluator reteEvaluator) {
+        return isRuleDataDriven(reteEvaluator, getRule());
     }
 
-    protected boolean isRuleDataDriven( ReteEvaluator reteEvaluator, RuleImpl rule ) {
+    protected boolean isRuleDataDriven(ReteEvaluator reteEvaluator, RuleImpl rule) {
         return rule != null &&
-               ( rule.isDataDriven() || ( reteEvaluator != null && reteEvaluator.getRuleSessionConfiguration().getForceEagerActivationFilter().accept(rule) ));
+               (rule.isDataDriven() || (reteEvaluator != null && reteEvaluator.getRuleSessionConfiguration()
+                       .getForceEagerActivationFilter().accept(rule)));
     }
 
     public PathEndNode getPathEndNode() {
@@ -95,7 +99,7 @@ public class PathMemory extends AbstractLinkedListNode<Memory>
         linkedSegmentMask |= mask;
     }
 
-    public void linkSegment(long mask, ReteEvaluator reteEvaluator) {
+    public void linkSegment(long mask) {
         linkedSegmentMask |= mask;
         if (isLogTraceEnabled) {
             if (NodeTypeEnums.isTerminalNode(getPathEndNode())) {
@@ -106,16 +110,16 @@ public class PathMemory extends AbstractLinkedListNode<Memory>
             }
         }
         if (isRuleLinked()) {
-            doLinkRule(reteEvaluator);
+            doLinkRule();
         }
     }
 
-    public RuleAgendaItem getOrCreateRuleAgendaItem(ActivationsManager activationsManager) {
-        ensureAgendaItemCreated(activationsManager);
+    public RuleAgendaItem getOrCreateRuleAgendaItem() {
+        ensureAgendaItemCreated();
         return agendaItem;
     }
 
-    private TerminalNode ensureAgendaItemCreated(ActivationsManager activationsManager) {
+    private TerminalNode ensureAgendaItemCreated() {
         AbstractTerminalNode rtn = (AbstractTerminalNode) getPathEndNode();
         if (agendaItem == null) {
             int salience = rtn.getRule().getSalience().isDynamic() ? 0 : rtn.getRule().getSalience().getValue();
@@ -124,70 +128,62 @@ public class PathMemory extends AbstractLinkedListNode<Memory>
         return rtn;
     }
 
-    public void doLinkRule(ReteEvaluator reteEvaluator) {
-        doLinkRule( getActualActivationsManager( reteEvaluator ) );
-    }
-
-    public void doLinkRule(ActivationsManager activationsManager) {
-        TerminalNode rtn = ensureAgendaItemCreated(activationsManager);
+    public void doLinkRule() {
+        TerminalNode rtn = ensureAgendaItemCreated();
         if (isLogTraceEnabled) {
             log.trace(" LinkRule name={}", rtn.getRule().getName());
         }
 
-        queueRuleAgendaItem(activationsManager);
+        queueRuleAgendaItem();
     }
 
-    public void doUnlinkRule(ReteEvaluator reteEvaluator) {
-        doUnlinkRule( getActualActivationsManager( reteEvaluator ) );
-    }
-
-    public void doUnlinkRule(ActivationsManager activationsManager) {
-        TerminalNode rtn = ensureAgendaItemCreated(activationsManager);
+    public void doUnlinkRule() {
+        TerminalNode rtn = ensureAgendaItemCreated();
         if (isLogTraceEnabled) {
             log.trace("    UnlinkRule name={}", rtn.getRule().getName());
         }
 
         agendaItem.getRuleExecutor().setDirty(true);
-        if ( !agendaItem.isQueued() ) {
-            if ( isLogTraceEnabled ) {
+        if (!agendaItem.isQueued()) {
+            if (isLogTraceEnabled) {
                 log.trace("Queue RuleAgendaItem {}", agendaItem);
             }
             InternalAgendaGroup ag = agendaItem.getAgendaGroup();
-            ag.add( agendaItem );
+            ag.add(agendaItem);
         }
     }
 
-    public void queueRuleAgendaItem(ActivationsManager activationsManager) {
+    public void queueRuleAgendaItem() {
         agendaItem.getRuleExecutor().setDirty(true);
 
         ActivationsFilter activationFilter = activationsManager.getActivationsFilter();
-        if ( activationFilter != null ) {
-            activationFilter.accept( agendaItem );
+        if (activationFilter != null) {
+            activationFilter.accept(agendaItem);
         }
 
-        if ( !agendaItem.isQueued() ) {
-            if ( isLogTraceEnabled ) {
+        if (!agendaItem.isQueued()) {
+            if (isLogTraceEnabled) {
                 log.trace("Queue RuleAgendaItem {}", agendaItem);
             }
             InternalAgendaGroup ag = agendaItem.getAgendaGroup();
-            ag.add( agendaItem );
+            ag.add(agendaItem);
         }
 
-        if ( agendaItem.getRule().isQuery() ) {
-            activationsManager.addQueryAgendaItem( agendaItem );
-        } else if ( agendaItem.getRule().isEager() ) {
-            activationsManager.addEagerRuleAgendaItem( agendaItem );
+        if (agendaItem.getRule().isQuery()) {
+            activationsManager.addQueryAgendaItem(agendaItem);
+        } else if (agendaItem.getRule().isEager()) {
+            activationsManager.addEagerRuleAgendaItem(agendaItem);
         }
     }
 
-    public void unlinkedSegment(long mask, ReteEvaluator reteEvaluator) {
-        boolean linkedRule =  isRuleLinked();
+    public void unlinkedSegment(long mask) {
+        boolean linkedRule = isRuleLinked();
         linkedSegmentMask &= ~mask;
         if (isLogTraceEnabled) {
             log.trace("  UnlinkSegment smask={} rmask={} name={}", mask, linkedSegmentMask, this);
         }
         if (linkedRule && !isRuleLinked()) {
-            doUnlinkRule(reteEvaluator);
+            doUnlinkRule();
         }
     }
 
@@ -237,8 +233,7 @@ public class PathMemory extends AbstractLinkedListNode<Memory>
         this.agendaItem = null;
     }
 
-    public ActivationsManager getActualActivationsManager(ReteEvaluator reteEvaluator) {
-        ActivationsManager activationsManager = reteEvaluator.getActivationsManager();
-        return activationsManager.getPartitionedAgendaForNode( getPathEndNode() );
+    public ActivationsManager getActualActivationsManager() {
+        return activationsManager;
     }
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
@@ -176,7 +176,7 @@ public abstract class RightInputAdapterNode<T extends  BetaNode> extends BaseNod
             if ( stagedDeleteWasEmpty ) {
                 memory.setNodeDirtyWithoutNotify();
             }
-            shouldFlush = memory.unlinkNode(reteEvaluator) | shouldFlush;
+            shouldFlush = memory.unlinkNode() | shouldFlush;
         } else if ( stagedDeleteWasEmpty ) {
             // nothing staged before, notify rule, so it can evaluate network
             shouldFlush = memory.setNodeDirty( betaNode, reteEvaluator ) | shouldFlush;

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
@@ -142,7 +142,7 @@ public class RuleTerminalNode extends AbstractTerminalNode {
                 }
             }
             RuleExecutor ruleExecutor = ((RuleTerminalNodeLeftTuple)leftTuple).getRuleAgendaItem().getRuleExecutor();
-            PhreakRuleTerminalNode.doLeftDelete(ruleExecutor.getPathMemory().getActualActivationsManager( reteEvaluator ), ruleExecutor, (RuleTerminalNodeLeftTuple) leftTuple);
+            PhreakRuleTerminalNode.doLeftDelete(ruleExecutor.getPathMemory().getActualActivationsManager( ), ruleExecutor, (RuleTerminalNodeLeftTuple) leftTuple);
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
@@ -26,7 +26,6 @@ import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.base.rule.Declaration;
 import org.drools.base.rule.GroupElement;
-import org.drools.core.common.ReteEvaluator;
 import org.drools.core.phreak.PhreakRuleTerminalNode;
 import org.drools.core.phreak.RuleExecutor;
 import org.drools.core.reteoo.builder.BuildContext;
@@ -132,7 +131,7 @@ public class RuleTerminalNode extends AbstractTerminalNode {
         return consequenceName == null ? RuleImpl.DEFAULT_CONSEQUENCE_NAME : consequenceName;
     }
 
-    public void cancelMatch(InternalMatch match, ReteEvaluator reteEvaluator) {
+    public void cancelMatch(InternalMatch match) {
         if ( match.isQueued() ) {
             TupleImpl leftTuple = match.getTuple();
             if ( match.getRuleAgendaItem() != null ) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
@@ -150,7 +150,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         return sbuilder.toString();
     }
 
-    public boolean linkNode(long mask, ReteEvaluator reteEvaluator) {
+    public boolean linkNode(long mask) {
         linkedNodeMask |= mask;
         dirtyNodeMask |= mask;
         if (IS_LOG_TRACE_ENABLED) {
@@ -158,7 +158,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
                     getRuleNames());
         }
 
-        return notifyRuleLinkSegment(reteEvaluator);
+        return notifyRuleLinkSegment();
     }
 
     public boolean linkNodeWithoutRuleNotify(long mask) {
@@ -190,29 +190,29 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         return dataDrivePmemLinked;
     }
 
-    public boolean notifyRuleLinkSegment(ReteEvaluator reteEvaluator, long mask) {
+    public boolean notifyRuleLinkSegment(long mask) {
         dirtyNodeMask |= mask;
-        return notifyRuleLinkSegment(reteEvaluator);
+        return notifyRuleLinkSegment();
     }
 
-    public boolean notifyRuleLinkSegment(ReteEvaluator reteEvaluator) {
+    public boolean notifyRuleLinkSegment() {
         boolean dataDrivePmemLinked = false;
         if (isSegmentLinked()) {
             for (int i = 0, length = pathMemories.size(); i < length; i++) {
                 // do not use foreach, don't want Iterator object creation
                 PathMemory pmem = pathMemories.get(i);
-                notifyRuleLinkSegment(reteEvaluator, pmem);
+                notifyRuleLinkSegment(pmem);
                 dataDrivePmemLinked |= (pmem.isDataDriven() && pmem.isRuleLinked());
             }
         }
         return dataDrivePmemLinked;
     }
 
-    public void notifyRuleLinkSegment(ReteEvaluator reteEvaluator, PathMemory pmem) {
-        pmem.linkSegment(segmentPosMaskBit, reteEvaluator);
+    public void notifyRuleLinkSegment(PathMemory pmem) {
+        pmem.linkSegment(segmentPosMaskBit);
     }
 
-    public boolean unlinkNode(long mask, ReteEvaluator reteEvaluator) {
+    public boolean unlinkNode(long mask) {
         boolean dataDrivePmemLinked = false;
         boolean linked = isSegmentLinked();
         // some node unlinking does not unlink the segment, such as nodes after a Branch CE
@@ -230,24 +230,24 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
                 PathMemory pmem = pathMemories.get(i);
                 // the data driven pmem has to be flushed only if the pmem was formerly linked
                 dataDrivePmemLinked |= (pmem.isDataDriven() && pmem.isRuleLinked());
-                pmem.unlinkedSegment(segmentPosMaskBit, reteEvaluator);
+                pmem.unlinkedSegment(segmentPosMaskBit);
             }
         } else {
             // if not unlinked, then we still need to notify if the rule is linked
             for (int i = 0, length = pathMemories.size(); i < length; i++) {
                 // do not use foreach, don't want Iterator object creation
                 if (pathMemories.get(i).isRuleLinked()) {
-                    pathMemories.get(i).doLinkRule(reteEvaluator);
+                    pathMemories.get(i).doLinkRule();
                 }
             }
         }
         return dataDrivePmemLinked;
     }
 
-    public void unlinkSegment(ReteEvaluator reteEvaluator) {
+    public void unlinkSegment() {
         for (int i = 0, length = pathMemories.size(); i < length; i++) {
             // do not use foreach, don't want Iterator object creation
-            pathMemories.get(i).unlinkedSegment(segmentPosMaskBit, reteEvaluator);
+            pathMemories.get(i).unlinkedSegment(segmentPosMaskBit);
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/SingleObjectSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SingleObjectSinkAdapter.java
@@ -132,7 +132,7 @@ public class SingleObjectSinkAdapter implements ObjectSinkPropagator {
         if (sink.getType() == NodeTypeEnums.NotNode) {
             bm.linkNode( ( BetaNode ) sink, reteEvaluator );
         } else {
-            bm.unlinkNode(reteEvaluator);
+            bm.unlinkNode();
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
@@ -19,10 +19,7 @@
 package org.drools.core.reteoo;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-
 import org.drools.base.base.ObjectType;
 import org.drools.base.common.NetworkNode;
 import org.drools.base.definitions.rule.impl.RuleImpl;
@@ -45,22 +42,23 @@ import org.kie.api.definition.rule.Rule;
  * the main network.
  */
 public class TupleToObjectNode extends ObjectSource
-    implements
-    LeftTupleSinkNode,
-    PathEndNode {
+                               implements
+                               LeftTupleSinkNode,
+                               PathEndNode {
 
     private static final long serialVersionUID = 510l;
 
-    private LeftTupleSource   tupleSource;
+    private LeftTupleSource tupleSource;
 
     /**
      * This is first node inside of the subnetwork. The split, with two outs, would be the parent node.
      */
-    private LeftTupleSource   startTupleSource;
+    private LeftTupleSource startTupleSource;
 
-    private boolean           tupleMemoryEnabled;
+    private boolean tupleMemoryEnabled;
 
     private LeftTupleSinkNode previousTupleSinkNode;
+
     private LeftTupleSinkNode nextTupleSinkNode;
 
     private LeftTupleNode[] pathNodes;
@@ -75,8 +73,7 @@ public class TupleToObjectNode extends ObjectSource
 
     private int objectCount;
 
-    public TupleToObjectNode() {
-    }
+    public TupleToObjectNode() {}
 
     /**
      * Constructor specifying the unique id of the node in the Rete network, the position of the propagating <code>FactHandleImpl</code> in
@@ -91,20 +88,19 @@ public class TupleToObjectNode extends ObjectSource
                              final LeftTupleSource source,
                              final LeftTupleSource startTupleSource,
                              final BuildContext context) {
-        super( id, context.getPartitionId() );
+        super(id, context.getPartitionId());
         this.tupleSource = source;
         this.tupleMemoryEnabled = context.isTupleMemoryEnabled();
         this.startTupleSource = startTupleSource;
 
         hashcode = calculateHashCode();
-        initMemoryId( context );
+        initMemoryId(context);
     }
 
     @Override
     public PathMemSpec getPathMemSpec() {
         return getPathMemSpec(null);
     }
-
 
     /**
      * used during network build time, potentially during rule removal time.
@@ -114,11 +110,10 @@ public class TupleToObjectNode extends ObjectSource
     @Override
     public PathMemSpec getPathMemSpec(TerminalNode removingTN) {
         if (pathMemSpec == null) {
-            pathMemSpec = calculatePathMemSpec( startTupleSource, removingTN );
+            pathMemSpec = calculatePathMemSpec(startTupleSource, removingTN);
         }
         return pathMemSpec;
     }
-
 
     @Override
     public void nullPathMemSpec() {
@@ -184,23 +179,23 @@ public class TupleToObjectNode extends ObjectSource
 
     /**
      * Creates and return the node memory
-     */    
+     */
     public SubnetworkPathMemory createMemory(final RuleBaseConfiguration config, ReteEvaluator reteEvaluator) {
-        return (SubnetworkPathMemory) AbstractTerminalNode.initPathMemory(this, new SubnetworkPathMemory(this, reteEvaluator));
+        return (SubnetworkPathMemory) AbstractTerminalNode.initPathMemory(this, new SubnetworkPathMemory(this,
+                reteEvaluator));
     }
 
-    public void doAttach( BuildContext context ) {
-        this.tupleSource.addTupleSink( this, context );
+    public void doAttach(BuildContext context) {
+        this.tupleSource.addTupleSink(this, context);
     }
 
     public void networkUpdated(UpdateContext updateContext) {
         this.tupleSource.networkUpdated(updateContext);
     }
 
-
     protected boolean doRemove(final RuleRemovalContext context,
-                            final ReteooBuilder builder) {
-        if ( !isInUse() ) {
+                               final ReteooBuilder builder) {
+        if (!isInUse()) {
             tupleSource.removeTupleSink(this);
             return true;
         }
@@ -261,22 +256,24 @@ public class TupleToObjectNode extends ObjectSource
             return true;
         }
 
-        return ((NetworkNode)object).getType() == NodeTypeEnums.TupleToObjectNode && this.hashCode() == object.hashCode() &&
-               this.tupleSource.getId() == ((TupleToObjectNode)object).tupleSource.getId() &&
-               this.tupleMemoryEnabled == ( (TupleToObjectNode) object ).tupleMemoryEnabled;
+        return ((NetworkNode) object).getType() == NodeTypeEnums.TupleToObjectNode && this.hashCode() == object
+                .hashCode() &&
+               this.tupleSource.getId() == ((TupleToObjectNode) object).tupleSource.getId() &&
+               this.tupleMemoryEnabled == ((TupleToObjectNode) object).tupleMemoryEnabled;
     }
 
     @Override
     public String toString() {
-        return "RightInputAdapterNode(" + id + ")[ tupleMemoryEnabled=" + tupleMemoryEnabled + ", tupleSource=" + tupleSource + ", source="
-               + source + ", associations=" + associations + ", partitionId=" + partitionId + "]";
+        return "RightInputAdapterNode(" + id + ")[ tupleMemoryEnabled=" + tupleMemoryEnabled + ", tupleSource=" +
+                tupleSource + ", source=" + source + ", associations=" + associations + ", partitionId=" + partitionId +
+                "]";
     }
 
     public LeftTupleSource getLeftTupleSource() {
         return this.tupleSource;
     }
 
-    public void setTupleSource( LeftTupleSource tupleSource ) {
+    public void setTupleSource(LeftTupleSource tupleSource) {
         this.tupleSource = tupleSource;
     }
 
@@ -286,15 +283,15 @@ public class TupleToObjectNode extends ObjectSource
 
     public void setInputOtnId(ObjectTypeNodeId leftInputOtnId) {
         throw new UnsupportedOperationException();
-    }      
-    
+    }
+
     @Override
     public BitMask calculateDeclaredMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
         throw new UnsupportedOperationException();
     }
 
     public static class SubnetworkPathMemory extends PathMemory implements Memory {
-        private List<RuleImpl> rules;
+
         private ReteEvaluator reteEvaluator;
 
         public SubnetworkPathMemory(PathEndNode pathEndNode, ReteEvaluator reteEvaluator) {
@@ -303,11 +300,11 @@ public class TupleToObjectNode extends ObjectSource
         }
 
         @Override
-        protected boolean initDataDriven( ReteEvaluator reteEvaluator ) {
+        protected boolean initDataDriven(ReteEvaluator reteEvaluator) {
             for (PathEndNode pnode : getPathEndNode().getPathEndNodes()) {
                 if (NodeTypeEnums.isTerminalNode(pnode)) {
-                    RuleImpl rule = ( (TerminalNode) pnode ).getRule();
-                    if ( isRuleDataDriven( reteEvaluator, rule ) ) {
+                    RuleImpl rule = ((TerminalNode) pnode).getRule();
+                    if (isRuleDataDriven(reteEvaluator, rule)) {
                         return true;
                     }
                 }
@@ -335,8 +332,8 @@ public class TupleToObjectNode extends ObjectSource
         }
 
         public String toString() {
-            return "TupleToObjectNodeMem(" + getTupleToObjectNode().getId() + ") ["
-                    + RuleNameExtractor.getRuleNames(getTupleToObjectNode().getObjectSinkPropagator().getSinks()) + "]";
+            return "TupleToObjectNodeMem(" + getTupleToObjectNode().getId() + ") [" + RuleNameExtractor.getRuleNames(
+                    getTupleToObjectNode().getObjectSinkPropagator().getSinks()) + "]";
         }
     }
 
@@ -351,7 +348,7 @@ public class TupleToObjectNode extends ObjectSource
 
     public LeftTupleNode[] getPathNodes() {
         if (pathNodes == null) {
-            pathNodes = AbstractTerminalNode.getPathNodes( this );
+            pathNodes = AbstractTerminalNode.getPathNodes(this);
         }
         return pathNodes;
     }
@@ -372,11 +369,11 @@ public class TupleToObjectNode extends ObjectSource
     @Override
     public void addAssociation(Rule rule, BuildContext context) {
         super.addAssociation(rule, context);
-        context.addPathEndNode( this );
+        context.addPathEndNode(this);
     }
 
     @Override
-    public boolean removeAssociation( Rule rule, RuleRemovalContext context ) {
+    public boolean removeAssociation(Rule rule, RuleRemovalContext context) {
         boolean result = super.associations.remove(rule);
         if (getAssociationsSize() == 0) {
             // avoid to recalculate the pathEndNodes if this node is going to be removed
@@ -389,7 +386,7 @@ public class TupleToObjectNode extends ObjectSource
                 remainingPathNodes.add(pathEndNode);
             }
         }
-        pathEndNodes = remainingPathNodes.toArray( new PathEndNode[remainingPathNodes.size()] );
+        pathEndNodes = remainingPathNodes.toArray(new PathEndNode[remainingPathNodes.size()]);
         return result;
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
@@ -29,7 +29,6 @@ import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.base.rule.Pattern;
 import org.drools.core.RuleBaseConfiguration;
-import org.drools.core.common.ActivationsManager;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Memory;
 import org.drools.core.common.PropagationContext;
@@ -295,9 +294,12 @@ public class TupleToObjectNode extends ObjectSource
     }
 
     public static class SubnetworkPathMemory extends PathMemory implements Memory {
+        private List<RuleImpl> rules;
+        private ReteEvaluator reteEvaluator;
 
         public SubnetworkPathMemory(PathEndNode pathEndNode, ReteEvaluator reteEvaluator) {
             super(pathEndNode, reteEvaluator);
+            this.reteEvaluator = reteEvaluator;
         }
 
         @Override
@@ -318,17 +320,12 @@ public class TupleToObjectNode extends ObjectSource
         }
 
         @Override
-        public void doLinkRule(ReteEvaluator reteEvaluator) {
+        public void doLinkRule() {
             getTupleToObjectNode().getObjectSinkPropagator().doLinkSubnetwork(reteEvaluator);
         }
 
         @Override
-        public void doLinkRule(ActivationsManager activationsManager) {
-            doLinkRule(activationsManager.getReteEvaluator());
-        }
-
-        @Override
-        public void doUnlinkRule(ReteEvaluator reteEvaluator) {
+        public void doUnlinkRule() {
             getTupleToObjectNode().getObjectSinkPropagator().doUnlinkSubnetwork(reteEvaluator);
         }
 

--- a/drools-kiesession/src/main/java/org/drools/kiesession/consequence/DefaultKnowledgeHelper.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/consequence/DefaultKnowledgeHelper.java
@@ -178,7 +178,7 @@ public class DefaultKnowledgeHelper implements KnowledgeHelper, Externalizable {
 
     public void cancelMatch(Match act) {
         InternalMatch match = (InternalMatch) act;
-        ((RuleTerminalNode)match.getTerminalNode()).cancelMatch( match, reteEvaluator);
+        ((RuleTerminalNode)match.getTerminalNode()).cancelMatch( match);
     }
 
     public FactHandle getFactHandle(Object object) {

--- a/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
@@ -532,7 +532,7 @@ public class NodeSegmentUnlinkingTest {
         n3.getRightInput().assertObject( f1, context, ksession );
                 
         // this doesn't unlink on the assertObject, as the node's memory must be processed. So use the helper method the main network evaluator uses.
-        PhreakNotNode.unlinkNotNodeOnRightInsert( (NotNode) n3, bm, ksession );
+        PhreakNotNode.unlinkNotNodeOnRightInsert( (NotNode) n3, bm );
         assertThat(bm.getSegmentMemory().isSegmentLinked()).isFalse();                
 
         n3.getRightInput().retractRightTuple( f1.getFirstRightTuple(), context, ksession );

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufInputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufInputMarshaller.java
@@ -755,13 +755,13 @@ public class ProtobufInputMarshaller {
 
         public void evaluateRNEAs(final InternalWorkingMemory wm) {
             for ( RuleAgendaItem rai : rneaToFire ) {
-                rai.getRuleExecutor().evaluateNetworkIfDirty( wm );
+                rai.getRuleExecutor().evaluateNetworkIfDirty( );
             }
         }
 
         public void removeEmptyRNEAs(final InternalWorkingMemory wm) {
             for ( RuleAgendaItem rai : rneaToFire ) {
-                rai.getRuleExecutor().removeRuleAgendaItemWhenEmpty( wm );
+                rai.getRuleExecutor().removeRuleAgendaItemWhenEmpty( );
             }
             rneaToFire.clear();
         }
@@ -769,8 +769,8 @@ public class ProtobufInputMarshaller {
         public void fireRNEAs(final InternalWorkingMemory wm) {
             for ( RuleAgendaItem rai : rneaToFire ) {
                 RuleExecutor ruleExecutor = rai.getRuleExecutor();
-                ruleExecutor.evaluateNetworkIfDirty( wm );
-                ruleExecutor.removeRuleAgendaItemWhenEmpty( wm );
+                ruleExecutor.evaluateNetworkIfDirty( );
+                ruleExecutor.removeRuleAgendaItemWhenEmpty( );
             }
             rneaToFire.clear();
         }

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufOutputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufOutputMarshaller.java
@@ -239,8 +239,8 @@ public class ProtobufOutputMarshaller {
             // this must clone as re-evaluation will under underlying Collection
             for ( RuleAgendaItem activation : new ArrayList<>(wm.getAgenda().getAgendaGroupsManager().getActivations())) {
                 // evaluate it
-                activation.getRuleExecutor().evaluateNetworkIfDirty( wm );
-                activation.getRuleExecutor().removeRuleAgendaItemWhenEmpty( wm );
+                activation.getRuleExecutor().evaluateNetworkIfDirty( );
+                activation.getRuleExecutor().removeRuleAgendaItemWhenEmpty( );
             }
             dirty = false;
             // network evaluation with phreak and TMS may make previous processed rules dirty again, so need to reprocess until all is flushed.


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

A new PR - this is about moving ActivationsManager inside the PathMemory. 

There was tons of code that was just moving around ReteEvaluator to make it available to the PathMemory itself.

Now PathMemory keeps a reference to the ActivationsManager.

The consequence is that - for example - SegmentMemory now has many less usages for ReteEvaluator.

I plan to tackle them in another PR.

I feel we are moving in the right direction.
