### PR TITLE
Apache 10.2.0 release: Cleaning up code used for testing pipelines

### DIFF
--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -20,9 +20,6 @@ git:
   - name: 10.1.x
     seed:
       branch: seed-drools-10.1.x
-  - name: 1.1.x
-    seed:
-      branch: seed-drools-1.1.x
   - name: 2.2.x
     seed:
       branch: seed-drools-2.2.x


### PR DESCRIPTION
In preparation for the 10.2.0 release, I created a couple of test branches. 1.1.x is no longer needed, and the rest of the tests will be run using 2.2.x