### PR TITLE
[incubator-kie-issues #203] Cleanup Phreak code - Minor refactoring in SegmentMemory handling

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
+++ b/drools-core/src/main/java/org/drools/core/common/SegmentMemorySupport.java
@@ -19,7 +19,6 @@
 package org.drools.core.common;
 
 import org.drools.core.reteoo.LeftTupleNode;
-import org.drools.core.reteoo.LeftTupleSinkPropagator;
 import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.PathEndNode;
 import org.drools.core.reteoo.PathMemory;
@@ -36,7 +35,7 @@ public interface SegmentMemorySupport {
     
     public SegmentMemory getQuerySegmentMemory(QueryElementNode queryNode);
     
-    public void createChildSegments(LeftTupleSinkPropagator sinkProp, SegmentMemory smem);
+    public void initializeChildSegmentsIfNeeded(SegmentMemory smem);
       
     public SegmentMemory createChildSegment(LeftTupleNode node);
    

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -1121,8 +1121,9 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             memory.getSegmentMemory().getStagedLeftTuples().addInsert(peer);
         } else {
             // If parent is Lian, then this must be called, so that any linking or unlinking can be done.
-            LeftInputAdapterNode.doInsertSegmentMemoryWithFlush(wm, true, liaMem, memory.getSegmentMemory(), peer, node
-                    .getLeftTupleSource().isStreamMode());
+            List<PathMemory> pathsToFlush = LeftInputAdapterNode.doInsertSegmentMemory(wm, true, liaMem, memory.getSegmentMemory(), peer, node
+                                .getLeftTupleSource().isStreamMode() );
+            wm.getRuleNetworkEvaluator().forceFlushPaths(pathsToFlush);
         }
 
         return peer;

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -1032,8 +1032,9 @@ class LazyPhreakBuilder implements PhreakBuilder {
             memory.getSegmentMemory().getStagedLeftTuples().addInsert(peer);
         } else {
             // If parent is Lian, then this must be called, so that any linking or unlinking can be done.
-            LeftInputAdapterNode.doInsertSegmentMemoryWithFlush(wm, true, liaMem, memory.getSegmentMemory(), peer, node
-                    .getLeftTupleSource().isStreamMode());
+            List<PathMemory> pathsToFlush = LeftInputAdapterNode.doInsertSegmentMemory(wm, true, liaMem, memory.getSegmentMemory(), peer, node
+                                .getLeftTupleSource().isStreamMode() );
+            wm.getRuleNetworkEvaluator().forceFlushPaths(pathsToFlush);
         }
 
         return peer;

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -18,6 +18,7 @@
  */
 package org.drools.core.phreak;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.base.common.NetworkNode;
@@ -51,15 +52,18 @@ public interface RuleNetworkEvaluator {
     
     void forceFlushWhenSubnetwork(PathMemory pmem);
     
-    public boolean flushLeftTupleIfNecessary(SegmentMemory sm, boolean streamMode);
+    boolean flushLeftTupleIfNecessary(SegmentMemory sm, boolean streamMode);
     
-    public boolean flushLeftTupleIfNecessary(SegmentMemory sm,
+    boolean flushLeftTupleIfNecessary(SegmentMemory sm,
                                              TupleImpl leftTuple,
                                              boolean streamMode,
                                              short stagedType);
     
     List<PathMemory> findPathsToFlushFromSubnetwork(PathMemory pmem);
     
-    void propagate(SegmentMemory sourceSegment, TupleSets leftTuples);
+
+    void forceFlushPaths(Collection<PathMemory> pathsToFlush);
+
+    void propagate(SegmentMemory smem, TupleSets actualResultLeftTuples);
 
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
@@ -145,7 +145,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
             return;
         }
 
-        LeftInputAdapterNode liaNode = (LeftInputAdapterNode) smem.getRootNode();
+        LeftTupleNode liaNode = smem.getRootNode();
 
         NetworkNode node;
         Memory nodeMem;
@@ -186,7 +186,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         }
 
         long bit = 1;
-        for (NetworkNode node = sm.getRootNode(); node != sink; node = ((LeftTupleSource) node).getSinkPropagator()
+        for (NetworkNode node = sm.getRootNode(); node != sink; node = ((LeftTupleNode) node).getSinkPropagator()
                 .getFirstLeftTupleSink()) {
             //update the bit to the correct node position.
             bit = nextNodePosMask(bit);
@@ -199,7 +199,12 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
     
     @Override
     public void forceFlushWhenSubnetwork(PathMemory pmem) {
-        for (PathMemory outPmem : findPathsToFlushFromSubnetwork(pmem)) {
+        forceFlushPaths(findPathsToFlushFromSubnetwork(pmem));
+    }
+    
+    @Override
+    public void forceFlushPaths(Collection<PathMemory> pmems) {
+        for (PathMemory outPmem : pmems) {
             forceFlushPath(outPmem);
         }
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
@@ -19,6 +19,7 @@
 package org.drools.core.phreak;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -49,12 +50,10 @@ import org.drools.core.reteoo.ExistsNode;
 import org.drools.core.reteoo.FromNode;
 import org.drools.core.reteoo.FromNode.FromMemory;
 import org.drools.core.reteoo.JoinNode;
-import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.LeftTuple;
 import org.drools.core.reteoo.LeftTupleNode;
 import org.drools.core.reteoo.LeftTupleSink;
 import org.drools.core.reteoo.LeftTupleSinkNode;
-import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.NotNode;
 import org.drools.core.reteoo.ObjectSink;
 import org.drools.core.reteoo.PathEndNode;
@@ -73,7 +72,6 @@ import org.drools.core.reteoo.Tuple;
 import org.drools.core.reteoo.TupleFactory;
 import org.drools.core.reteoo.TupleImpl;
 import org.drools.core.reteoo.TupleToObjectNode;
-import org.drools.core.reteoo.TupleToObjectNode.SubnetworkPathMemory;
 import org.drools.core.util.LinkedList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,6 +203,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
             forceFlushPath(outPmem);
         }
     }
+    
     
     @Override
     public List<PathMemory> findPathsToFlushFromSubnetwork(PathMemory pmem) {
@@ -399,8 +398,8 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
 
                         // this is needed for subnetworks that feed into a parent network that has no right inputs,
                         // and may not yet be initialized
-                        if (smem.isEmpty() && !NodeTypeEnums.isTerminalNode(smem.getTipNode())) {
-                            segmentMemorySupport.createChildSegments(smem.getTipNode().getSinkPropagator(), smem);
+                        if (!NodeTypeEnums.isTerminalNode(smem.getTipNode())) {
+                            segmentMemorySupport.initializeChildSegmentsIfNeeded(smem);
                         }
                         
                         smem = smems[i];
@@ -436,7 +435,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
                         log.trace("{} Skip Node {}", indent(offset), node);
                     }
                     bit = nextNodePosMask(bit); // shift to check the next node
-                    node = ((LeftTupleSource) node).getSinkPropagator().getFirstLeftTupleSink();
+                    node = ((LeftTupleNode) node).getSinkPropagator().getFirstLeftTupleSink();
                     nodeMem = nodeMem.getNext();
                 }
             }
@@ -460,7 +459,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
             }
 
             stagedLeftTuples = getTargetStagedLeftTuples(smem, node);
-            LeftTupleSinkNode sink = ((LeftTupleSource) node).getSinkPropagator().getFirstLeftTupleSink();
+            LeftTupleSinkNode sink = ((LeftTupleNode) node).getSinkPropagator().getFirstLeftTupleSink();
 
             trgTuples = evalNode(activationsManager, executor, stack, pmem, smems, smem, smemIndex, bit, nodeMem, node, sink, srcTuples, stagedLeftTuples, processSubnetwork);
             if (trgTuples == null) {
@@ -569,9 +568,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
                                                        NetworkNode node) {
         if (node == smem.getTipNode()) {
             // we are about to process the segment tip, allow it to merge insert/update/delete clashes
-            if (smem.isEmpty()) {
-                segmentMemorySupport.createChildSegments(((LeftTupleSource) node).getSinkPropagator(), smem);
-            }
+            segmentMemorySupport.initializeChildSegmentsIfNeeded(smem);
             return smem.getFirst().getStagedLeftTuples().takeAll();
         } else {
             return null;
@@ -749,7 +746,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
                               BetaMemory bm,
                               BetaNode betaNode,
                               LeftTupleSinkNode sink) {
-        SubnetworkPathMemory pathMem         = bm.getSubnetworkPathMemory();
+        PathMemory pathMem = bm.getSubnetworkPathMemory();
         SegmentMemory[]      subnetworkSmems = pathMem.getSegmentMemories();
         SegmentMemory subSmem = null;
         for (int i = 0; subSmem == null; i++) {
@@ -767,6 +764,8 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
             log.trace("{} SubnetworkQueue {} {}", indent(offset), betaNode.toString(), srcTuples.toStringSizes());
         }
 
+        
+        
 
         TupleSets subLts = subSmem.getStagedLeftTuples().takeAll();
         // node is first in the segment, so bit is 1
@@ -892,16 +891,13 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         srcTuples.resetAll();
     }
     
+    @Override
     public void propagate(SegmentMemory sourceSegment, TupleSets leftTuples) {
         if (leftTuples.isEmpty()) {
             return;
         }
-
-        LeftTupleSource source = ( LeftTupleSource )  sourceSegment.getTipNode();
         
-        if ( sourceSegment.isEmpty() ) {
-            segmentMemorySupport.createChildSegments(source.getSinkPropagator(), sourceSegment);
-        }
+        segmentMemorySupport.initializeChildSegmentsIfNeeded(sourceSegment);
                 
         processPeers(sourceSegment, leftTuples);
 
@@ -1030,7 +1026,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
     }
 
     private static int getOffset(NetworkNode node) {
-        LeftTupleSource lt;
+        LeftTupleNode lt;
         int offset = 1;
         if (NodeTypeEnums.isTerminalNode(node)) {
             lt = ((TerminalNode) node).getLeftTupleSource();
@@ -1038,7 +1034,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         } else if (node.getType() == NodeTypeEnums.TupleToObjectNode) {
             lt = ((TupleToObjectNode) node).getLeftTupleSource();
         } else {
-            lt = (LeftTupleSource) node;
+            lt = (LeftTupleNode) node;
         }
         while (!NodeTypeEnums.isLeftInputAdapterNode(lt)) {
             offset++;

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentMemorySupportImpl.java
@@ -210,11 +210,13 @@ public class SegmentMemorySupportImpl implements SegmentMemorySupport {
         return memory.getSegmentMemory();
     }
 
-    public void createChildSegments(LeftTupleSinkPropagator sinkProp, SegmentMemory smem) {
+    @Override
+    public void initializeChildSegmentsIfNeeded(SegmentMemory smem) {
+        LeftTupleSinkPropagator sinkPropagator = smem.getTipNode().getSinkPropagator();
         if (!smem.isEmpty()) {
             return; // this can happen when multiple threads are trying to initialize the segment
         }
-        for (LeftTupleSinkNode sink = sinkProp.getFirstLeftTupleSink(); sink != null; sink = sink
+        for (LeftTupleSinkNode sink = sinkPropagator.getFirstLeftTupleSink(); sink != null; sink = sink
                 .getNextLeftTupleSinkNode()) {
             SegmentMemory childSmem = PhreakBuilder.isEagerSegmentCreation() ? createChildSegment(sink)
                     : createChildSegmentLazily(sink);

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
@@ -79,6 +79,10 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
         return proto.getRootNode();
     }
 
+    public boolean isOnlyLiaSegment() {
+        return getRootNode() == getTipNode();
+    }
+    
     public SegmentPrototype getSegmentPrototype() {
         return proto;
     }

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakTimerNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakTimerNodeMetric.java
@@ -22,7 +22,6 @@ import org.drools.core.common.ActivationsManager;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.TupleSets;
 import org.drools.core.phreak.PhreakTimerNode;
-import org.drools.core.reteoo.LeftTuple;
 import org.drools.core.reteoo.LeftTupleSink;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.SegmentMemory;


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->
  This PR introduces two improvements to segment memory handling:

  1. Added isOnlyLiaSegment() helper method to SegmentMemory
  2. Refactored createChildSegments() → initializeChildSegmentsIfNeeded() with simplified signature




