### PR TITLE
[incubator-kie-issues #203] Cleanup Phreak code - Create segment memory factory

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/Memory.java
+++ b/drools-core/src/main/java/org/drools/core/common/Memory.java
@@ -18,7 +18,6 @@
  */
 package org.drools.core.common;
 
-import org.drools.core.phreak.RuntimeSegmentUtilities;
 import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.util.DoubleLinkedEntry;
@@ -35,7 +34,7 @@ public interface Memory extends DoubleLinkedEntry<Memory> {
     default SegmentMemory getOrCreateSegmentMemory( LeftTupleSource tupleSource, ReteEvaluator reteEvaluator ) {
         SegmentMemory smem = getSegmentMemory();
         if (smem == null) {
-            smem = RuntimeSegmentUtilities.getOrCreateSegmentMemory(reteEvaluator, tupleSource, this);
+            smem = reteEvaluator.getSegmentMemorySupport().getOrCreateSegmentMemory(tupleSource, this);
         }
         return smem;
     }

--- a/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/common/ReteEvaluator.java
@@ -68,6 +68,8 @@ public interface ReteEvaluator extends ValueResolver {
     <T extends Memory> T getNodeMemory(MemoryFactory<T> node);
 
     NodeMemories getNodeMemories();
+    
+    SegmentMemorySupport getSegmentMemorySupport();
 
     default Object getGlobal(String identifier) {
         return getGlobalResolver().resolveGlobal( identifier );

--- a/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
+++ b/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
@@ -1,0 +1,30 @@
+package org.drools.core.common;
+
+import org.drools.core.reteoo.BetaNode;
+import org.drools.core.reteoo.LeftTupleNode;
+import org.drools.core.reteoo.LeftTupleSinkPropagator;
+import org.drools.core.reteoo.PathEndNode;
+import org.drools.core.reteoo.PathMemory;
+import org.drools.core.reteoo.QueryElementNode;
+import org.drools.core.reteoo.SegmentMemory;
+import org.drools.core.reteoo.TupleToObjectNode;
+
+public interface SegmentMemorySupport {
+    
+    public SegmentMemory getOrCreateSegmentMemory(LeftTupleNode node);
+    
+    public SegmentMemory getOrCreateSegmentMemory(LeftTupleNode node, Memory memory);
+    
+    public SegmentMemory getQuerySegmentMemory(QueryElementNode queryNode);
+    
+    public void createChildSegments(LeftTupleSinkPropagator sinkProp, SegmentMemory smem);
+    
+    public SegmentMemory createChildSegment(LeftTupleNode node);
+    
+    public TupleToObjectNode createSubnetworkSegmentMemory(BetaNode betaNode);
+    
+    public PathMemory initializePathMemory(PathEndNode pathEndNode);
+    
+    
+
+}

--- a/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
+++ b/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
@@ -3,6 +3,7 @@ package org.drools.core.common;
 import org.drools.core.reteoo.BetaNode;
 import org.drools.core.reteoo.LeftTupleNode;
 import org.drools.core.reteoo.LeftTupleSinkPropagator;
+import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.PathEndNode;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.QueryElementNode;
@@ -15,16 +16,29 @@ public interface SegmentMemorySupport {
     
     public SegmentMemory getOrCreateSegmentMemory(LeftTupleNode node, Memory memory);
     
+    public SegmentMemory createSegmentMemoryLazily(LeftTupleSource segmentRoot);
+    
     public SegmentMemory getQuerySegmentMemory(QueryElementNode queryNode);
     
     public void createChildSegments(LeftTupleSinkPropagator sinkProp, SegmentMemory smem);
-    
+      
     public SegmentMemory createChildSegment(LeftTupleNode node);
+   
+    public SegmentMemory createChildSegmentLazily(LeftTupleNode node);
     
     public TupleToObjectNode createSubnetworkSegmentMemory(BetaNode betaNode);
     
     public PathMemory initializePathMemory(PathEndNode pathEndNode);
     
+    public void checkEagerSegmentCreation(LeftTupleSource lt, int nodeTypesInSegment);
+    
+    public int checkSegmentBoundary(LeftTupleSource lt, int nodeTypesInSegment);
+    
+    public int updateSubnetworkAndTerminalMemoryLazily(LeftTupleSource lt,
+                                                       LeftTupleSource originalLt,
+                                                       SegmentMemory smem,
+                                                       boolean fromPrototype,
+                                                       int nodeTypesInSegment);
     
 
 }

--- a/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
+++ b/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
@@ -1,6 +1,5 @@
 package org.drools.core.common;
 
-import org.drools.core.reteoo.BetaNode;
 import org.drools.core.reteoo.LeftTupleNode;
 import org.drools.core.reteoo.LeftTupleSinkPropagator;
 import org.drools.core.reteoo.LeftTupleSource;
@@ -8,7 +7,6 @@ import org.drools.core.reteoo.PathEndNode;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.QueryElementNode;
 import org.drools.core.reteoo.SegmentMemory;
-import org.drools.core.reteoo.TupleToObjectNode;
 
 public interface SegmentMemorySupport {
     
@@ -26,19 +24,10 @@ public interface SegmentMemorySupport {
    
     public SegmentMemory createChildSegmentLazily(LeftTupleNode node);
     
-    public TupleToObjectNode createSubnetworkSegmentMemory(BetaNode betaNode);
-    
     public PathMemory initializePathMemory(PathEndNode pathEndNode);
     
     public void checkEagerSegmentCreation(LeftTupleSource lt, int nodeTypesInSegment);
     
-    public int checkSegmentBoundary(LeftTupleSource lt, int nodeTypesInSegment);
-    
-    public int updateSubnetworkAndTerminalMemoryLazily(LeftTupleSource lt,
-                                                       LeftTupleSource originalLt,
-                                                       SegmentMemory smem,
-                                                       boolean fromPrototype,
-                                                       int nodeTypesInSegment);
     
 
 }

--- a/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
+++ b/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.core.common;
 
 import org.drools.core.reteoo.LeftTupleNode;
@@ -27,7 +45,4 @@ public interface SegmentMemorySupport {
     public PathMemory initializePathMemory(PathEndNode pathEndNode);
     
     public void checkEagerSegmentCreation(LeftTupleSource lt, int nodeTypesInSegment);
-    
-    
-
 }

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -944,11 +944,11 @@ public class KnowledgeBaseImpl implements InternalRuleBase {
 
     @Override
     public SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleSource tupleSource) {
-        return segmentPrototypeRegistry.createSegmentFromPrototype(reteEvaluator, tupleSource);
+        return segmentPrototypeRegistry.createSegmentFromPrototype(reteEvaluator.getNodeMemories(), reteEvaluator.getSegmentMemorySupport(), tupleSource);
     }
 
     public SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, SegmentPrototype proto) {
-        return segmentPrototypeRegistry.createSegmentFromPrototype(reteEvaluator, proto);
+        return segmentPrototypeRegistry.createSegmentFromPrototype(proto, reteEvaluator.getNodeMemories(), reteEvaluator.getSegmentMemorySupport());
     }
 
     public SegmentPrototype getSegmentPrototype(SegmentMemory segment) {

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -329,11 +329,11 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
                     PathMemory pmem = (PathMemory) wm.getNodeMemories().peekNodeMemory(endNode);
                     if (pmem == null) {
-                        pmem = RuntimeSegmentUtilities.initializePathMemory(wm, endNode);
+                        pmem = wm.getSegmentMemorySupport().initializePathMemory(endNode);
                     }
                     if (pmem.getSegmentMemories()[proto.getPos()] == null) {
                         // we check null, as this might have been fixed due to eager initialisation
-                        RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, smem);
+                        pmem.addSegmentToPathMemory(smem);
                     }
                 }
             }));
@@ -520,7 +520,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                             Memory mem = wm.getNodeMemories().peekNodeMemory(sproto.getRootNode());
                             if (mem != null && mem.getSegmentMemory() != null) {
                                 if (pmem == null) {
-                                    pmem = RuntimeSegmentUtilities.initializePathMemory(wm, endNode);
+                                    pmem = wm.getSegmentMemorySupport().initializePathMemory(endNode);
                                 }
                                 SegmentMemory sm = mem.getSegmentMemory();
                                 pmem.getSegmentMemories()[sproto.getPos()] = sm;
@@ -532,7 +532,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                             SegmentMemory sm = sproto.shallowNewSegmentMemory();
                             sm.setNodeMemories(new Memory[]{pmem});
                             pmem.setSegmentMemory(sm);
-                            RuntimeSegmentUtilities.addSegmentToPathMemory(pmem, sm);
+                            pmem.addSegmentToPathMemory(sm);
                             notifyImpactedSegments(wm, sm, smemsToNotify);
                         }
                     }
