### PR TITLE
[incubator-kie-issues #203] Cleanup Phreak code - Extract SegmentCursor

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -61,8 +61,8 @@ public class PhreakAccumulateNode {
                        LeftTupleSink sink,
                        AccumulateMemory am,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         BetaMemory bm             = am.getBetaMemory();
         TupleSets srcRightTuples = bm.getStagedRightTuples().takeAll();

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
@@ -47,13 +47,13 @@ public class PhreakBranchNode {
     }
 
     public void doNode(ActivationsManager activationsManager,
+                       RuleExecutor executor,
                        ConditionalBranchNode branchNode,
                        ConditionalBranchMemory cbm,
                        LeftTupleSink sink,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples,
-                       RuleExecutor executor) {
+                       TupleSets trgLeftTuples) {
 
         if (srcLeftTuples.getDeleteFirst() != null) {
             doLeftDeletes(sink, activationsManager, srcLeftTuples, trgLeftTuples, stagedLeftTuples, executor);

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakEvalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakEvalNode.java
@@ -54,8 +54,8 @@ public class PhreakEvalNode {
                        EvalMemory em,
                        LeftTupleSink sink,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         if (srcLeftTuples.getDeleteFirst() != null) {
             doLeftDeletes(srcLeftTuples, trgLeftTuples, stagedLeftTuples);

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
@@ -51,8 +51,8 @@ public class PhreakExistsNode {
                        LeftTupleSink sink,
                        BetaMemory bm,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
         if (!existsNode.getRightInput().inputIsTupleToObjectNode()) {
             doNormalNode(existsNode, sink, bm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
         } else {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
@@ -57,8 +57,8 @@ public class PhreakFromNode {
                        FromMemory fm,
                        LeftTupleSink sink,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         if (srcLeftTuples.getDeleteFirst() != null) {
             doLeftDeletes(fm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
@@ -48,8 +48,8 @@ public class PhreakJoinNode {
                        LeftTupleSink sink,
                        BetaMemory bm,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         TupleSets srcRightTuples = bm.getStagedRightTuples().takeAll();
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
@@ -52,8 +52,8 @@ public class PhreakNotNode {
                        LeftTupleSink sink,
                        BetaMemory bm,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         if (!notNode.getRightInput().inputIsTupleToObjectNode()) {
             doNormalNode(notNode, sink, bm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
@@ -41,12 +41,12 @@ public class PhreakQueryNode {
         this.reteEvaluator = reteEvaluator;
     }
 
-    public void doNode(QueryElementNode queryNode,
+    public void doNode(StackEntry stackEntry,
+                       QueryElementNode queryNode,
                        QueryElementNodeMemory qmem,
-                       StackEntry stackEntry,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         if (srcLeftTuples.getDeleteFirst() != null) {
             doLeftDeletes(qmem, srcLeftTuples, trgLeftTuples, stagedLeftTuples);

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakReactiveFromNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakReactiveFromNode.java
@@ -36,10 +36,10 @@ public class PhreakReactiveFromNode extends PhreakFromNode {
                        ReactiveFromMemory fm,
                        LeftTupleSink sink,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
-        super.doNode(fromNode, fm, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+        super.doNode(fromNode, fm, sink, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
         trgLeftTuples.addAll(fm.getStagedLeftTuples().takeAll());
     }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakSubnetworkNotExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakSubnetworkNotExistsNode.java
@@ -23,7 +23,6 @@ import org.drools.core.common.TupleSets;
 import org.drools.core.reteoo.BetaMemory;
 import org.drools.core.reteoo.BetaNode;
 import org.drools.core.reteoo.LeftTupleSink;
-import org.drools.core.reteoo.SubnetworkTuple;
 import org.drools.core.reteoo.Tuple;
 import org.drools.core.reteoo.TupleImpl;
 import org.drools.core.reteoo.TupleMemory;
@@ -88,7 +87,7 @@ public class PhreakSubnetworkNotExistsNode {
             for (TupleImpl rightTuple = srcRightTuples.getDeleteFirst(); rightTuple != null; ) {
                 TupleImpl next = rightTuple.getStagedNext();
 
-                TupleImpl leftTuple = node.getStartTuple((SubnetworkTuple)rightTuple);
+                TupleImpl leftTuple = node.getStartTuple(rightTuple);
                 // don't use matches here, as it may be null, if the LT was also being removed.
                 rightTuple.getMemory().remove(rightTuple);
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -62,26 +62,25 @@ public class PhreakTimerNode {
         this.reteEvaluator = reteEvaluator;
     }
 
-    public void doNode(TimerNode timerNode,
+    public void doNode(ActivationsManager activationsManager,
+                       SegmentCursor sc, 
+                       TimerNode timerNode,
                        TimerNodeMemory tm,
-                       PathMemory pmem,
-                       SegmentMemory smem,
                        LeftTupleSink sink,
-                       ActivationsManager activationsManager,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         if ( srcLeftTuples.getDeleteFirst() != null ) {
-            doLeftDeletes( timerNode, tm, pmem, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples );
+            doLeftDeletes( timerNode, tm, sc.getPathMemory(), sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples );
         }
 
         if ( srcLeftTuples.getUpdateFirst() != null ) {
-            doLeftUpdates( timerNode, tm, pmem, smem, sink, activationsManager, srcLeftTuples, trgLeftTuples, stagedLeftTuples );
+            doLeftUpdates( timerNode, tm, sc.getPathMemory(), sc.getCurrentSegment(), sink, activationsManager, srcLeftTuples, trgLeftTuples, stagedLeftTuples );
         }
 
         if ( srcLeftTuples.getInsertFirst() != null ) {
-            doLeftInserts( timerNode, tm, pmem, smem, sink, activationsManager, srcLeftTuples, trgLeftTuples );
+            doLeftInserts( timerNode, tm, sc.getPathMemory(), sc.getCurrentSegment(), sink, activationsManager, srcLeftTuples, trgLeftTuples );
         }
 
         doPropagateChildLeftTuples( tm, sink, trgLeftTuples, stagedLeftTuples );

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
@@ -573,7 +573,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
                 sc.moveToNextAvailableSegment();
             }
             
-            if (NodeTypeEnums.isTerminalNode(sc.node)) {
+            if (NodeTypeEnums.isEndNode(sc.node)) {
                 evaluateTerminalNode(activationsManager, executor, stack, sc);
                 break;
             }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
@@ -390,7 +390,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         if (log.isTraceEnabled()) {
             log.trace("Rule[name={}] segments={} {}", ((TerminalNode)pmem.getPathEndNode()).getRule().getName(), pmem.getSegmentMemories().length, segmentCursor.srcTuples.toStringSizes());
         }
-        outerEval(activationsManager, executor, segmentCursor, segmentCursor.srcTuples, true);
+        outerEval(activationsManager, executor, segmentCursor, true);
     }
 
     @Override
@@ -401,7 +401,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
                           TupleSets trgLeftTuples) {
         SegmentCursor segmentCursor = SegmentCursor.createSegmentCursor(pmem, sink, tm, trgLeftTuples);
         
-        outerEval(activationsManager, pmem.getRuleAgendaItem().getRuleExecutor(), segmentCursor, trgLeftTuples, true);
+        outerEval(activationsManager, pmem.getRuleAgendaItem().getRuleExecutor(), segmentCursor, true);
     }
 
     
@@ -461,7 +461,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         ActivationsManager activationsManager = pmem.getActualActivationsManager();
 
         
-        outerEval(activationsManager, rtnPmem.getOrCreateRuleAgendaItem().getRuleExecutor(), segmentCursor, leftTupleSets, true);
+        outerEval(activationsManager, rtnPmem.getOrCreateRuleAgendaItem().getRuleExecutor(), segmentCursor, true);
     }
 
 
@@ -496,11 +496,10 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
     private void outerEval(ActivationsManager activationsManager,
                            RuleExecutor executor,
                            SegmentCursor sc,
-                           TupleSets trgTuples,
                            boolean processSubnetwork) {
 
          LinkedList<StackEntry> stack = new LinkedList<>();
-         innerEval(activationsManager, executor, stack, sc.pmem, sc.smems, sc.smemIndex, sc.bit, sc.nodeMem, sc.node, trgTuples, processSubnetwork);
+         innerEval(activationsManager, executor, stack, sc, processSubnetwork);
          while (!stack.isEmpty()) {
              // eval
              StackEntry entry = stack.removeLast();
@@ -622,6 +621,15 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         }
     }
 
+    private void innerEval(ActivationsManager activationsManager,
+                           RuleExecutor executor,
+                           LinkedList<StackEntry> stack,
+                           SegmentCursor sc,
+                           boolean processSubnetwork) {
+        
+        innerEval(activationsManager, executor, stack, sc.pmem, sc.smems, sc.smemIndex, sc.bit, sc.nodeMem, sc.node, sc.srcTuples, processSubnetwork);
+         
+     }
     private void evaluateTerminalNode(ActivationsManager activationsManager,
                           RuleExecutor executor,
                           LinkedList<StackEntry> stack,

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentCursor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentCursor.java
@@ -40,8 +40,9 @@ import static org.drools.core.phreak.BuildtimeSegmentUtilities.nextNodePosMask;
 public class SegmentCursor {
     private static final Logger log = LoggerFactory.getLogger(SegmentCursor.class);
     
-    private PathMemory pmem;
-    private SegmentMemory[] smems;
+    private final PathMemory pmem;
+    private final SegmentMemory[] smems;
+
     private int smemIndex;
     private long bit;
     private Memory nodeMem;
@@ -359,7 +360,6 @@ public class SegmentCursor {
                     sm.getPos(),
                     1L,
                     sm.getNodeMemories()[0],
-                    // The segment is the first and it has the lian shared with other nodes, the lian must be skipped, so adjust the bit and sink
                     sm.getRootNode(), 
                     tupleSets);
         }

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentCursor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentCursor.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.drools.core.phreak;
 
 import org.drools.base.common.NetworkNode;

--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentCursor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentCursor.java
@@ -1,0 +1,457 @@
+package org.drools.core.phreak;
+
+import org.drools.base.common.NetworkNode;
+import org.drools.base.reteoo.NodeTypeEnums;
+import org.drools.core.common.Memory;
+import org.drools.core.common.TupleSets;
+import org.drools.core.reteoo.BetaMemory;
+import org.drools.core.reteoo.BetaNode;
+import org.drools.core.reteoo.LeftTupleNode;
+import org.drools.core.reteoo.LeftTupleSink;
+import org.drools.core.reteoo.LeftTupleSinkNode;
+import org.drools.core.reteoo.PathMemory;
+import org.drools.core.reteoo.SegmentMemory;
+import org.drools.core.reteoo.SegmentNodeMemory;
+import org.drools.core.reteoo.TerminalNode;
+import org.drools.core.reteoo.TupleToObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.drools.core.phreak.BuildtimeSegmentUtilities.nextNodePosMask;
+
+public class SegmentCursor {
+    private static final Logger log = LoggerFactory.getLogger(SegmentCursor.class);
+    
+    private PathMemory pmem;
+    private SegmentMemory[] smems;
+    private int smemIndex;
+    private long bit;
+    private Memory nodeMem;
+    private NetworkNode node;
+    private TupleSets srcTuples;
+    private TupleSets stagedLeftTuples;
+    
+    public SegmentCursor(PathMemory pmem,
+                         SegmentMemory[] smems,
+                         int smemIndex,
+                         long bit,
+                         Memory nodeMem,
+                         NetworkNode node, 
+                         TupleSets srcTuples) {
+        this.pmem = pmem;
+        this.smems = smems;
+        this.smemIndex = smemIndex;
+        this.bit = bit;
+        this.nodeMem = nodeMem;
+        this.node = node;
+        this.srcTuples = srcTuples;
+    }
+    
+    public PathMemory getPathMemory() {
+        return pmem;
+    }
+    
+    public int getSegmentMemorySize() {
+        return smems.length;
+    }
+    
+    public Memory getCurrentNodeMemory() {
+        return nodeMem;
+    }
+    
+    public int getSegmentMemoryIndex() {
+        return smemIndex;
+    }
+    
+    public NetworkNode getCurrentNode() {
+        return node;
+    }
+    
+    public TupleSets getSourceTuples() {
+        return srcTuples;
+    }
+    
+    public TupleSets getStagedLeftTuples() {
+        return stagedLeftTuples;
+    }
+    
+    public SegmentMemory getCurrentSegment() {
+        return smems[smemIndex];
+    }
+    
+    public void setSourceTuples(TupleSets srcTuples) {
+        this.srcTuples = srcTuples;
+    }
+    
+    
+    public void moveToNextAvailableSegment() {
+        while ((getCurrentSegment().getDirtyNodeMask() & bit) == 0 && node != getCurrentSegment().getTipNode() && !NodeTypeEnums.isBetaNodeWithSubnetwork(node)) {
+        //while ((dirtyMask & bit) == 0 && node != smem.getTipNode() && NodeTypeEnums.isBetaNodeWithoutSubnetwork(node)) {
+            if (log.isTraceEnabled()) {
+                int offset = getOffset(node);
+                log.trace("{} Skip Node {}", indent(offset), node);
+            }
+            bit = nextNodePosMask(bit); // shift to check the next node
+            node = ((LeftTupleNode) node).getSinkPropagator().getFirstLeftTupleSink();
+            nodeMem = nodeMem.getNext();
+        }
+    }
+
+    public void moveToNextNodeInSegment() {
+        node = ((LeftTupleNode) node).getSinkPropagator().getFirstLeftTupleSink();
+        nodeMem = nodeMem.getNext();
+        bit = nextNodePosMask(bit);
+    }
+
+    public void moveToNextSegment() {
+        // Reached end of segment, start on new segment.
+        bit = 1;
+        smemIndex = smemIndex + 1;
+    
+        node = getCurrentSegment().getRootNode();
+        nodeMem = getCurrentSegment().getNodeMemories()[0];
+    }
+
+    public void moveToNextNodeOrSegment() {
+        if (node == getCurrentSegment().getTipNode()) {
+            moveToNextSegment();
+            srcTuples = getCurrentSegment().getStagedLeftTuples().takeAll();
+            traceMoveToNextNodeOrSegment();
+        } else {
+            // get next node and node memory in the segment
+            moveToNextNodeInSegment();
+        }
+    }
+
+    public void moveToSegment(int i) {
+        smemIndex = i;
+        bit = 1;
+        srcTuples = getCurrentSegment().getStagedLeftTuples().takeAll();
+        node = getCurrentSegment().getRootNode();
+        nodeMem = getCurrentSegment().getNodeMemories()[0];
+    }
+
+    public boolean isDirtySegmentOrIsSubnetwork() {
+        return !srcTuples.isEmpty() ||
+             getCurrentSegment().getDirtyNodeMask() != 0 ||
+             (NodeTypeEnums.isBetaNode(node) && ((BetaNode)node).getRightInput().inputIsTupleToObjectNode());
+    }
+
+    public boolean isOnEmptyOrNonDirtySegment() {
+        return srcTuples.isEmpty() && getCurrentSegment().getDirtyNodeMask() == 0;
+    }
+
+    public boolean isAtEndOfSegmentMemory() {
+        return node == getCurrentSegment().getTipNode();
+    }
+
+    public boolean hasNoSourceTuples() {
+        return srcTuples.isEmpty();
+    }
+
+    public void restoreStagedLeftTuples() {
+        getCurrentSegment().getFirst().getStagedLeftTuples().addAll(stagedLeftTuples);
+    }
+
+    public boolean stagedLeftTuplesAreNotEmpty() {
+        return stagedLeftTuples != null && !stagedLeftTuples.isEmpty();
+    }
+
+    public void traceStartOfEvaluation(int cycle) {
+        if (log.isTraceEnabled()) {
+            int offset = getOffset(node);
+            log.trace("{} {} {} {}", indent(offset), cycle, node.toString(), srcTuples.toStringSizes());
+        }
+    }
+
+    public void traceMoveToDirtySegment(int cycle2) {
+        if (log.isTraceEnabled()) {
+            int offset = getOffset(node);
+            log.trace("{} Segment {}", indent(offset), smemIndex);
+            log.trace("{} {} {} {}", indent(offset), cycle2, node.toString(), srcTuples.toStringSizes());
+        }
+    }
+
+    public void traceSkipNonDirtySegment(int i) {
+        if (log.isTraceEnabled()) {
+            int offset = getOffset(node);
+            log.trace("{} Skip Segment {}", indent(offset), i-1);
+        }
+    }
+
+    public void traceMoveToNextNodeOrSegment() {
+        if (log.isTraceEnabled()) {
+            int offset = getOffset(node);
+            log.trace("{} Segment {}", indent(offset), smemIndex);
+        }
+    }
+    
+    public void traceResumeFromStack() {
+        if (log.isTraceEnabled()) {
+            int offset = getOffset(node);
+            log.trace("{} Resume {} {}", indent(offset), node.toString(), srcTuples.toStringSizes());
+        }
+    }
+
+    public void traceSubnetworkQueue() {
+        if (log.isTraceEnabled()) {
+            int offset = getOffset(node);
+            log.trace("{} SubnetworkQueue {} {}", indent(offset), node.toString(), srcTuples.toStringSizes());
+        }
+    }
+
+    public void traceSwitchOnBetaNodes(BetaMemory bm) {
+        if (log.isTraceEnabled()) {
+            int offset = getOffset(node);
+            log.trace("{} rightTuples {}", indent(offset), bm.getStagedRightTuples().toStringSizes());
+        }
+    }
+
+    public void traceQueryResultTuples() {
+        if (log.isTraceEnabled()) {
+            int offset = getOffset(node);
+            log.trace("{} query result tuples {}", indent(offset), ((org.drools.core.reteoo.QueryElementNode.QueryElementNodeMemory) nodeMem).getResultLeftTuples().toStringSizes());
+        }
+    }
+
+    public void traceOrQueryBranchQueued(int i) {
+        if (log.isTraceEnabled()) {
+            int offset = getOffset(node);
+            log.trace("{} ORQueue branch={} {} {}", indent(offset), i, node.toString(), srcTuples.toStringSizes());
+        }
+    }
+
+    public void traceNetworkEvaluation() {
+        if (log.isTraceEnabled()) {
+            log.trace("Rule[name={}] segments={} {}", ((TerminalNode)pmem.getPathEndNode()).getRule().getName(), pmem.getSegmentMemories().length, srcTuples.toStringSizes());
+        }
+    }
+
+    public StackEntry saveForResumeAfterQueryExecution(TupleSets trgTuples) {
+        LeftTupleSinkNode sink = getFirstLeftTupleSink();
+        StackEntry stackEntry = new StackEntry(node, bit, sink, pmem, nodeMem, smems,
+                                               smemIndex, trgTuples, true, true);
+        return stackEntry;
+    }
+
+    public StackEntry saveForResumeAfterSubnetworkExecution() {
+        LeftTupleSinkNode sink = getFirstLeftTupleSink();
+        // Resume the node after the TupleToObjectNode segment has been processed and the right input memory populated
+        return new StackEntry(node, ((SegmentNodeMemory) nodeMem).getNodePosMaskBit(), sink, pmem, nodeMem, smems,
+                                               smemIndex, srcTuples, false, false);
+    }
+
+    public StackEntry saveForQueryBranchEvaluation() {
+        return new StackEntry(node, bit, null, pmem,
+                                    nodeMem, pmem.getSegmentMemories(), smemIndex,
+                                    srcTuples, false, true);
+    }
+
+    public LeftTupleSinkNode getFirstLeftTupleSink() {
+        return ((LeftTupleNode) node).getSinkPropagator().getFirstLeftTupleSink();
+    }
+
+    public void saveStagedLeftTuples() {
+        stagedLeftTuples = getCurrentSegment().getFirst().getStagedLeftTuples().takeAll();
+    }
+
+    public void resetStagedLeftTuples() {
+        stagedLeftTuples = null;
+    }
+
+    public static SegmentCursor createForSubNetwork(PathMemory pathMem) {
+        SegmentMemory[]      subnetworkSmems = pathMem.getSegmentMemories();
+        SegmentMemory subSmem = null;
+        for (int i = 0; subSmem == null; i++) {
+            // segment positions outside of the subnetwork, in the parent chain, are null
+            // so we must iterate to find the first non null segment memory
+            subSmem =  subnetworkSmems[i];
+        }
+        TupleSets subLts = subSmem.getStagedLeftTuples().takeAll();
+        // node is first in the segment, so bit is 1
+        
+        return new SegmentCursor(pathMem, 
+                subnetworkSmems, 
+                subSmem.getPos(), 
+                1, 
+                subSmem.getNodeMemories()[0], 
+                subSmem.getRootNode(), 
+                subLts);
+    }
+
+    public static SegmentCursor createForResume(StackEntry entry) {
+        NetworkNode node;
+        SegmentMemory smem = entry.getSmems()[entry.getSmemIndex()];
+        if (entry.getNode() == smem.getTipNode()) {
+            // Reached end of segment, start on new segment.
+            smem = entry.getSmems()[entry.getSmemIndex() + 1];
+            return new SegmentCursor(entry.getRmem(), 
+                    entry.getSmems(), 
+                    entry.getSmemIndex() + 1, 
+                    1, // update bit to start of new segment
+                    smem.getNodeMemories()[0], 
+                    smem.getRootNode(), 
+                    smem.getStagedLeftTuples().takeAll());
+            
+    
+        } else {
+            // get next node and node memory in the segment
+            LeftTupleSink nextSink = entry.getSink().getNextLeftTupleSinkNode();
+            if (nextSink == null) {
+                node = entry.getSink();
+            } else {
+                // there is a nested subnetwork, take out path
+                node = nextSink;
+            }
+            return new SegmentCursor(entry.getRmem(), 
+                    entry.getSmems(), 
+                    entry.getSmemIndex(), 
+                    nextNodePosMask(entry.getBit()), // update bit to new node, 
+                    entry.getNodeMem().getNext(), 
+                    node, 
+                    entry.getTrgTuples());
+        }
+    }
+
+    public static SegmentCursor createForNonResume(StackEntry entry) {
+        SegmentCursor sc;
+        sc = new SegmentCursor(entry.getRmem(), 
+                entry.getSmems(), 
+                entry.getSmemIndex(), 
+                entry.getBit(), 
+                entry.getNodeMem(), 
+                entry.getNode(), 
+                entry.getTrgTuples());
+        return sc;
+    }
+
+    public static SegmentCursor createSegmentCursor(PathMemory pmem, SegmentMemory sm, TupleSets tupleSets) {
+        if (NodeTypeEnums.isLeftInputAdapterNode(sm.getRootNode()) && !NodeTypeEnums.isLeftInputAdapterNode(sm.getTipNode())) {
+            return new SegmentCursor(pmem, 
+                    pmem.getSegmentMemories(), 
+                    sm.getPos(),
+                    2L,
+                    sm.getNodeMemories()[1],
+                    // The segment is the first and it has the lian shared with other nodes, the lian must be skipped, so adjust the bit and sink
+                    sm.getRootNode().getSinkPropagator().getFirstLeftTupleSink(), 
+                    tupleSets);
+        } else {
+            return new SegmentCursor(pmem, 
+                    pmem.getSegmentMemories(), 
+                    sm.getPos(),
+                    1L,
+                    sm.getNodeMemories()[0],
+                    // The segment is the first and it has the lian shared with other nodes, the lian must be skipped, so adjust the bit and sink
+                    sm.getRootNode(), 
+                    tupleSets);
+        }
+    }
+
+    
+
+    public static SegmentCursor createSegmentCursor(PathMemory pmem, NetworkNode sink, Memory tm, TupleSets tupleSets) {
+        SegmentMemory[] smems = pmem.getSegmentMemories();
+        SegmentMemory sm = tm.getSegmentMemory();
+        int smemIndex = 0;
+        for (SegmentMemory smem : smems) {
+            if (smem == sm) {
+                break;
+            }
+            smemIndex++;
+        }
+
+        long bit = 1;
+        for (NetworkNode node = sm.getRootNode(); node != sink; node = ((LeftTupleNode) node).getSinkPropagator()
+                .getFirstLeftTupleSink()) {
+            //update the bit to the correct node position.
+            bit = nextNodePosMask(bit);
+        }
+
+        return new SegmentCursor(pmem, 
+                smems,
+                smemIndex,
+                bit,
+                tm,
+                sink, tupleSets);
+    }
+
+    public static SegmentCursor createSegmentCursorForQueryExecution(PathMemory pmem) {
+        if (pmem.getPathEndNode().getPathNodes()[0] == pmem.getSegmentMemories()[0].getTipNode()) {
+            // segment only has liaNode in it
+            // nothing is staged in the liaNode, so skip to next segment
+            return new SegmentCursor(
+                    pmem, 
+                    pmem.getSegmentMemories(), 
+                    1, 
+                    1L,  
+                    pmem.getSegmentMemories()[1].getNodeMemories()[0], 
+                    pmem.getSegmentMemories()[1].getRootNode(), 
+                    pmem.getSegmentMemories()[1].getStagedLeftTuples().takeAll());
+        } else {
+            // lia is in shared segment, so point to next node
+            return new SegmentCursor(
+                    pmem, 
+                    pmem.getSegmentMemories(), 
+                    0, 
+                    2L,  
+                    pmem.getSegmentMemories()[0].getNodeMemories()[1], 
+                    pmem.getPathEndNode().getPathNodes()[0].getSinkPropagator().getFirstLeftTupleSink(), 
+                    pmem.getSegmentMemories()[0].getStagedLeftTuples().takeAll());
+        }
+    }
+
+    public static SegmentCursor createSegmentCursor(PathMemory pmem) {
+        if (pmem.getSegmentMemories()[0].isOnlyLiaSegment()) {
+            return new SegmentCursor(
+                    pmem,
+                    pmem.getSegmentMemories(),
+                    1,
+                    1L,
+                    // segment only has liaNode in it
+                    // nothing is staged in the liaNode, so skip to next segment
+                    pmem.getSegmentMemories()[1].getNodeMemories()[0],
+                    pmem.getSegmentMemories()[1].getRootNode(), 
+                    pmem.getSegmentMemories()[1].getStagedLeftTuples());
+            
+        } else {
+            // lia is in shared segment, so point to next node
+            return new SegmentCursor(
+                    pmem, 
+                    pmem.getSegmentMemories(),
+                    0,
+                    2L,
+                    pmem.getSegmentMemories()[0].getNodeMemories()[1],
+                    pmem.getSegmentMemories()[0].getRootNode().getSinkPropagator().getFirstLeftTupleSink(),
+                    pmem.getSegmentMemories()[0].getStagedLeftTuples());
+        }
+    }
+
+    private static String indent(int size) {
+        StringBuilder sbuilder = new StringBuilder();
+        for (int i = 0; i < size; i++) {
+            sbuilder.append("  ");
+        }
+
+        return sbuilder.toString();
+    }
+
+    private static int getOffset(NetworkNode node) {
+        LeftTupleNode lt;
+        int offset = 1;
+        if (NodeTypeEnums.isTerminalNode(node)) {
+            lt = ((TerminalNode) node).getLeftTupleSource();
+            offset++;
+        } else if (node.getType() == NodeTypeEnums.TupleToObjectNode) {
+            lt = ((TupleToObjectNode) node).getLeftTupleSource();
+        } else {
+            lt = (LeftTupleNode) node;
+        }
+        while (!NodeTypeEnums.isLeftInputAdapterNode(lt)) {
+            offset++;
+            lt = lt.getLeftTupleSource();
+        }
+
+        return offset;
+    }
+    
+}

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAccumulateNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakAccumulateNodeMetric.java
@@ -37,13 +37,13 @@ public class PhreakAccumulateNodeMetric extends PhreakAccumulateNode {
                        LeftTupleSink sink,
                        AccumulateMemory am,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(accNode);
 
-            super.doNode(accNode, sink, am, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(accNode, sink, am, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakBranchNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakBranchNodeMetric.java
@@ -36,18 +36,18 @@ public class PhreakBranchNodeMetric extends PhreakBranchNode {
 
     @Override
     public void doNode(ActivationsManager activationsManager,
+                       RuleExecutor executor,
                        ConditionalBranchNode branchNode,
                        ConditionalBranchMemory cbm,
                        LeftTupleSink sink,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
                        TupleSets stagedLeftTuples,
-                       RuleExecutor executor) {
+                       TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(branchNode);
 
-            super.doNode(activationsManager, branchNode, cbm, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples, executor);
+            super.doNode(activationsManager, executor, branchNode, cbm, sink, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakEvalNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakEvalNodeMetric.java
@@ -37,13 +37,13 @@ public class PhreakEvalNodeMetric extends PhreakEvalNode {
                        EvalMemory em,
                        LeftTupleSink sink,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(evalNode);
 
-            super.doNode(evalNode, em, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(evalNode, em, sink, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakExistsNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakExistsNodeMetric.java
@@ -37,13 +37,13 @@ public class PhreakExistsNodeMetric extends PhreakExistsNode {
                        LeftTupleSink sink,
                        BetaMemory bm,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(existsNode);
 
-            super.doNode(existsNode, sink, bm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(existsNode, sink, bm, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakFromNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakFromNodeMetric.java
@@ -38,13 +38,13 @@ public class PhreakFromNodeMetric extends PhreakFromNode {
                        FromMemory fm,
                        LeftTupleSink sink,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(fromNode);
 
-            super.doNode(fromNode, fm, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(fromNode, fm, sink, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakGroupByNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakGroupByNodeMetric.java
@@ -36,13 +36,13 @@ public class PhreakGroupByNodeMetric extends PhreakGroupByNode {
                         LeftTupleSink sink,
                         AccumulateNode.AccumulateMemory am,
                         TupleSets srcLeftTuples,
-                        TupleSets trgLeftTuples,
-                        TupleSets stagedLeftTuples) {
+                        TupleSets stagedLeftTuples,
+                        TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(accNode);
 
-            super.doNode(accNode, sink, am, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(accNode, sink, am, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakJoinNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakJoinNodeMetric.java
@@ -37,12 +37,12 @@ public class PhreakJoinNodeMetric extends PhreakJoinNode {
                        LeftTupleSink sink,
                        BetaMemory bm,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
         try {
             MetricLogUtils.getInstance().startMetrics(joinNode);
 
-            super.doNode(joinNode, sink, bm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(joinNode, sink, bm, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakNotNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakNotNodeMetric.java
@@ -37,13 +37,13 @@ public class PhreakNotNodeMetric extends PhreakNotNode {
                        LeftTupleSink sink,
                        BetaMemory bm,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(notNode);
 
-            super.doNode(notNode, sink, bm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(notNode, sink, bm, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakQueryNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakQueryNodeMetric.java
@@ -33,17 +33,17 @@ public class PhreakQueryNodeMetric extends PhreakQueryNode {
     }
 
     @Override
-    public void doNode(QueryElementNode queryNode,
+    public void doNode(StackEntry stackEntry,
+                       QueryElementNode queryNode,
                        QueryElementNodeMemory qmem,
-                       StackEntry stackEntry,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(queryNode);
 
-            super.doNode(queryNode, qmem, stackEntry, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(stackEntry, queryNode, qmem, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakReactiveFromNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakReactiveFromNodeMetric.java
@@ -37,13 +37,13 @@ public class PhreakReactiveFromNodeMetric extends PhreakReactiveFromNode {
                        ReactiveFromMemory fm,
                        LeftTupleSink sink,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(fromNode);
 
-            super.doNode(fromNode, fm, sink, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(fromNode, fm, sink, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-metric/src/main/java/org/drools/metric/phreak/PhreakTimerNodeMetric.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/PhreakTimerNodeMetric.java
@@ -22,9 +22,8 @@ import org.drools.core.common.ActivationsManager;
 import org.drools.core.common.ReteEvaluator;
 import org.drools.core.common.TupleSets;
 import org.drools.core.phreak.PhreakTimerNode;
+import org.drools.core.phreak.SegmentCursor;
 import org.drools.core.reteoo.LeftTupleSink;
-import org.drools.core.reteoo.PathMemory;
-import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.reteoo.TimerNode;
 import org.drools.core.reteoo.TimerNode.TimerNodeMemory;
 import org.drools.metric.util.MetricLogUtils;
@@ -36,20 +35,19 @@ public class PhreakTimerNodeMetric extends PhreakTimerNode {
     }
 
     @Override
-    public void doNode(TimerNode timerNode,
+    public void doNode(ActivationsManager activationsManager,
+                       SegmentCursor sc,
+                       TimerNode timerNode,
                        TimerNodeMemory tm,
-                       PathMemory pmem,
-                       SegmentMemory smem,
                        LeftTupleSink sink,
-                       ActivationsManager activationsManager,
                        TupleSets srcLeftTuples,
-                       TupleSets trgLeftTuples,
-                       TupleSets stagedLeftTuples) {
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
 
         try {
             MetricLogUtils.getInstance().startMetrics(timerNode);
 
-            super.doNode(timerNode, tm, pmem, smem, sink, activationsManager, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+            super.doNode(activationsManager, sc, timerNode, tm, sink, srcLeftTuples, stagedLeftTuples, trgLeftTuples);
 
         } finally {
             MetricLogUtils.getInstance().logAndEndMetrics();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Scenario.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Scenario.java
@@ -177,14 +177,14 @@ public class Scenario {
         
         if ( phreakNode == PhreakJoinNode.class ) {
             new PhreakJoinNode(wm).doNode( (JoinNode) betaNode, sinkNode,
-                                          bm, leftTuples, actualResultLeftTuples, previousResultTuples );
+                                          bm, leftTuples, previousResultTuples, actualResultLeftTuples );
             
         } else if ( phreakNode == PhreakNotNode.class ) {
             new PhreakNotNode(wm).doNode( (NotNode) betaNode, sinkNode,
-                                        bm, leftTuples, actualResultLeftTuples, previousResultTuples );            
+                                        bm, leftTuples, previousResultTuples, actualResultLeftTuples );            
         } else if ( phreakNode == PhreakExistsNode.class ) {
             new PhreakExistsNode(wm).doNode( (ExistsNode) betaNode, sinkNode,
-                                           bm, leftTuples, actualResultLeftTuples, previousResultTuples );            
+                                           bm, leftTuples, previousResultTuples, actualResultLeftTuples );            
         }
         
         if ( expectedResultBuilder != null ) {


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

 Refactors PHREAK rule network evaluation to encapsulate traversal state into a dedicated SegmentCursor class.

  - Extracted SegmentCursor.java  - Encapsulates segment traversal state and navigation logic
  - Refactored RuleNetworkEvaluatorImpl.java - Simplified to focus on evaluation logic
  - Updated method signatures foro the new API