@@ -552,7 +552,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
                     if (parentMem != null && parentMem.getSegmentMemory() != null &&
                         !parentMem.getSegmentMemory().isEmpty()) {
                         SegmentMemory sm = parentMem.getSegmentMemory();
-                        SegmentMemory childSmem = RuntimeSegmentUtilities.createChildSegment(wm, child);
+                        SegmentMemory childSmem = wm.getSegmentMemorySupport().createChildSegment(child);
                         sm.add(childSmem);
                         sm.notifyRuleLinkSegment();
                         notifyImpactedSegments(wm, sm, smemsToNotify);
@@ -769,12 +769,12 @@ public class EagerPhreakBuilder implements PhreakBuilder {
 
             if (sm1 == null) {
                 // To be able to merge sm1 must exist
-                sm1 = RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, proto1.getRootNode());
+                sm1 = wm.getSegmentMemorySupport().getOrCreateSegmentMemory(proto1.getRootNode());
             }
 
             if (sm2 == null) {
                 // To be able to merge sm2 must exist
-                sm2 = RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, proto2.getRootNode());
+                sm2 = wm.getSegmentMemorySupport().getOrCreateSegmentMemory(proto2.getRootNode());
             }
 
             // merge the memories and reassign back to sm1

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -38,7 +38,6 @@ import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.PropagationContextFactory;
-import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.SuperCacheFixer;
 import org.drools.core.common.TupleSets;
 import org.drools.core.impl.InternalRuleBase;

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -189,7 +189,7 @@ public interface PropagationEntry {
             LeftInputAdapterNode lian = (LeftInputAdapterNode) lts;
             LeftInputAdapterNode.LiaNodeMemory lmem = reteEvaluator.getNodeMemory( lian );
             if ( lmem.getSegmentMemory() == null ) {
-                RuntimeSegmentUtilities.getOrCreateSegmentMemory(reteEvaluator, lts, lmem);
+                reteEvaluator.getSegmentMemorySupport().getOrCreateSegmentMemory(lts, lmem);
             }
 
             LeftInputAdapterNode.doInsertObject( handle, pCtx, lian, reteEvaluator, lmem, false, queryObject.isOpen() );

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -259,7 +259,7 @@ public class RuleNetworkEvaluator {
                         // this is needed for subnetworks that feed into a parent network that has no right inputs,
                         // and may not yet be initialized
                         if (smem.isEmpty() && !NodeTypeEnums.isTerminalNode(smem.getTipNode())) {
-                            RuntimeSegmentUtilities.createChildSegments(activationsManager.getReteEvaluator(), smem.getTipNode().getSinkPropagator(), smem);
+                            activationsManager.getReteEvaluator().getSegmentMemorySupport().createChildSegments(smem.getTipNode().getSinkPropagator(), smem);
                         }
                         
                         smem = smems[i];
@@ -430,7 +430,7 @@ public class RuleNetworkEvaluator {
         if (node == smem.getTipNode()) {
             // we are about to process the segment tip, allow it to merge insert/update/delete clashes
             if (smem.isEmpty()) {
-                RuntimeSegmentUtilities.createChildSegments(reteEvaluator, ((LeftTupleSource) node).getSinkPropagator(), smem);
+                reteEvaluator.getSegmentMemorySupport().createChildSegments(((LeftTupleSource) node).getSinkPropagator(), smem);
             }
             return smem.getFirst().getStagedLeftTuples().takeAll();
         } else {

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
@@ -27,7 +27,6 @@ import org.drools.core.WorkingMemoryEntryPoint;
 import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
 import org.drools.core.common.NodeMemories;
-import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.SegmentMemorySupport;
 import org.drools.core.reteoo.AbstractTerminalNode;
 import org.drools.core.reteoo.AccumulateNode;
@@ -71,16 +70,13 @@ import static org.drools.core.phreak.EagerPhreakBuilder.isInsideSubnetwork;
 
 public class SegmentMemorySupportImpl implements SegmentMemorySupport {
 
-    private final ReteEvaluator reteEvaluator;
     private final NodeMemories nodeMemories;
     private final SegmentPrototypeRegistry segmentPrototypeRegistry;
     private final WorkingMemoryEntryPoint defaultEntryPoint;
 
-    public SegmentMemorySupportImpl(ReteEvaluator reteEvaluator,
-                                    NodeMemories nodeMemories,
+    public SegmentMemorySupportImpl(NodeMemories nodeMemories,
                                     SegmentPrototypeRegistry segmentPrototypeRegistry,
                                     WorkingMemoryEntryPoint defaultEntryPoint) {
-        this.reteEvaluator = reteEvaluator;
         this.nodeMemories = nodeMemories;
         this.segmentPrototypeRegistry = segmentPrototypeRegistry;
         this.defaultEntryPoint = defaultEntryPoint;
@@ -161,7 +157,7 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
             }
         }
 
-        SegmentMemory smem = segmentPrototypeRegistry.createSegmentFromPrototype(reteEvaluator, proto);
+        SegmentMemory smem = segmentPrototypeRegistry.createSegmentFromPrototype(proto, nodeMemories, this);
 
         updateSubnetworkAndTerminalMemory(smem, proto);
 
@@ -170,7 +166,7 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
 
     private void restoreSegmentFromPrototypeLazily(LeftTupleSource segmentRoot,
                                                    int nodeTypesInSegment) {
-        SegmentMemory smem = segmentPrototypeRegistry.createSegmentFromPrototype(reteEvaluator, segmentRoot);
+        SegmentMemory smem = segmentPrototypeRegistry.createSegmentFromPrototype(nodeMemories, this, segmentRoot);
         if (smem != null) {
             updateSubnetworkAndTerminalMemoryLazily(segmentRoot, segmentRoot, smem, true, nodeTypesInSegment);
         }

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
@@ -425,8 +425,8 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
                         processAsyncReceiveNode((AsyncReceiveNode) tupleSource, smem, memories, nodePosMask);
                         break;
                     case NodeTypeEnums.QueryElementNode:
-                        updateNodeBit = processQueryNode((QueryElementNode) tupleSource, segmentRoot, smem,
-                                memories, nodePosMask);
+                        updateNodeBit = processQueryNode((QueryElementNode) tupleSource, smem, memories,
+                                nodePosMask);
                         break;
                 }
             }
@@ -503,7 +503,6 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
     }
 
     private boolean processQueryNode(QueryElementNode queryNode,
-                                            LeftTupleSource segmentRoot,
                                             SegmentMemory smem,
                                             List<Memory> memories,
                                             long nodePosMask) {

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
@@ -169,7 +169,7 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         return querySmem;
     }
 
-    public TupleToObjectNode createSubnetworkSegmentMemory(BetaNode betaNode) {
+    private TupleToObjectNode createSubnetworkSegmentMemory(BetaNode betaNode) {
         TupleToObjectNode tton = (TupleToObjectNode) betaNode.getRightInput().getParent();
 
         LeftTupleSource subnetworkLts = tton.getStartTupleSource();
@@ -286,7 +286,7 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         }
     }
 
-    public int checkSegmentBoundary(LeftTupleSource lt, int nodeTypesInSegment) {
+    private int checkSegmentBoundary(LeftTupleSource lt, int nodeTypesInSegment) {
         if (isRootNode(lt, null)) {
             // we are in a new child segment
             checkEagerSegmentCreation(lt.getLeftTupleSource(), nodeTypesInSegment);
@@ -303,7 +303,7 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
      * This is because the TupleToObjectNode only cares if all of it's segments are linked, then
      * it sets the bit of node it is the right input for.
      */
-    public int updateSubnetworkAndTerminalMemoryLazily(LeftTupleSource lt,
+    private int updateSubnetworkAndTerminalMemoryLazily(LeftTupleSource lt,
                                                         LeftTupleSource originalLt,
                                                         SegmentMemory smem,
                                                         boolean fromPrototype,

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.core.phreak;
 
 import java.util.ArrayList;
@@ -99,7 +117,7 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         // it should not be possible to reach here, for BuildTimeSegmentProtos
         return createSegmentMemoryLazily(segmentRoot);
     }
-    
+
     private SegmentMemory createSegmentMemoryLazily(LeftTupleNode segmentRoot) {
         if (NodeTypeEnums.isTerminalNode(segmentRoot)) {
             Memory memory = nodeMemories.getNodeMemory((MemoryFactory) segmentRoot);
@@ -182,7 +200,7 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         }
         return tton;
     }
-    
+
     public SegmentMemory createChildSegmentLazily(LeftTupleNode node) {
         Memory memory = nodeMemories.getNodeMemory((MemoryFactory) node);
         if (memory.getSegmentMemory() == null) {
@@ -378,7 +396,7 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
 
         return false;
     }
-    
+
     public SegmentMemory createSegmentMemoryLazily(LeftTupleSource segmentRoot) {
         LeftTupleSource tupleSource = segmentRoot;
         SegmentMemory smem = new SegmentMemory(segmentRoot);
@@ -394,7 +412,8 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         while (true) {
             nodeTypesInSegment = updateNodeTypesMask(tupleSource, nodeTypesInSegment);
             if (NodeTypeEnums.isBetaNode(tupleSource)) {
-                allLinkedTestMask = processBetaNode((BetaNode) tupleSource, smem, memories, nodePosMask, allLinkedTestMask,
+                allLinkedTestMask = processBetaNode((BetaNode) tupleSource, smem, memories, nodePosMask,
+                        allLinkedTestMask,
                         updateNodeBit);
             } else {
                 switch (tupleSource.getType()) {
@@ -497,15 +516,16 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
 
         updateSubnetworkAndTerminalMemoryLazily(tupleSource, tupleSource, smem, false, nodeTypesInSegment);
 
-        segmentPrototypeRegistry.registerSegmentPrototype(segmentRoot, smem.getSegmentPrototype().initFromSegmentMemory(smem));
+        segmentPrototypeRegistry.registerSegmentPrototype(segmentRoot, smem.getSegmentPrototype().initFromSegmentMemory(
+                smem));
 
         return smem;
     }
 
     private boolean processQueryNode(QueryElementNode queryNode,
-                                            SegmentMemory smem,
-                                            List<Memory> memories,
-                                            long nodePosMask) {
+                                     SegmentMemory smem,
+                                     List<Memory> memories,
+                                     long nodePosMask) {
         // Initialize the QueryElementNode and have it's memory reference the actual query SegmentMemory
         SegmentMemory querySmem = getQuerySegmentMemory(queryNode);
         QueryElementNode.QueryElementNodeMemory queryNodeMem = nodeMemories.getNodeMemory(queryNode);
@@ -517,25 +537,25 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
     }
 
     private void processFromNode(MemoryFactory tupleSource,
-                                        SegmentMemory smem,
-                                        List<Memory> memories) {
+                                 SegmentMemory smem,
+                                 List<Memory> memories) {
         Memory mem = nodeMemories.getNodeMemory(tupleSource);
         memories.add(mem);
         mem.setSegmentMemory(smem);
     }
 
     private void processAsyncSendNode(MemoryFactory tupleSource,
-                                             SegmentMemory smem,
-                                             List<Memory> memories) {
+                                      SegmentMemory smem,
+                                      List<Memory> memories) {
         Memory mem = nodeMemories.getNodeMemory(tupleSource);
         mem.setSegmentMemory(smem);
         memories.add(mem);
     }
 
     private void processAsyncReceiveNode(AsyncReceiveNode tupleSource,
-                                                SegmentMemory smem,
-                                                List<Memory> memories,
-                                                long nodePosMask) {
+                                         SegmentMemory smem,
+                                         List<Memory> memories,
+                                         long nodePosMask) {
         AsyncReceiveNode.AsyncReceiveMemory tnMem = nodeMemories.getNodeMemory(tupleSource);
         memories.add(tnMem);
         tnMem.setNodePosMaskBit(nodePosMask);
@@ -543,9 +563,9 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
     }
 
     private void processReactiveFromNode(MemoryFactory tupleSource,
-                                                SegmentMemory smem,
-                                                List<Memory> memories,
-                                                long nodePosMask) {
+                                         SegmentMemory smem,
+                                         List<Memory> memories,
+                                         long nodePosMask) {
         FromNode.FromMemory mem = ((FromNode.FromMemory) nodeMemories.getNodeMemory(tupleSource));
         memories.add(mem);
         mem.setSegmentMemory(smem);
@@ -553,8 +573,8 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
     }
 
     private boolean processBranchNode(ConditionalBranchNode tupleSource,
-                                             SegmentMemory smem,
-                                             List<Memory> memories) {
+                                      SegmentMemory smem,
+                                      List<Memory> memories) {
         ConditionalBranchNode.ConditionalBranchMemory branchMem = nodeMemories.getNodeMemory(tupleSource);
         memories.add(branchMem);
         branchMem.setSegmentMemory(smem);
@@ -563,17 +583,17 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
     }
 
     private void processEvalNode(EvalConditionNode tupleSource,
-                                        SegmentMemory smem,
-                                        List<Memory> memories) {
+                                 SegmentMemory smem,
+                                 List<Memory> memories) {
         EvalConditionNode.EvalMemory evalMem = nodeMemories.getNodeMemory(tupleSource);
         memories.add(evalMem);
         evalMem.setSegmentMemory(smem);
     }
 
     private void processTimerNode(TimerNode tupleSource,
-                                         SegmentMemory smem,
-                                         List<Memory> memories,
-                                         long nodePosMask) {
+                                  SegmentMemory smem,
+                                  List<Memory> memories,
+                                  long nodePosMask) {
         TimerNode.TimerNodeMemory tnMem = nodeMemories.getNodeMemory(tupleSource);
         memories.add(tnMem);
         tnMem.setNodePosMaskBit(nodePosMask);
@@ -581,10 +601,10 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
     }
 
     private long processLiaNode(LeftInputAdapterNode tupleSource,
-                                       SegmentMemory smem,
-                                       List<Memory> memories,
-                                       long nodePosMask,
-                                       long allLinkedTestMask) {
+                                SegmentMemory smem,
+                                List<Memory> memories,
+                                long nodePosMask,
+                                long allLinkedTestMask) {
         LeftInputAdapterNode.LiaNodeMemory liaMemory = nodeMemories.getNodeMemory(tupleSource);
         memories.add(liaMemory);
         liaMemory.setSegmentMemory(smem);
@@ -594,14 +614,15 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
     }
 
     private long processBetaNode(BetaNode betaNode,
-                                        SegmentMemory smem,
-                                        List<Memory> memories,
-                                        long nodePosMask,
-                                        long allLinkedTestMask,
-                                        boolean updateNodeBit) {
+                                 SegmentMemory smem,
+                                 List<Memory> memories,
+                                 long nodePosMask,
+                                 long allLinkedTestMask,
+                                 boolean updateNodeBit) {
         BetaMemory bm;
         if (NodeTypeEnums.AccumulateNode == betaNode.getType()) {
-            AccumulateNode.AccumulateMemory accMemory = ((AccumulateNode.AccumulateMemory) nodeMemories.getNodeMemory(betaNode));
+            AccumulateNode.AccumulateMemory accMemory = ((AccumulateNode.AccumulateMemory) nodeMemories.getNodeMemory(
+                    betaNode));
             memories.add(accMemory);
             accMemory.setSegmentMemory(smem);
 
@@ -637,6 +658,5 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         }
         return allLinkedTestMask;
     }
-
 
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
@@ -1,5 +1,8 @@
 package org.drools.core.phreak;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.base.rule.constraint.QueryNameConstraint;
 import org.drools.core.WorkingMemoryEntryPoint;
@@ -8,10 +11,19 @@ import org.drools.core.common.MemoryFactory;
 import org.drools.core.common.NodeMemories;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.SegmentMemorySupport;
+import org.drools.core.reteoo.AbstractTerminalNode;
+import org.drools.core.reteoo.AccumulateNode;
 import org.drools.core.reteoo.AlphaNode;
+import org.drools.core.reteoo.AsyncReceiveNode;
+import org.drools.core.reteoo.AsyncSendNode;
+import org.drools.core.reteoo.BetaMemory;
 import org.drools.core.reteoo.BetaNode;
+import org.drools.core.reteoo.ConditionalBranchNode;
+import org.drools.core.reteoo.EvalConditionNode;
+import org.drools.core.reteoo.FromNode;
 import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.LeftTupleNode;
+import org.drools.core.reteoo.LeftTupleSink;
 import org.drools.core.reteoo.LeftTupleSinkNode;
 import org.drools.core.reteoo.LeftTupleSinkPropagator;
 import org.drools.core.reteoo.LeftTupleSource;
@@ -22,10 +34,21 @@ import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.QueryElementNode;
 import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.reteoo.SegmentPrototypeRegistry;
+import org.drools.core.reteoo.TimerNode;
 import org.drools.core.reteoo.TupleToObjectNode;
 import org.drools.core.reteoo.LeftInputAdapterNode.LiaNodeMemory;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
+import org.drools.core.reteoo.TupleToObjectNode.SubnetworkPathMemory;
 
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.JOIN_NODE_BIT;
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.NOT_NODE_BIT;
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.REACTIVE_EXISTS_NODE_BIT;
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.canBeDisabled;
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.isNonTerminalTipNode;
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.isRootNode;
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.isSet;
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.nextNodePosMask;
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.updateNodeTypesMask;
 import static org.drools.core.phreak.EagerPhreakBuilder.isInsideSubnetwork;
 
 public class SegmentMemorySupportImpl implements SegmentMemorySupport {
@@ -36,9 +59,9 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
     private final WorkingMemoryEntryPoint defaultEntryPoint;
 
     public SegmentMemorySupportImpl(ReteEvaluator reteEvaluator,
-                                     NodeMemories nodeMemories,
-                                     SegmentPrototypeRegistry segmentPrototypeRegistry,
-                                     WorkingMemoryEntryPoint defaultEntryPoint) {
+                                    NodeMemories nodeMemories,
+                                    SegmentPrototypeRegistry segmentPrototypeRegistry,
+                                    WorkingMemoryEntryPoint defaultEntryPoint) {
         this.reteEvaluator = reteEvaluator;
         this.nodeMemories = nodeMemories;
         this.segmentPrototypeRegistry = segmentPrototypeRegistry;
@@ -74,7 +97,28 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         }
 
         // it should not be possible to reach here, for BuildTimeSegmentProtos
-        return LazyPhreakBuilder.createSegmentMemory(reteEvaluator, segmentRoot);
+        return createSegmentMemoryLazily(segmentRoot);
+    }
+    
+    private SegmentMemory createSegmentMemoryLazily(LeftTupleNode segmentRoot) {
+        if (NodeTypeEnums.isTerminalNode(segmentRoot)) {
+            Memory memory = nodeMemories.getNodeMemory((MemoryFactory) segmentRoot);
+            return createChildSegmentForTerminalNode(segmentRoot, memory);
+        }
+        return createSegmentMemoryLazily((LeftTupleSource) segmentRoot);
+    }
+
+    private static SegmentMemory createChildSegmentForTerminalNode(LeftTupleNode node, Memory memory) {
+        SegmentMemory childSmem = new SegmentMemory(node); // rtns or TupleToObjectNodes don't need a queue
+        PathMemory pmem = (PathMemory) memory;
+
+        childSmem.setPos(pmem.getSegmentMemories().length - 1);
+        pmem.setSegmentMemory(childSmem);
+        pmem.addSegmentToPathMemory(childSmem);
+
+        childSmem.setTipNode(node);
+        childSmem.setNodeMemories(new Memory[]{memory});
+        return childSmem;
     }
 
     private SegmentMemory restoreSegmentFromPrototype(LeftTupleNode segmentRoot) {
@@ -106,6 +150,14 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         return smem;
     }
 
+    private void restoreSegmentFromPrototypeLazily(LeftTupleSource segmentRoot,
+                                                   int nodeTypesInSegment) {
+        SegmentMemory smem = segmentPrototypeRegistry.createSegmentFromPrototype(reteEvaluator, segmentRoot);
+        if (smem != null) {
+            updateSubnetworkAndTerminalMemoryLazily(segmentRoot, segmentRoot, smem, true, nodeTypesInSegment);
+        }
+    }
+
     public SegmentMemory getQuerySegmentMemory(QueryElementNode queryNode) {
         ObjectTypeNode queryOtn = defaultEntryPoint.getEntryPointNode().getQueryNode();
         LeftInputAdapterNode liaNode = getQueryLiaNode(queryOtn, queryNode.getQueryElement().getQueryName());
@@ -130,6 +182,19 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         }
         return tton;
     }
+    
+    public SegmentMemory createChildSegmentLazily(LeftTupleNode node) {
+        Memory memory = nodeMemories.getNodeMemory((MemoryFactory) node);
+        if (memory.getSegmentMemory() == null) {
+            if (NodeTypeEnums.isEndNode(node)) {
+                // RTNS and TupleToObjectNode's have their own segment, if they are the child of a split.
+                createChildSegmentForTerminalNode(node, memory);
+            } else {
+                createSegmentMemoryLazily((LeftTupleSource) node);
+            }
+        }
+        return memory.getSegmentMemory();
+    }
 
     public void createChildSegments(LeftTupleSinkPropagator sinkProp, SegmentMemory smem) {
         if (!smem.isEmpty()) {
@@ -138,7 +203,7 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         for (LeftTupleSinkNode sink = sinkProp.getFirstLeftTupleSink(); sink != null; sink = sink
                 .getNextLeftTupleSinkNode()) {
             SegmentMemory childSmem = PhreakBuilder.isEagerSegmentCreation() ? createChildSegment(sink)
-                    : LazyPhreakBuilder.createChildSegment(reteEvaluator, sink);
+                    : createChildSegmentLazily(sink);
             smem.add(childSmem);
         }
     }
@@ -211,4 +276,368 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
 
         throw new RuntimeException("Unable to find query '" + queryName + "'");
     }
+
+    public void checkEagerSegmentCreation(LeftTupleSource lt, int nodeTypesInSegment) {
+        // A Not node has to be eagerly initialized unless in its segment there is at least a join node
+        if (isSet(nodeTypesInSegment, NOT_NODE_BIT) &&
+            !isSet(nodeTypesInSegment, JOIN_NODE_BIT) &&
+            !isSet(nodeTypesInSegment, REACTIVE_EXISTS_NODE_BIT)) {
+            getOrCreateSegmentMemory(lt);
+        }
+    }
+
+    public int checkSegmentBoundary(LeftTupleSource lt, int nodeTypesInSegment) {
+        if (isRootNode(lt, null)) {
+            // we are in a new child segment
+            checkEagerSegmentCreation(lt.getLeftTupleSource(), nodeTypesInSegment);
+            nodeTypesInSegment = 0;
+        }
+        return updateNodeTypesMask(lt, nodeTypesInSegment);
+    }
+
+    /**
+     * This adds the segment memory to the terminal node or TupleToObjectNode node's list of memories.
+     * In the case of the terminal node this allows it to know that all segments from
+     * the tip to root are linked.
+     * In the case of the ria node its all the segments up to the start of the subnetwork.
+     * This is because the TupleToObjectNode only cares if all of it's segments are linked, then
+     * it sets the bit of node it is the right input for.
+     */
+    public int updateSubnetworkAndTerminalMemoryLazily(LeftTupleSource lt,
+                                                        LeftTupleSource originalLt,
+                                                        SegmentMemory smem,
+                                                        boolean fromPrototype,
+                                                        int nodeTypesInSegment) {
+
+        nodeTypesInSegment = checkSegmentBoundary(lt, nodeTypesInSegment);
+
+        PathMemory pmem = null;
+        for (LeftTupleSink sink : lt.getSinkPropagator().getSinks()) {
+            if (NodeTypeEnums.isLeftTupleSource(sink)) {
+                nodeTypesInSegment = updateSubnetworkAndTerminalMemoryLazily((LeftTupleSource) sink,
+                        originalLt, smem, fromPrototype, nodeTypesInSegment);
+            } else if (sink.getType() == NodeTypeEnums.TupleToObjectNode) {
+                // Even though we don't add the pmem and smem together, all pmem's for all pathend nodes must be initialized
+                SubnetworkPathMemory subnMem = (SubnetworkPathMemory) nodeMemories.getNodeMemory((MemoryFactory) sink);
+                // Only add the TupleToObjectNode, if the LeftTupleSource is part of the TupleToObjectNode subnetwork
+                if (inSubNetwork((TupleToObjectNode) sink, originalLt)) {
+                    pmem = subnMem;
+
+                    if (fromPrototype) {
+                        ObjectSink[] nodes = ((TupleToObjectNode) sink).getObjectSinkPropagator().getSinks();
+                        for (ObjectSink node : nodes) {
+                            // check if the SegmentMemory has been already created by the BetaNode and if so avoid to build it twice
+                            if (NodeTypeEnums.isLeftTupleSource(node) && nodeMemories.getNodeMemory(
+                                    (MemoryFactory) node).getSegmentMemory() == null) {
+                                restoreSegmentFromPrototypeLazily((LeftTupleSource) node, nodeTypesInSegment);
+                            }
+                        }
+                    } else if ((pmem.getAllLinkedMaskTest() & (1L << pmem.getSegmentMemories().length)) == 0) {
+                        // must eagerly initialize child segment memories
+                        ObjectSink[] nodes = ((TupleToObjectNode) sink).getObjectSinkPropagator().getSinks();
+                        for (ObjectSink node : nodes) {
+                            if (NodeTypeEnums.isLeftTupleSource(node)) {
+                                getOrCreateSegmentMemory((LeftTupleSource) node);
+                            }
+                        }
+                    }
+                }
+
+            } else if (NodeTypeEnums.isTerminalNode(sink)) {
+                pmem = nodeMemories.getNodeMemory((AbstractTerminalNode) sink);
+            }
+
+            if (pmem != null && smem.getPos() < pmem.getSegmentMemories().length) {
+                pmem.addSegmentToPathMemory(smem);
+                if (smem.isSegmentLinked()) {
+                    // not's can cause segments to be linked, and the rules need to be notified for evaluation
+                    smem.notifyRuleLinkSegment();
+                }
+                checkEagerSegmentCreation(sink.getLeftTupleSource(), nodeTypesInSegment);
+                pmem = null;
+            }
+        }
+        return nodeTypesInSegment;
+    }
+
+    /**
+     * Is the LeftTupleSource a node in the sub network for the RightInputAdapterNode
+     * To be in the same network, it must be a node is after the two output of the parent
+     * and before the TupleToObjectNode.
+     */
+    private static boolean inSubNetwork(TupleToObjectNode tton, LeftTupleSource leftTupleSource) {
+        LeftTupleSource startTupleSource = tton.getStartTupleSource().getLeftTupleSource();
+        LeftTupleSource current = tton.getLeftTupleSource();
+
+        while (current != startTupleSource) {
+            if (current == leftTupleSource) {
+                return true;
+            }
+            current = current.getLeftTupleSource();
+        }
+
+        return false;
+    }
+    
+    public SegmentMemory createSegmentMemoryLazily(LeftTupleSource segmentRoot) {
+        LeftTupleSource tupleSource = segmentRoot;
+        SegmentMemory smem = new SegmentMemory(segmentRoot);
+
+        // Iterate all nodes on the same segment, assigning their position as a bit mask value
+        // allLinkedTestMask is the resulting mask used to test if all nodes are linked in
+        long nodePosMask = 1;
+        long allLinkedTestMask = 0;
+        boolean updateNodeBit = true; // nodes after a branch CE can notify, but they cannot impact linking
+
+        int nodeTypesInSegment = 0;
+        List<Memory> memories = new ArrayList<>();
+        while (true) {
+            nodeTypesInSegment = updateNodeTypesMask(tupleSource, nodeTypesInSegment);
+            if (NodeTypeEnums.isBetaNode(tupleSource)) {
+                allLinkedTestMask = processBetaNode((BetaNode) tupleSource, smem, memories, nodePosMask, allLinkedTestMask,
+                        updateNodeBit);
+            } else {
+                switch (tupleSource.getType()) {
+                    case NodeTypeEnums.LeftInputAdapterNode:
+                    case NodeTypeEnums.AlphaTerminalNode:
+                        allLinkedTestMask = processLiaNode((LeftInputAdapterNode) tupleSource, smem, memories,
+                                nodePosMask, allLinkedTestMask);
+                        break;
+                    case NodeTypeEnums.EvalConditionNode:
+                        processEvalNode((EvalConditionNode) tupleSource, smem, memories);
+                        break;
+                    case NodeTypeEnums.ConditionalBranchNode:
+                        updateNodeBit = processBranchNode((ConditionalBranchNode) tupleSource, smem, memories);
+                        break;
+                    case NodeTypeEnums.FromNode:
+                        processFromNode((FromNode) tupleSource, smem, memories);
+                        break;
+                    case NodeTypeEnums.ReactiveFromNode:
+                        processReactiveFromNode((MemoryFactory) tupleSource, smem, memories, nodePosMask);
+                        break;
+                    case NodeTypeEnums.TimerConditionNode:
+                        processTimerNode((TimerNode) tupleSource, smem, memories, nodePosMask);
+                        break;
+                    case NodeTypeEnums.AsyncSendNode:
+                        processAsyncSendNode((AsyncSendNode) tupleSource, smem, memories);
+                        break;
+                    case NodeTypeEnums.AsyncReceiveNode:
+                        processAsyncReceiveNode((AsyncReceiveNode) tupleSource, smem, memories, nodePosMask);
+                        break;
+                    case NodeTypeEnums.QueryElementNode:
+                        updateNodeBit = processQueryNode((QueryElementNode) tupleSource, segmentRoot, smem,
+                                memories, nodePosMask);
+                        break;
+                }
+            }
+
+            nodePosMask = nextNodePosMask(nodePosMask);
+
+            if (tupleSource.getSinkPropagator().size() == 1) {
+                LeftTupleSinkNode sink = tupleSource.getSinkPropagator().getFirstLeftTupleSink();
+                if (NodeTypeEnums.isLeftTupleSource(sink)) {
+                    tupleSource = (LeftTupleSource) sink;
+                } else {
+                    // rtn or TupleToObjectNode
+                    // While not technically in a segment, we want to be able to iterate easily from the last node memory to the TupleToObjectNode/rtn memory
+                    // we don't use createNodeMemory, as these may already have been created by, but not added, by the method updateTupleToObjectAndTerminalMemory
+                    Memory memory = nodeMemories.getNodeMemory((MemoryFactory) sink);
+                    if (sink.getType() == NodeTypeEnums.TupleToObjectNode) {
+                        PathMemory subnMem = (SubnetworkPathMemory) memory;
+                        memories.add(subnMem);
+
+                        TupleToObjectNode tton = (TupleToObjectNode) sink;
+                        ObjectSink[] nodes = tton.getObjectSinkPropagator().getSinks();
+                        for (ObjectSink node : nodes) {
+                            if (NodeTypeEnums.isLeftTupleSource(node)) {
+                                getOrCreateSegmentMemory((LeftTupleSource) node);
+                            }
+                        }
+                    } else if (NodeTypeEnums.isTerminalNode(sink)) {
+                        memories.add(memory);
+                    }
+                    memory.setSegmentMemory(smem);
+                    smem.setTipNode(sink);
+                    break;
+                }
+            } else {
+                // not in same segment
+                smem.setTipNode(tupleSource);
+                break;
+            }
+        }
+        smem.setAllLinkedMaskTest(allLinkedTestMask);
+        smem.setNodeMemories(memories.toArray(new Memory[memories.size()]));
+
+        // Update the memory linked references
+        Memory lastMem = null;
+        for (Memory mem : memories) {
+            if (lastMem != null) {
+                mem.setPrevious(lastMem);
+                lastMem.setNext(mem);
+            }
+            lastMem = mem;
+        }
+
+        // iterate to find root and determine the SegmentNodes position in the RuleSegment
+        LeftTupleSource pathRoot = segmentRoot;
+        int ruleSegmentPosMask = 1;
+        int counter = 0;
+        while (!NodeTypeEnums.isLeftInputAdapterNode(pathRoot)) {
+            LeftTupleSource leftTupleSource = pathRoot.getLeftTupleSource();
+            if (isNonTerminalTipNode(leftTupleSource, null)) {
+                // for each new found segment, increase the mask bit position
+                ruleSegmentPosMask = ruleSegmentPosMask << 1;
+                counter++;
+            }
+            pathRoot = leftTupleSource;
+        }
+        smem.setSegmentPosMaskBit(ruleSegmentPosMask);
+        smem.setPos(counter);
+
+        updateSubnetworkAndTerminalMemoryLazily(tupleSource, tupleSource, smem, false, nodeTypesInSegment);
+
+        segmentPrototypeRegistry.registerSegmentPrototype(segmentRoot, smem.getSegmentPrototype().initFromSegmentMemory(smem));
+
+        return smem;
+    }
+
+    private boolean processQueryNode(QueryElementNode queryNode,
+                                            LeftTupleSource segmentRoot,
+                                            SegmentMemory smem,
+                                            List<Memory> memories,
+                                            long nodePosMask) {
+        // Initialize the QueryElementNode and have it's memory reference the actual query SegmentMemory
+        SegmentMemory querySmem = getQuerySegmentMemory(queryNode);
+        QueryElementNode.QueryElementNodeMemory queryNodeMem = nodeMemories.getNodeMemory(queryNode);
+        queryNodeMem.setNodePosMaskBit(nodePosMask);
+        queryNodeMem.setQuerySegmentMemory(querySmem);
+        queryNodeMem.setSegmentMemory(smem);
+        memories.add(queryNodeMem);
+        return !queryNode.getQueryElement().isAbductive();
+    }
+
+    private void processFromNode(MemoryFactory tupleSource,
+                                        SegmentMemory smem,
+                                        List<Memory> memories) {
+        Memory mem = nodeMemories.getNodeMemory(tupleSource);
+        memories.add(mem);
+        mem.setSegmentMemory(smem);
+    }
+
+    private void processAsyncSendNode(MemoryFactory tupleSource,
+                                             SegmentMemory smem,
+                                             List<Memory> memories) {
+        Memory mem = nodeMemories.getNodeMemory(tupleSource);
+        mem.setSegmentMemory(smem);
+        memories.add(mem);
+    }
+
+    private void processAsyncReceiveNode(AsyncReceiveNode tupleSource,
+                                                SegmentMemory smem,
+                                                List<Memory> memories,
+                                                long nodePosMask) {
+        AsyncReceiveNode.AsyncReceiveMemory tnMem = nodeMemories.getNodeMemory(tupleSource);
+        memories.add(tnMem);
+        tnMem.setNodePosMaskBit(nodePosMask);
+        tnMem.setSegmentMemory(smem);
+    }
+
+    private void processReactiveFromNode(MemoryFactory tupleSource,
+                                                SegmentMemory smem,
+                                                List<Memory> memories,
+                                                long nodePosMask) {
+        FromNode.FromMemory mem = ((FromNode.FromMemory) nodeMemories.getNodeMemory(tupleSource));
+        memories.add(mem);
+        mem.setSegmentMemory(smem);
+        mem.setNodePosMaskBit(nodePosMask);
+    }
+
+    private boolean processBranchNode(ConditionalBranchNode tupleSource,
+                                             SegmentMemory smem,
+                                             List<Memory> memories) {
+        ConditionalBranchNode.ConditionalBranchMemory branchMem = nodeMemories.getNodeMemory(tupleSource);
+        memories.add(branchMem);
+        branchMem.setSegmentMemory(smem);
+        // nodes after a branch CE can notify, but they cannot impact linking
+        return false;
+    }
+
+    private void processEvalNode(EvalConditionNode tupleSource,
+                                        SegmentMemory smem,
+                                        List<Memory> memories) {
+        EvalConditionNode.EvalMemory evalMem = nodeMemories.getNodeMemory(tupleSource);
+        memories.add(evalMem);
+        evalMem.setSegmentMemory(smem);
+    }
+
+    private void processTimerNode(TimerNode tupleSource,
+                                         SegmentMemory smem,
+                                         List<Memory> memories,
+                                         long nodePosMask) {
+        TimerNode.TimerNodeMemory tnMem = nodeMemories.getNodeMemory(tupleSource);
+        memories.add(tnMem);
+        tnMem.setNodePosMaskBit(nodePosMask);
+        tnMem.setSegmentMemory(smem);
+    }
+
+    private long processLiaNode(LeftInputAdapterNode tupleSource,
+                                       SegmentMemory smem,
+                                       List<Memory> memories,
+                                       long nodePosMask,
+                                       long allLinkedTestMask) {
+        LeftInputAdapterNode.LiaNodeMemory liaMemory = nodeMemories.getNodeMemory(tupleSource);
+        memories.add(liaMemory);
+        liaMemory.setSegmentMemory(smem);
+        liaMemory.setNodePosMaskBit(nodePosMask);
+        allLinkedTestMask = allLinkedTestMask | nodePosMask;
+        return allLinkedTestMask;
+    }
+
+    private long processBetaNode(BetaNode betaNode,
+                                        SegmentMemory smem,
+                                        List<Memory> memories,
+                                        long nodePosMask,
+                                        long allLinkedTestMask,
+                                        boolean updateNodeBit) {
+        BetaMemory bm;
+        if (NodeTypeEnums.AccumulateNode == betaNode.getType()) {
+            AccumulateNode.AccumulateMemory accMemory = ((AccumulateNode.AccumulateMemory) nodeMemories.getNodeMemory(betaNode));
+            memories.add(accMemory);
+            accMemory.setSegmentMemory(smem);
+
+            bm = accMemory.getBetaMemory();
+        } else {
+            bm = (BetaMemory) nodeMemories.getNodeMemory(betaNode);
+            memories.add(bm);
+        }
+
+        bm.setSegmentMemory(smem);
+
+        // this must be set first, to avoid recursion as sub networks can be initialised multiple ways
+        // and bm.getSegmentMemory == null check can be used to avoid recursion.
+        bm.setSegmentMemory(smem);
+
+        if (betaNode.getRightInput().inputIsTupleToObjectNode()) {
+            TupleToObjectNode tton = createSubnetworkSegmentMemory(betaNode);
+
+            PathMemory subnetworkPathMemory = nodeMemories.getNodeMemory(tton);
+            bm.setSubnetworkPathMemory((SubnetworkPathMemory) subnetworkPathMemory);
+            if (updateNodeBit && canBeDisabled(betaNode) && subnetworkPathMemory.getAllLinkedMaskTest() > 0) {
+                // only TupleToObjectNode's with reactive subnetworks can be disabled and thus need checking
+                allLinkedTestMask = allLinkedTestMask | nodePosMask;
+            }
+        } else if (updateNodeBit && canBeDisabled(betaNode)) {
+            allLinkedTestMask = allLinkedTestMask | nodePosMask;
+
+        }
+        bm.setNodePosMaskBit(nodePosMask);
+        if (NodeTypeEnums.NotNode == betaNode.getType()) {
+            // not nodes start up linked in
+            smem.linkNodeWithoutRuleNotify(bm.getNodePosMaskBit());
+        }
+        return allLinkedTestMask;
+    }
+
+
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentPropagator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentPropagator.java
@@ -44,7 +44,7 @@ public class SegmentPropagator {
         LeftTupleSource source = ( LeftTupleSource )  sourceSegment.getTipNode();
         
         if ( sourceSegment.isEmpty() ) {
-            RuntimeSegmentUtilities.createChildSegments(reteEvaluator, source.getSinkPropagator(), sourceSegment);
+            reteEvaluator.getSegmentMemorySupport().createChildSegments(source.getSinkPropagator(), sourceSegment);
         }
                 
         processPeers(sourceSegment, leftTuples);

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -42,7 +42,6 @@ import org.drools.core.common.SuperCacheFixer;
 import org.drools.core.common.TupleSets;
 import org.drools.core.common.UpdateContext;
 import org.drools.core.phreak.DetachedTuple;
-import org.drools.core.phreak.RuntimeSegmentUtilities;
 import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.core.util.AbstractLinkedListNode;
@@ -180,9 +179,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
         if ( sm.getTipNode() == liaNode) {
             // liaNode in its own segment and child segments not yet created
             if ( sm.isEmpty() ) {
-                RuntimeSegmentUtilities.createChildSegments(reteEvaluator,
-                                                            liaNode.getSinkPropagator(),
-                                                            sm);
+                reteEvaluator.getSegmentMemorySupport().createChildSegments(liaNode.getSinkPropagator(), sm);
             }
             sm = sm.getFirst(); // repoint to the child sm
         }
@@ -272,9 +269,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
         if ( sm.getTipNode() == liaNode ) {
             // liaNode in it's own segment and child segments not yet created
             if ( sm.isEmpty() ) {
-                RuntimeSegmentUtilities.createChildSegments(reteEvaluator,
-                                                            liaNode.getSinkPropagator(),
-                                                            sm);
+                reteEvaluator.getSegmentMemorySupport().createChildSegments(liaNode.getSinkPropagator(), sm);
             }
             sm = sm.getFirst(); // repoint to the child sm
         }
@@ -332,9 +327,7 @@ public class LeftInputAdapterNode extends LeftTupleSource
         if ( sm.getTipNode() == liaNode) {
             // liaNode in it's own segment and child segments not yet created
             if ( sm.isEmpty() ) {
-                RuntimeSegmentUtilities.createChildSegments(reteEvaluator,
-                                                            liaNode.getSinkPropagator(),
-                                                            sm);
+                reteEvaluator.getSegmentMemorySupport().createChildSegments(liaNode.getSinkPropagator(), sm);
             }
             sm = sm.getFirst(); // repoint to the child sm
         }

--- a/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PathMemory.java
@@ -236,4 +236,12 @@ public class PathMemory extends AbstractLinkedListNode<Memory>
     public ActivationsManager getActualActivationsManager() {
         return activationsManager;
     }
+    
+    public void addSegmentToPathMemory(SegmentMemory smem) {
+        if (smem.getRootNode().getPathIndex() >= getPathEndNode().getStartTupleSource().getPathIndex()) {
+            smem.addPathMemory(this);
+            setSegmentMemory(smem.getPos(), smem);
+        }
+
+    }
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
@@ -31,7 +31,6 @@ import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.TupleSets;
 import org.drools.core.common.TupleSetsImpl;
 import org.drools.core.phreak.BuildtimeSegmentUtilities;
-import org.drools.core.phreak.RuntimeSegmentUtilities;
 import org.drools.core.reteoo.AsyncReceiveNode.AsyncReceiveMemory;
 import org.drools.core.reteoo.QueryElementNode.QueryElementNodeMemory;
 import org.drools.core.reteoo.TupleToObjectNode.SubnetworkPathMemory;
@@ -42,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.drools.core.phreak.BuildtimeSegmentUtilities.nextNodePosMask;
-import static org.drools.core.phreak.RuntimeSegmentUtilities.getQuerySegmentMemory;
 
 public class SegmentMemory extends LinkedList<SegmentMemory>
                            implements
@@ -1057,7 +1055,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
                 SubnetworkPathMemory riaMem = (SubnetworkPathMemory) reteEvaluator.getNodeMemories().peekNodeMemory(
                         tton);
                 if (riaMem == null) {
-                    riaMem = (SubnetworkPathMemory) RuntimeSegmentUtilities.initializePathMemory(reteEvaluator, tton);
+                    riaMem = (SubnetworkPathMemory) reteEvaluator.getSegmentMemorySupport().initializePathMemory(tton);
                 }
                 betaMemory.setSubnetworkPathMemory(riaMem);
             }
@@ -1140,7 +1138,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         @Override
         public void populateMemory(ReteEvaluator reteEvaluator, Memory mem) {
             QueryElementNodeMemory qmem = (QueryElementNodeMemory) mem;
-            SegmentMemory querySmem = getQuerySegmentMemory(reteEvaluator, queryNode);
+            SegmentMemory querySmem = reteEvaluator.getSegmentMemorySupport().getQuerySegmentMemory(queryNode);
             qmem.setQuerySegmentMemory(querySmem);
             qmem.setNodePosMaskBit(nodePosMaskBit);
         }

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
@@ -27,7 +27,8 @@ import java.util.List;
 import org.drools.base.reteoo.NodeTypeEnums;
 import org.drools.core.common.Memory;
 import org.drools.core.common.MemoryFactory;
-import org.drools.core.common.ReteEvaluator;
+import org.drools.core.common.NodeMemories;
+import org.drools.core.common.SegmentMemorySupport;
 import org.drools.core.common.TupleSets;
 import org.drools.core.common.TupleSetsImpl;
 import org.drools.core.phreak.BuildtimeSegmentUtilities;
@@ -682,9 +683,9 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
             this.tipNode = tipNode;
         }
 
-        public SegmentMemory newSegmentMemory(ReteEvaluator reteEvaluator) {
+        public SegmentMemory newSegmentMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport) {
             SegmentMemory smem = new SegmentMemory();
-            updateSegmentMemory(smem, reteEvaluator);
+            updateSegmentMemory(nodeMemories, segmentMemorySupport, smem);
             return smem;
         }
 
@@ -694,23 +695,23 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
             return smem;
         }
 
-        public void updateSegmentMemory(SegmentMemory smem, ReteEvaluator reteEvaluator) {
+        public void updateSegmentMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, SegmentMemory smem) {
             smem.updateFromPrototype(this);
-            Memory[] nodeMemories = new Memory[getNodesInSegment().length];
+            Memory[] updatedMemories = new Memory[getNodesInSegment().length];
             for (int i = 0; i < memories.length; i++) {
-                Memory mem = reteEvaluator.getNodeMemory((MemoryFactory) getNodesInSegment()[i]);
+                Memory mem = nodeMemories.getNodeMemory((MemoryFactory) getNodesInSegment()[i]);
                 if (i > 0) {
-                    mem.setPrevious(nodeMemories[i - 1]);
-                    nodeMemories[i - 1].setNext(mem);
+                    mem.setPrevious(updatedMemories[i - 1]);
+                    updatedMemories[i - 1].setNext(mem);
                 }
-                nodeMemories[i] = mem;
+                updatedMemories[i] = mem;
                 mem.setSegmentMemory(smem);
                 MemoryPrototype proto = memories[i];
                 if (proto != null) {
-                    proto.populateMemory(reteEvaluator, mem);
+                    proto.populateMemory(nodeMemories, segmentMemorySupport, mem);
                 }
             }
-            smem.setNodeMemories(nodeMemories);
+            smem.setNodeMemories(updatedMemories);
         }
 
         public SegmentPrototype initFromSegmentMemory(SegmentMemory smem) {
@@ -1027,7 +1028,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
             return null;
         }
 
-        public abstract void populateMemory(ReteEvaluator reteEvaluator, Memory memory);
+        public abstract void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory memory);
 
         public void setNodePosMaskBit(long nodePosMaskBit) {
             this.nodePosMaskBit = nodePosMaskBit;
@@ -1048,14 +1049,14 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         }
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory memory) {
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory memory) {
             BetaMemory betaMemory = (BetaMemory) memory;
             betaMemory.setNodePosMaskBit(nodePosMaskBit);
             if (tton != null) {
-                SubnetworkPathMemory riaMem = (SubnetworkPathMemory) reteEvaluator.getNodeMemories().peekNodeMemory(
+                SubnetworkPathMemory riaMem = (SubnetworkPathMemory) nodeMemories.peekNodeMemory(
                         tton);
                 if (riaMem == null) {
-                    riaMem = (SubnetworkPathMemory) reteEvaluator.getSegmentMemorySupport().initializePathMemory(tton);
+                    riaMem = (SubnetworkPathMemory) segmentMemorySupport.initializePathMemory(tton);
                 }
                 betaMemory.setSubnetworkPathMemory(riaMem);
             }
@@ -1069,7 +1070,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         }
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory liaMemory) {
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory liaMemory) {
             ((SegmentNodeMemory) liaMemory).setNodePosMaskBit(nodePosMaskBit);
         }
     }
@@ -1081,7 +1082,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         }
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory memory) {
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory memory) {
             ((ReactiveFromNode.ReactiveFromMemory) memory).setNodePosMaskBit(nodePosMaskBit);
         }
     }
@@ -1091,7 +1092,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         public ConditionalBranchMemoryPrototype() {}
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory memory) {}
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory memory) {}
     }
 
     public static class RightInputAdapterPrototype extends MemoryPrototype {
@@ -1099,7 +1100,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         public RightInputAdapterPrototype() {}
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory memory) {}
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory memory) {}
     }
 
     public static class TerminalPrototype extends MemoryPrototype {
@@ -1107,7 +1108,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         public TerminalPrototype() {}
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory memory) {}
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory memory) {}
     }
 
     public static class FromMemoryPrototype extends MemoryPrototype {
@@ -1115,7 +1116,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         public FromMemoryPrototype() {}
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory memory) {}
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory memory) {}
     }
 
     public static class EvalMemoryPrototype extends MemoryPrototype {
@@ -1123,7 +1124,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         public EvalMemoryPrototype() {}
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory memory) {}
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory memory) {}
     }
 
     public static class QueryMemoryPrototype extends MemoryPrototype {
@@ -1136,9 +1137,9 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         }
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory mem) {
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory mem) {
             QueryElementNodeMemory qmem = (QueryElementNodeMemory) mem;
-            SegmentMemory querySmem = reteEvaluator.getSegmentMemorySupport().getQuerySegmentMemory(queryNode);
+            SegmentMemory querySmem = segmentMemorySupport.getQuerySegmentMemory(queryNode);
             qmem.setQuerySegmentMemory(querySmem);
             qmem.setNodePosMaskBit(nodePosMaskBit);
         }
@@ -1151,7 +1152,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         }
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory mem) {
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory mem) {
             TimerNodeMemory tmem = (TimerNodeMemory) mem;
             tmem.setNodePosMaskBit(nodePosMaskBit);
         }
@@ -1162,7 +1163,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         public AsyncSendMemoryPrototype() {}
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory mem) {}
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory mem) {}
     }
 
     public static class AsyncReceiveMemoryPrototype extends MemoryPrototype {
@@ -1172,7 +1173,7 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         }
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory mem) {
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory mem) {
             AsyncReceiveMemory amem = (AsyncReceiveMemory) mem;
             amem.setNodePosMaskBit(nodePosMaskBit);
         }
@@ -1187,8 +1188,8 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         }
 
         @Override
-        public void populateMemory(ReteEvaluator reteEvaluator, Memory accMemory) {
-            betaProto.populateMemory(reteEvaluator, ((AccumulateNode.AccumulateMemory) accMemory).getBetaMemory());
+        public void populateMemory(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, Memory accMemory) {
+            betaProto.populateMemory(nodeMemories, segmentMemorySupport, ((AccumulateNode.AccumulateMemory) accMemory).getBetaMemory());
         }
     }
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistry.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistry.java
@@ -18,7 +18,8 @@
  */
 package org.drools.core.reteoo;
 
-import org.drools.core.common.ReteEvaluator;
+import org.drools.core.common.NodeMemories;
+import org.drools.core.common.SegmentMemorySupport;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 
 public interface SegmentPrototypeRegistry {
@@ -27,9 +28,9 @@ public interface SegmentPrototypeRegistry {
     
     void registerSegmentPrototype(LeftTupleNode tupleSource, SegmentPrototype smem);
 
-    SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleSource tupleSource);
+    SegmentMemory createSegmentFromPrototype(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, LeftTupleSource tupleSource);
 
-    SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, SegmentPrototype smem);
+    SegmentMemory createSegmentFromPrototype(SegmentPrototype smem, NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport);
 
     SegmentPrototype getSegmentPrototype(SegmentMemory segment);
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistryImpl.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentPrototypeRegistryImpl.java
@@ -22,7 +22,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.drools.core.common.ReteEvaluator;
+import org.drools.core.common.NodeMemories;
+import org.drools.core.common.SegmentMemorySupport;
 import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 
 
@@ -52,13 +53,13 @@ public class SegmentPrototypeRegistryImpl implements SegmentPrototypeRegistry {
     }
 
     @Override
-    public SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, LeftTupleSource tupleSource) {
+    public SegmentMemory createSegmentFromPrototype(NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport, LeftTupleSource tupleSource) {
         SegmentPrototype proto = segmentProtos.get(tupleSource.getId());
-        return createSegmentFromPrototype(reteEvaluator, proto);
+        return createSegmentFromPrototype(proto, nodeMemories, segmentMemorySupport);
     }
 
-    public SegmentMemory createSegmentFromPrototype(ReteEvaluator reteEvaluator, SegmentPrototype proto) {
-        return proto.newSegmentMemory(reteEvaluator);
+    public SegmentMemory createSegmentFromPrototype(SegmentPrototype proto, NodeMemories nodeMemories, SegmentMemorySupport segmentMemorySupport) {
+        return proto.newSegmentMemory(nodeMemories, segmentMemorySupport);
     }
 
     public SegmentPrototype getSegmentPrototype(SegmentMemory segment) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
@@ -291,6 +291,8 @@ public class TupleToObjectNode extends ObjectSource
     }
 
     public static class SubnetworkPathMemory extends PathMemory implements Memory {
+        private List<RuleImpl> rules;
+        private ReteEvaluator reteEvaluator;
 
         private ReteEvaluator reteEvaluator;
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
@@ -291,7 +291,7 @@ public class TupleToObjectNode extends ObjectSource
     }
 
     public static class SubnetworkPathMemory extends PathMemory implements Memory {
-        private List<RuleImpl> rules;
+
         private ReteEvaluator reteEvaluator;
 
         private ReteEvaluator reteEvaluator;

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleToObjectNode.java
@@ -294,8 +294,6 @@ public class TupleToObjectNode extends ObjectSource
 
         private ReteEvaluator reteEvaluator;
 
-        private ReteEvaluator reteEvaluator;
-
         public SubnetworkPathMemory(PathEndNode pathEndNode, ReteEvaluator reteEvaluator) {
             super(pathEndNode, reteEvaluator);
             this.reteEvaluator = reteEvaluator;

--- a/drools-kiesession/src/main/java/org/drools/kiesession/consequence/StatefulKnowledgeSessionForRHS.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/consequence/StatefulKnowledgeSessionForRHS.java
@@ -41,6 +41,7 @@ import org.drools.core.common.NodeMemories;
 import org.drools.core.common.ObjectStore;
 import org.drools.core.common.ObjectTypeConfigurationRegistry;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.common.SegmentMemorySupport;
 import org.drools.core.event.AgendaEventSupport;
 import org.drools.core.event.RuleEventListenerSupport;
 import org.drools.core.event.RuleRuntimeEventSupport;
@@ -434,6 +435,10 @@ public class StatefulKnowledgeSessionForRHS
 
     public NodeMemories getNodeMemories() {
         return delegate.getNodeMemories();
+    }
+    
+    public SegmentMemorySupport getSegmentMemorySupport() {
+        return delegate.getSegmentMemorySupport();
     }
 
     public long getNextPropagationIdCounter() {

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -55,6 +55,7 @@ import org.drools.core.common.ObjectTypeConfigurationRegistry;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.PropagationContextFactory;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.common.SegmentMemorySupport;
 import org.drools.core.common.SuperCacheFixer;
 import org.drools.core.event.AgendaEventSupport;
 import org.drools.core.event.RuleEventListenerSupport;
@@ -65,6 +66,7 @@ import org.drools.core.management.DroolsManagementAgent;
 import org.drools.core.marshalling.MarshallerReaderContext;
 import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.phreak.RuleAgendaItem;
+import org.drools.core.phreak.SegmentMemorySupportImpl;
 import org.drools.core.reteoo.AsyncReceiveNode;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.LeftInputAdapterNode;
@@ -174,6 +176,8 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
     /** The actual memory for the <code>JoinNode</code>s. */
     private NodeMemories nodeMemories;
 
+    private SegmentMemorySupport segmentMemorySupport;
+    
     /** Global values which are associated with this memory. */
     protected GlobalResolver globalResolver;
 
@@ -345,6 +349,8 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(kBase, this, handleFactory);
 
+        this.segmentMemorySupport = new SegmentMemorySupportImpl(this, nodeMemories, kBase.getSegmentPrototypeRegistry(), entryPointsManager.getDefaultEntryPoint());
+        
         this.sequential = conf.isSequential();
 
         this.globalResolver = RuntimeComponentFactory.get().createGlobalResolver(this, this.environment);
@@ -1351,6 +1357,11 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         return nodeMemories;
     }
 
+    
+    public SegmentMemorySupport getSegmentMemorySupport() {
+        return segmentMemorySupport;
+    }
+    
     public RuleRuntimeEventSupport getRuleRuntimeEventSupport() {
         return this.ruleRuntimeEventSupport;
     }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/session/StatefulKnowledgeSessionImpl.java
@@ -349,7 +349,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         this.entryPointsManager = (NamedEntryPointsManager) RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(kBase, this, handleFactory);
 
-        this.segmentMemorySupport = new SegmentMemorySupportImpl(this, nodeMemories, kBase.getSegmentPrototypeRegistry(), entryPointsManager.getDefaultEntryPoint());
+        this.segmentMemorySupport = new SegmentMemorySupportImpl(nodeMemories, kBase.getSegmentPrototypeRegistry(), entryPointsManager.getDefaultEntryPoint());
         
         this.sequential = conf.isSequential();
 

--- a/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/NodeSegmentUnlinkingTest.java
@@ -40,7 +40,6 @@ import org.drools.core.reteoo.SegmentMemory.SegmentPrototype;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
 import org.drools.core.phreak.PhreakNotNode;
-import org.drools.core.phreak.RuntimeSegmentUtilities;
 import org.drools.core.reteoo.BetaNode;
 import org.drools.core.reteoo.ExistsNode;
 import org.drools.core.reteoo.JoinNode;
@@ -285,7 +284,7 @@ public class NodeSegmentUnlinkingTest {
 
         StatefulKnowledgeSessionImpl ksession = (StatefulKnowledgeSessionImpl)kBase.newKieSession();
 
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(ksession, liaNode);
+        ksession.getSegmentMemorySupport().getOrCreateSegmentMemory(liaNode);
         liaNode.assertObject((InternalFactHandle) ksession.insert("str"), context, ksession);
         
 
@@ -318,7 +317,7 @@ public class NodeSegmentUnlinkingTest {
         // Initialise from lian
         StatefulKnowledgeSessionImpl ksession = (StatefulKnowledgeSessionImpl)kBase.newKieSession();
 
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(ksession, liaNode);
+        ksession.getSegmentMemorySupport().getOrCreateSegmentMemory(liaNode);
         
         InternalFactHandle fh1 = (InternalFactHandle) ksession.insert( "str1" );
         n1.getRightInput().assertObject( fh1, context, ksession );
@@ -510,7 +509,7 @@ public class NodeSegmentUnlinkingTest {
                                                   InternalWorkingMemory wm) {
         BetaMemory betaMemory = (BetaMemory) wm.getNodeMemory(node);
         if ( betaMemory.getSegmentMemory() == null ) {
-            RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, node);
+            wm.getSegmentMemorySupport().getOrCreateSegmentMemory(node);
         }
         return betaMemory;
 

--- a/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingTest.java
@@ -38,7 +38,6 @@ import org.drools.core.reteoo.NotRight;
 import org.drools.core.reteoo.PathEndNode;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.kiesession.rulebase.InternalKnowledgeBase;
-import org.drools.core.phreak.RuntimeSegmentUtilities;
 import org.drools.core.reteoo.BetaNode;
 import org.drools.core.reteoo.ExistsNode;
 import org.drools.core.reteoo.JoinNode;
@@ -328,7 +327,7 @@ public class RuleUnlinkingTest {
 
         DefaultFactHandle f1 = (DefaultFactHandle) wm.insert( "test1" );
 
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, liaNode);
+        wm.getSegmentMemorySupport().getOrCreateSegmentMemory(liaNode);
         liaNode.assertObject( f1, context, wm );
         n1.getRightInput().assertObject( f1, context, wm );
         n3.getRightInput().assertObject( f1, context, wm );
@@ -389,7 +388,7 @@ public class RuleUnlinkingTest {
                                                   InternalWorkingMemory wm) {
         BetaMemory betaMemory = (BetaMemory) wm.getNodeMemory(node);
         if ( betaMemory.getSegmentMemory() == null ) {
-            RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, node);
+            wm.getSegmentMemorySupport().getOrCreateSegmentMemory(node);
         }
         return betaMemory;
 

--- a/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingWithSegmentMemoryTest.java
+++ b/drools-kiesession/src/test/java/org/drools/kiesession/RuleUnlinkingWithSegmentMemoryTest.java
@@ -29,7 +29,6 @@ import org.drools.core.common.PhreakPropagationContextFactory;
 import org.drools.core.common.PropagationContextFactory;
 import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.RuleBaseFactory;
-import org.drools.core.phreak.RuntimeSegmentUtilities;
 import org.drools.core.phreak.BuildtimeSegmentUtilities;
 import org.drools.core.reteoo.BetaMemory;
 import org.drools.core.reteoo.BetaNode;
@@ -230,12 +229,12 @@ public class RuleUnlinkingWithSegmentMemoryTest {
         PathMemory rtn3Rs = wm.getNodeMemory( rtn3 );
 
         // lian
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, lian);
+        wm.getSegmentMemorySupport().getOrCreateSegmentMemory(lian);
         LeftInputAdapterNode.LiaNodeMemory lmem = wm.getNodeMemory( lian );
         assertThat(lmem.getNodePosMaskBit()).isEqualTo(1);
 
         // n1
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, n1);
+        wm.getSegmentMemorySupport().getOrCreateSegmentMemory(n1);
         bm = (BetaMemory) wm.getNodeMemory(n1);
         assertThat(bm.getNodePosMaskBit()).isEqualTo(2);
         assertThat(bm.getSegmentMemory().getAllLinkedMaskTest()).isEqualTo(15);
@@ -269,7 +268,7 @@ public class RuleUnlinkingWithSegmentMemoryTest {
         assertThat(list.contains(rtn3Rs)).isTrue();           
         
         // n4
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, n4);
+        wm.getSegmentMemorySupport().getOrCreateSegmentMemory(n4);
         bm = (BetaMemory) wm.getNodeMemory(n4);
         assertThat(bm.getNodePosMaskBit()).isEqualTo(1);
         assertThat(bm.getSegmentMemory().getAllLinkedMaskTest()).isEqualTo(3);
@@ -290,7 +289,7 @@ public class RuleUnlinkingWithSegmentMemoryTest {
         assertThat(list.contains(rtn3Rs)).isTrue();
         
         // n6
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, n6);
+        wm.getSegmentMemorySupport().getOrCreateSegmentMemory(n6);
         bm = (BetaMemory) wm.getNodeMemory(n6);
         assertThat(bm.getNodePosMaskBit()).isEqualTo(1);
         assertThat(bm.getSegmentMemory().getAllLinkedMaskTest()).isEqualTo(7);

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
@@ -136,7 +136,7 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
         this.activationsManager = new ActivationsManagerImpl(ruleBase, this, handleFactory);
         this.entryPointsManager = RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(ruleBase, this, handleFactory);
         
-        this.segmentMemorySupport = new SegmentMemorySupportImpl(this, nodeMemories, ruleBase.getSegmentPrototypeRegistry(), entryPointsManager.getDefaultEntryPoint());
+        this.segmentMemorySupport = new SegmentMemorySupportImpl(nodeMemories, ruleBase.getSegmentPrototypeRegistry(), entryPointsManager.getDefaultEntryPoint());
         this.timerService = sessionConfiguration.createTimerService();
 
         initInitialFact();

--- a/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
+++ b/drools-ruleunits/drools-ruleunits-impl/src/main/java/org/drools/ruleunits/impl/sessions/RuleUnitExecutorImpl.java
@@ -46,6 +46,7 @@ import org.drools.core.common.PhreakPropagationContext;
 import org.drools.core.common.PropagationContext;
 import org.drools.core.common.PropagationContextFactory;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.common.SegmentMemorySupport;
 import org.drools.core.common.SuperCacheFixer;
 import org.drools.core.event.AgendaEventSupport;
 import org.drools.core.event.RuleEventListenerSupport;
@@ -53,6 +54,7 @@ import org.drools.core.event.RuleRuntimeEventSupport;
 import org.drools.core.impl.ActivationsManagerImpl;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.PropagationEntry;
+import org.drools.core.phreak.SegmentMemorySupportImpl;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.RuntimeComponentFactory;
 import org.drools.core.reteoo.TerminalNode;
@@ -101,6 +103,8 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
     private final FactHandleFactory handleFactory;
 
     private final NodeMemories nodeMemories;
+    
+    private final SegmentMemorySupport segmentMemorySupport;
 
     private final ActivationsManager activationsManager;
     private final EntryPointsManager entryPointsManager;
@@ -131,6 +135,8 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
 
         this.activationsManager = new ActivationsManagerImpl(ruleBase, this, handleFactory);
         this.entryPointsManager = RuntimeComponentFactory.get().getEntryPointFactory().createEntryPointsManager(ruleBase, this, handleFactory);
+        
+        this.segmentMemorySupport = new SegmentMemorySupportImpl(this, nodeMemories, ruleBase.getSegmentPrototypeRegistry(), entryPointsManager.getDefaultEntryPoint());
         this.timerService = sessionConfiguration.createTimerService();
 
         initInitialFact();
@@ -182,6 +188,11 @@ public class RuleUnitExecutorImpl implements ReteEvaluator {
     @Override
     public <T extends Memory> T getNodeMemory(MemoryFactory<T> node) {
         return nodeMemories.getNodeMemory( node );
+    }
+    
+    @Override
+    public SegmentMemorySupport getSegmentMemorySupport() {
+        return segmentMemorySupport;
     }
 
     @Override

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LinkingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LinkingTest.java
@@ -34,7 +34,6 @@ import org.drools.core.reteoo.TupleToObjectNode.SubnetworkPathMemory;
 import org.drools.kiesession.session.StatefulKnowledgeSessionImpl;
 import org.drools.core.phreak.RuleAgendaItem;
 import org.drools.core.phreak.RuleExecutor;
-import org.drools.core.phreak.RuntimeSegmentUtilities;
 import org.drools.core.reteoo.EvalConditionNode;
 import org.drools.core.reteoo.ExistsNode;
 import org.drools.core.reteoo.JoinNode;
@@ -424,7 +423,7 @@ public class LinkingTest {
         JoinNode eNode = ( JoinNode ) exists1n.getSinkPropagator().getSinks()[0];
         RuleTerminalNode rtn = ( RuleTerminalNode ) eNode.getSinkPropagator().getSinks()[0];
 
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, exists1n);
+        wm.getSegmentMemorySupport().getOrCreateSegmentMemory(exists1n);
         BetaMemory existsBm = (BetaMemory) wm.getNodeMemory(exists1n);
 
         assertThat(existsBm.getSegmentMemory().getLinkedNodeMask()).isEqualTo(0);
@@ -1040,7 +1039,7 @@ public class LinkingTest {
         NotNode bNode = ( NotNode) aNode.getSinkPropagator().getSinks()[0];        
         JoinNode cNode = ( JoinNode) bNode.getSinkPropagator().getSinks()[0];                
         
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, cNode);
+        wm.getSegmentMemorySupport().getOrCreateSegmentMemory(cNode);
         LiaNodeMemory amem = wm.getNodeMemory(aNode);
 
         // Only NotNode is linked in
@@ -1117,7 +1116,7 @@ public class LinkingTest {
         NotNode bNode = ( NotNode) aNode.getSinkPropagator().getSinks()[0];        
         JoinNode cNode = ( JoinNode) bNode.getSinkPropagator().getSinks()[0];                
         
-        RuntimeSegmentUtilities.getOrCreateSegmentMemory(wm, cNode);
+        wm.getSegmentMemorySupport().getOrCreateSegmentMemory(cNode);
         LiaNodeMemory amem = wm.getNodeMemory(aNode);
 
         // Only NotNode is linked in

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
@@ -82,10 +82,10 @@ public class PhreakJoinNodeTest {
         
         bm0 =(BetaMemory)  wm.getNodeMemory(sinkNode);
         
-        smem = proto1.newSegmentMemory(wm);
+        smem = proto1.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm.setSegmentMemory( smem );
         
-        smem0 = proto2.newSegmentMemory(wm);
+        smem0 = proto2.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm0.setSegmentMemory( smem0 );       
         smem.add( smem0 );
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakNotNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakNotNodeTest.java
@@ -80,10 +80,10 @@ public class PhreakNotNodeTest {
         
         BetaMemory bm1 =(BetaMemory)  wm.getNodeMemory(sinkNode);
         
-        SegmentMemory smem = proto1.newSegmentMemory(wm);
+        SegmentMemory smem = proto1.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm.setSegmentMemory( smem );
         
-        SegmentMemory childSmem = proto2.newSegmentMemory(wm);
+        SegmentMemory childSmem = proto2.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm1.setSegmentMemory( childSmem );       
         smem.add( childSmem );     
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ScenarioTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ScenarioTest.java
@@ -84,10 +84,10 @@ public class ScenarioTest {
         
         bm0 =(BetaMemory)  wm.getNodeMemory(sinkNode);
         
-        smem = proto1.newSegmentMemory(wm);
+        smem = proto1.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm.setSegmentMemory( smem );
         
-        smem0 = proto2.newSegmentMemory(wm);
+        smem0 = proto2.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm0.setSegmentMemory( smem0 );       
         smem.add( smem0 );
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
@@ -104,18 +104,18 @@ public class SegmentPropagationTest {
         bm1 =(BetaMemory)  wm.getNodeMemory(sinkNode1);
         bm2 =(BetaMemory)  wm.getNodeMemory(sinkNode2);
         
-        smem = proto1.newSegmentMemory(wm);
+        smem = proto1.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm.setSegmentMemory( smem );
         
-        smem0 = proto2.newSegmentMemory(wm);
+        smem0 = proto2.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm0.setSegmentMemory( smem0 );       
         smem.add( smem0 );
 
-        smem1 = proto3.newSegmentMemory(wm);
+        smem1 = proto3.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm1.setSegmentMemory( smem1 );       
         smem.add( smem1 );    
         
-        smem2 = proto4.newSegmentMemory(wm);
+        smem2 = proto4.newSegmentMemory(wm.getNodeMemories(), wm.getSegmentMemorySupport());
         bm2.setSegmentMemory( smem2 );       
         smem.add( smem2 );          
     }


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->
Refactor: Extract segment memory creation into dedicated support class

Here is another PR for the Phreak improvement. The following summary is AI created and human revised.

Summary

  This PR refactors segment memory creation logic from scattered static utility methods into a cohesive, object-oriented SegmentMemorySupport component. This significantly improves code maintainability, reduces coupling, and eliminates excessive parameter passing throughout the Phreak evaluation codebase.

  Key Changes

  1. Introduced SegmentMemorySupport Interface & Implementation
  - Created new SegmentMemorySupport interface with 9 focused public methods for segment memory operations
  - Implemented SegmentMemorySupportImpl that encapsulates all segment creation logic
  - All segment memory building logic now lives in a single, well-defined component

  2. Eliminated Static Utility Pattern
  - Removed RuntimeSegmentUtilities  - static methods migrated to SegmentMemorySupportImpl
  - Reduced LazyPhreakBuilder - segment creation methods moved to new support class
  - Transformed procedural code into proper object-oriented design with instance state

  3. Reduced Coupling & Parameter Pollution
  - SegmentMemorySupportImpl depends only on what it needs:
    - NodeMemories - for memory access
    - SegmentPrototypeRegistry - for prototype-based creation
    - WorkingMemoryEntryPoint - for query handling
  - Eliminated ReteEvaluator dependency from segment creation layer
  - Removed repetitive parameter passing across dozens of method calls

  4. Enhanced SegmentPrototypeRegistry
  - Updated createSegmentFromPrototype to accept NodeMemories and SegmentMemorySupport
  - Registry now handles its own dependencies instead of requiring full ReteEvaluator
  - Better separation of concerns between prototype management and segment creation




