### PR TITLE
[incubator-kie-issues #203] Cleanup Phreak code - Remove getActivationsManager from ReteEvaluator

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/ActivationsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/ActivationsManager.java
@@ -36,8 +36,6 @@ public interface ActivationsManager {
     String ON_AFTER_ALL_FIRES_CONSEQUENCE_NAME = "$onAfterAllFire$";
     String ON_DELETE_MATCH_CONSEQUENCE_NAME = "$onDeleteMatch$";
 
-    ReteEvaluator getReteEvaluator();
-
     AgendaGroupsManager getAgendaGroupsManager();
 
     AgendaEventSupport getAgendaEventSupport();

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupsManager.java
@@ -326,7 +326,7 @@ public interface AgendaGroupsManager extends Externalizable {
         private void clearAndCancelAgendaGroup(InternalAgendaGroup agendaGroup, InternalAgenda agenda) {
             // enforce materialization of all activations of this group before removing them
             for (RuleAgendaItem activation : agendaGroup.getActivations()) {
-                activation.getRuleExecutor().evaluateNetworkIfDirty( agenda );
+                activation.getRuleExecutor().evaluateNetworkIfDirty(workingMemory, agenda );
             }
 
             final EventSupport eventsupport = this.workingMemory;

--- a/drools-core/src/main/java/org/drools/core/concurrent/AbstractGroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/AbstractGroupEvaluator.java
@@ -20,6 +20,7 @@ package org.drools.core.concurrent;
 
 import org.drools.core.common.ActivationsManager;
 import org.drools.core.common.InternalAgendaGroup;
+import org.drools.core.common.ReteEvaluator;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.RuleAgendaItem;
 import org.drools.core.rule.consequence.KnowledgeHelper;
@@ -34,11 +35,11 @@ public abstract class AbstractGroupEvaluator implements GroupEvaluator {
 
     private boolean haltEvaluation;
 
-	private InternalRuleBase ruleBase;
+    protected ReteEvaluator reteEvaluator;
 
-    public AbstractGroupEvaluator(InternalRuleBase ruleBase, ActivationsManager activationsManager) {
-        this.ruleBase = ruleBase;
-		this.activationsManager = activationsManager;
+    public AbstractGroupEvaluator(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, ActivationsManager activationsManager) {
+		this.reteEvaluator = reteEvaluator;
+        this.activationsManager = activationsManager;
         this.sequential = ruleBase.getRuleBaseConfiguration().isSequential();
         this.knowledgeHelper = newKnowledgeHelper();
     }
@@ -49,7 +50,7 @@ public abstract class AbstractGroupEvaluator implements GroupEvaluator {
         int loopFireCount = 0;
         while (item != null && !haltEvaluation && (fireLimit < 0 || (fireCount + loopFireCount) < fireLimit)) {
             activationsManager.evaluateQueriesForRule( item );
-            loopFireCount += item.getRuleExecutor().evaluateNetworkAndFire(activationsManager, filter, fireCount, fireLimit);
+            loopFireCount += item.getRuleExecutor().evaluateNetworkAndFire(reteEvaluator, activationsManager, filter, fireCount, fireLimit);
             activationsManager.flushPropagations();
             item = nextActivation(group);
         }
@@ -57,7 +58,7 @@ public abstract class AbstractGroupEvaluator implements GroupEvaluator {
     }
 
     private KnowledgeHelper newKnowledgeHelper() {
-        return activationsManager.getReteEvaluator().createKnowledgeHelper();
+        return reteEvaluator.createKnowledgeHelper();
     }
 
     private RuleAgendaItem nextActivation(InternalAgendaGroup group) {

--- a/drools-core/src/main/java/org/drools/core/concurrent/ParallelGroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/ParallelGroupEvaluator.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.drools.base.common.RuleBasePartitionId;
 import org.drools.core.common.ActivationsManager;
 import org.drools.core.common.InternalAgendaGroup;
+import org.drools.core.common.ReteEvaluator;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.RuleAgendaItem;
 
@@ -34,8 +35,8 @@ import static org.drools.base.common.PartitionsManager.doOnForkJoinPool;
 
 public class ParallelGroupEvaluator extends AbstractGroupEvaluator {
 
-    public ParallelGroupEvaluator(InternalRuleBase ruleBase, ActivationsManager activationsManager ) {
-        super(ruleBase, activationsManager);
+    public ParallelGroupEvaluator(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, ActivationsManager activationsManager ) {
+        super(ruleBase, reteEvaluator, activationsManager);
     }
 
     protected void startEvaluation(InternalAgendaGroup group) {
@@ -62,7 +63,7 @@ public class ParallelGroupEvaluator extends AbstractGroupEvaluator {
         doOnForkJoinPool(() ->
                 partitionedActivations.values().parallelStream()
                         .forEach( items -> items
-                                .forEach( item -> item.getRuleExecutor().evaluateNetworkIfDirty(activationsManager) ) )
+                                .forEach( item -> item.getRuleExecutor().evaluateNetworkIfDirty(reteEvaluator, activationsManager) ) )
         );
     }
 }

--- a/drools-core/src/main/java/org/drools/core/concurrent/SequentialGroupEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/SequentialGroupEvaluator.java
@@ -19,12 +19,13 @@
 package org.drools.core.concurrent;
 
 import org.drools.core.common.ActivationsManager;
+import org.drools.core.common.ReteEvaluator;
 import org.drools.core.impl.InternalRuleBase;
 
 public class SequentialGroupEvaluator extends AbstractGroupEvaluator {
 
-    public SequentialGroupEvaluator(InternalRuleBase ruleBase, ActivationsManager activationsManager) {
-        super(ruleBase, activationsManager);
+    public SequentialGroupEvaluator(InternalRuleBase ruleBase, ReteEvaluator reteEvaluator, ActivationsManager activationsManager) {
+        super(ruleBase, reteEvaluator, activationsManager);
     }
 }
 

--- a/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/ActivationsManagerImpl.java
@@ -89,15 +89,10 @@ public class ActivationsManagerImpl implements ActivationsManager {
 		this.factHandleFactory = factHandleFactory;
         this.agendaGroupsManager = new AgendaGroupsManager.SimpleAgendaGroupsManager(ruleBase, reteEvaluator, factHandleFactory);
         this.propagationList = new SynchronizedPropagationList(reteEvaluator);
-        this.groupEvaluator = new SequentialGroupEvaluator( ruleBase, this );
+        this.groupEvaluator = new SequentialGroupEvaluator( ruleBase, reteEvaluator, this );
         if (ruleBase.getRuleBaseConfiguration().getEventProcessingMode() == EventProcessingOption.STREAM) {
             expirationContexts = new ArrayList<>();
         }
-    }
-
-    @Override
-    public ReteEvaluator getReteEvaluator() {
-        return reteEvaluator;
     }
 
     @Override
@@ -139,7 +134,7 @@ public class ActivationsManagerImpl implements ActivationsManager {
 
     @Override
     public void removeQueryAgendaItem(RuleAgendaItem item) {
-        queries.remove( (QueryImpl) item.getRule() );
+        queries.remove(item.getRule());
     }
 
     @Override
@@ -240,7 +235,7 @@ public class ActivationsManagerImpl implements ActivationsManager {
             if (item.isRuleInUse()) { // this rule could have been removed by an incremental compilation
                 evaluateQueriesForRule( item );
                 RuleExecutor ruleExecutor = item.getRuleExecutor();
-                ruleExecutor.evaluateNetwork( this );
+                ruleExecutor.evaluateNetwork(reteEvaluator, this);
             }
         }
     }
@@ -252,7 +247,7 @@ public class ActivationsManagerImpl implements ActivationsManager {
             for (QueryImpl query : rule.getDependingQueries()) {
                 RuleAgendaItem queryAgendaItem = queries.remove(query);
                 if (queryAgendaItem != null) {
-                    queryAgendaItem.getRuleExecutor().evaluateNetwork(this);
+                    queryAgendaItem.getRuleExecutor().evaluateNetwork(reteEvaluator, this);
                 }
             }
         }

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -1098,8 +1098,8 @@ public class EagerPhreakBuilder implements PhreakBuilder {
             if (insert) {
                 TerminalNode rtn = (TerminalNode) node;
                 InternalAgenda agenda = wm.getAgenda();
-                RuleAgendaItem agendaItem = AlphaTerminalNode.getRuleAgendaItem(wm, agenda, rtn, insert);
-                PhreakRuleTerminalNode.doLeftTupleInsert(rtn, agendaItem.getRuleExecutor(), agenda, agendaItem,
+                RuleAgendaItem agendaItem = AlphaTerminalNode.getRuleAgendaItem(wm, rtn, insert);
+                PhreakRuleTerminalNode.doLeftTupleInsert(wm, rtn, agendaItem.getRuleExecutor(), agenda, agendaItem,
                         (RuleTerminalNodeLeftTuple) peer);
             }
             return peer;

--- a/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/LazyPhreakBuilder.java
@@ -1010,8 +1010,8 @@ class LazyPhreakBuilder implements PhreakBuilder {
             if (insert) {
                 TerminalNode rtn = (TerminalNode) node;
                 InternalAgenda agenda = wm.getAgenda();
-                RuleAgendaItem agendaItem = AlphaTerminalNode.getRuleAgendaItem(wm, agenda, rtn, insert);
-                PhreakRuleTerminalNode.doLeftTupleInsert(rtn, agendaItem.getRuleExecutor(), agenda, agendaItem,
+                RuleAgendaItem agendaItem = AlphaTerminalNode.getRuleAgendaItem(wm, rtn, insert);
+                PhreakRuleTerminalNode.doLeftTupleInsert(wm, rtn, agendaItem.getRuleExecutor(), agenda, agendaItem,
                         (RuleTerminalNodeLeftTuple) peer);
             }
             return peer;

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
@@ -92,7 +92,7 @@ public class PhreakBranchNode {
                 RuleTerminalNodeLeftTuple branchedLeftTuple = (RuleTerminalNodeLeftTuple) TupleFactory.createLeftTuple(leftTuple,
                                                                            rtn,
                                                                            leftTuple.getPropagationContext(), useLeftMemory);
-                PhreakRuleTerminalNode.doLeftTupleInsert( rtn, executor, activationsManager,
+                PhreakRuleTerminalNode.doLeftTupleInsert( reteEvaluator, rtn, executor, activationsManager,
                                                           executor.getRuleAgendaItem(), branchedLeftTuple) ;
                 breaking = conditionalExecution.isBreaking();
             }
@@ -149,7 +149,7 @@ public class PhreakBranchNode {
 
                 } else if (newRtn == oldRtn) {
                     // old and new on same branch, so update
-                    PhreakRuleTerminalNode.doLeftTupleUpdate(newRtn, executor, activationsManager, branchTuples.rtnLeftTuple) ;
+                    PhreakRuleTerminalNode.doLeftTupleUpdate(reteEvaluator, newRtn, executor, activationsManager, branchTuples.rtnLeftTuple) ;
 
                 } else {
                     // old and new on different branches, delete one and insert the other
@@ -161,7 +161,7 @@ public class PhreakBranchNode {
                     branchTuples.rtnLeftTuple = (RuleTerminalNodeLeftTuple) TupleFactory.createLeftTuple(leftTuple,
                                                                              newRtn,
                                                                              leftTuple.getPropagationContext(), true);
-                    PhreakRuleTerminalNode.doLeftTupleInsert( newRtn, executor, activationsManager,
+                    PhreakRuleTerminalNode.doLeftTupleInsert( reteEvaluator, newRtn, executor, activationsManager,
                                                               executor.getRuleAgendaItem(), branchTuples.rtnLeftTuple) ;
                 }
 
@@ -169,7 +169,7 @@ public class PhreakBranchNode {
                 // old does not exist, new exists, so insert
                 branchTuples.rtnLeftTuple = (RuleTerminalNodeLeftTuple) TupleFactory.createLeftTuple(leftTuple, newRtn,
                                                                          leftTuple.getPropagationContext(), true);
-                PhreakRuleTerminalNode.doLeftTupleInsert( newRtn, executor, activationsManager,
+                PhreakRuleTerminalNode.doLeftTupleInsert( reteEvaluator, newRtn, executor, activationsManager,
                                                           executor.getRuleAgendaItem(), branchTuples.rtnLeftTuple) ;
             }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
@@ -83,7 +83,7 @@ public class PhreakRuleTerminalNode {
         for (RuleTerminalNodeLeftTuple leftTuple = (RuleTerminalNodeLeftTuple) srcLeftTuples.getInsertFirst(); leftTuple != null; ) {
             RuleTerminalNodeLeftTuple next = (RuleTerminalNodeLeftTuple) leftTuple.getStagedNext();
 
-            doLeftTupleInsert(rtnNode, executor, activationsManager, ruleAgendaItem, leftTuple);
+            doLeftTupleInsert(reteEvaluator, rtnNode, executor, activationsManager, ruleAgendaItem, leftTuple);
 
             leftTuple.clearStaged();
             leftTuple = next;
@@ -99,10 +99,12 @@ public class PhreakRuleTerminalNode {
         return rule1.getName().equals(rule2.getName()) && rule1.getPackageName().equals(rule2.getPackageName()) &&
                ((RuleTerminalNode)rtn1).getConsequenceName().equals(((RuleTerminalNode)rtn2).getConsequenceName());
     }
-    public static void doLeftTupleInsert(TerminalNode rtnNode, RuleExecutor executor,
-                                         ActivationsManager activationsManager, RuleAgendaItem ruleAgendaItem,
+    public static void doLeftTupleInsert(ReteEvaluator reteEvaluator,
+                                         TerminalNode rtnNode, 
+                                         RuleExecutor executor,
+                                         ActivationsManager activationsManager, 
+                                         RuleAgendaItem ruleAgendaItem,
                                          RuleTerminalNodeLeftTuple leftTuple) {
-        ReteEvaluator reteEvaluator = activationsManager.getReteEvaluator();
         if ( reteEvaluator.getRuleSessionConfiguration().isDirectFiring() ) {
             executor.addActiveTuple(leftTuple);
             return;
@@ -169,16 +171,18 @@ public class PhreakRuleTerminalNode {
         for (RuleTerminalNodeLeftTuple leftTuple = (RuleTerminalNodeLeftTuple) srcLeftTuples.getUpdateFirst(); leftTuple != null; ) {
             RuleTerminalNodeLeftTuple next = (RuleTerminalNodeLeftTuple) leftTuple.getStagedNext();
 
-            doLeftTupleUpdate(rtnNode, executor, activationsManager, leftTuple);
+            doLeftTupleUpdate(reteEvaluator, rtnNode, executor, activationsManager, leftTuple);
 
             leftTuple.clearStaged();
             leftTuple = next;
         }
     }
 
-    public static void doLeftTupleUpdate(TerminalNode rtnNode, RuleExecutor executor,
-                                         ActivationsManager activationsManager, RuleTerminalNodeLeftTuple leftTuple) {
-        ReteEvaluator reteEvaluator = activationsManager.getReteEvaluator();
+    public static void doLeftTupleUpdate(ReteEvaluator reteEvaluator, 
+                                         TerminalNode rtnNode, 
+                                         RuleExecutor executor,
+                                         ActivationsManager activationsManager, 
+                                         RuleTerminalNodeLeftTuple leftTuple) {
 
         if ( reteEvaluator.getRuleSessionConfiguration().isDirectFiring() ) {
             if (!leftTuple.isQueued() ) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -418,15 +418,15 @@ public class PhreakTimerNode {
                 pmem.doLinkRule( );
 
                 if (needEvaluation && filter.accept(new Rule[]{pmem.getRule()})) {
-                    evaluateAndFireRule( pmem, activationsManager );
+                    evaluateAndFireRule( pmem, reteEvaluator, activationsManager );
                 }
             }
         }
 
-        private void evaluateAndFireRule(PathMemory pmem, ActivationsManager activationsManager) {
+        private void evaluateAndFireRule(PathMemory pmem, ReteEvaluator reteEvaluator, ActivationsManager activationsManager) {
             RuleExecutor ruleExecutor = pmem.getRuleAgendaItem().getRuleExecutor();
-            ruleExecutor.evaluateNetworkIfDirty( activationsManager );
-            ruleExecutor.fire( activationsManager );
+            ruleExecutor.evaluateNetworkIfDirty(reteEvaluator, activationsManager);
+            ruleExecutor.fire( reteEvaluator, activationsManager );
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -77,14 +77,13 @@ public class RuleExecutor {
                                        AgendaFilter filter,
                                        int fireCount,
                                        int fireLimit ) {
-        evaluateNetworkIfDirty( );
+        evaluateNetworkIfDirty(reteEvaluator);
         return fire(reteEvaluator, pmem.getActualActivationsManager( ), filter, fireCount, fireLimit);
     }
 
-    public int evaluateNetworkAndFire( ActivationsManager activationsManager, AgendaFilter filter, int fireCount, int fireLimit ) {
-        evaluateNetworkIfDirty( activationsManager );
+    public int evaluateNetworkAndFire(ReteEvaluator reteEvaluator, ActivationsManager activationsManager, AgendaFilter filter, int fireCount, int fireLimit ) {
+        evaluateNetworkIfDirty(reteEvaluator, activationsManager );
 
-        ReteEvaluator reteEvaluator = activationsManager.getReteEvaluator();
         if ( reteEvaluator.getRuleSessionConfiguration().isDirectFiring() ) {
             return doDirectFirings(activationsManager, filter, reteEvaluator);
         }
@@ -108,15 +107,11 @@ public class RuleExecutor {
         return directFirings;
     }
 
-    public void fire(ActivationsManager activationsManager) {
-        fire(activationsManager.getReteEvaluator(), activationsManager, null, 0, Integer.MAX_VALUE);
+    public void fire(ReteEvaluator reteEvaluator, ActivationsManager activationsManager) {
+        fire(reteEvaluator, activationsManager, null, 0, Integer.MAX_VALUE);
     }
 
-    public int fire(ActivationsManager activationsManager, AgendaFilter filter, int fireCount, int fireLimit) {
-        return fire(activationsManager.getReteEvaluator(), activationsManager, filter, fireCount, fireLimit);
-    }
-
-    private int fire( ReteEvaluator reteEvaluator, ActivationsManager activationsManager, AgendaFilter filter, int fireCount, int fireLimit) {
+    public int fire( ReteEvaluator reteEvaluator, ActivationsManager activationsManager, AgendaFilter filter, int fireCount, int fireLimit) {
         int localFireCount = 0;
 
         if (!activeMatches.isEmpty()) {
@@ -175,7 +170,7 @@ public class RuleExecutor {
                         break;
                     }
                     if (!reteEvaluator.isSequential()) {
-                        evaluateNetworkIfDirty( activationsManager );
+                        evaluateNetworkIfDirty(reteEvaluator, activationsManager );
                     }
                 }
             }
@@ -226,18 +221,19 @@ public class RuleExecutor {
         }
     }
 
-    public void evaluateNetwork(ActivationsManager activationsManager) {
-        activationsManager.getReteEvaluator().getRuleNetworkEvaluator().evaluateNetwork( activationsManager, this, pmem );
+    public void evaluateNetwork(ReteEvaluator reteEvaluator, ActivationsManager activationsManager) {
+        reteEvaluator.getRuleNetworkEvaluator().evaluateNetwork( activationsManager, this, pmem );
         setDirty( false );
     }
-
-    public void evaluateNetworkIfDirty() {
-        evaluateNetworkIfDirty(pmem.getActualActivationsManager( ));
+    
+    
+    public void evaluateNetworkIfDirty(ReteEvaluator reteEvaluator) {
+        evaluateNetworkIfDirty(reteEvaluator, pmem.getActualActivationsManager( ));
     }
-
-    public void evaluateNetworkIfDirty(ActivationsManager activationsManager) {
+    
+    public void evaluateNetworkIfDirty(ReteEvaluator reteEvaluator, ActivationsManager activationsManager) {
         if ( isDirty() ) {
-            evaluateNetwork(activationsManager);
+            evaluateNetwork(reteEvaluator, activationsManager);
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AlphaTerminalNode.java
@@ -46,13 +46,13 @@ public class AlphaTerminalNode extends LeftInputAdapterNode {
         NetworkNode[] sinks = getSinks();
         for (int i = 0; i < sinks.length; i++) {
             TerminalNode rtn = ( TerminalNode ) sinks[i];
-            RuleAgendaItem agendaItem = getRuleAgendaItem( reteEvaluator, activationsManager, rtn, true );
+            RuleAgendaItem agendaItem = getRuleAgendaItem( reteEvaluator, rtn, true );
             RuleTerminalNodeLeftTuple leftTuple = (RuleTerminalNodeLeftTuple) TupleFactory.createLeftTuple(rtn, factHandle, true );
             leftTuple.setPropagationContext( propagationContext );
 
             autoFocusIfNeeded(rtn, agendaItem, activationsManager);
 
-            PhreakRuleTerminalNode.doLeftTupleInsert( rtn, agendaItem.getRuleExecutor(), activationsManager, agendaItem, leftTuple );
+            PhreakRuleTerminalNode.doLeftTupleInsert( reteEvaluator, rtn, agendaItem.getRuleExecutor(), activationsManager, agendaItem, leftTuple );
         }
     }
 
@@ -66,7 +66,7 @@ public class AlphaTerminalNode extends LeftInputAdapterNode {
             ObjectTypeNodeId otnId     = rtn.getInputOtnId();
             TupleImpl        leftTuple = processDeletesFromModify(modifyPreviousTuples, context, reteEvaluator, otnId);
 
-            RuleAgendaItem agendaItem = getRuleAgendaItem( reteEvaluator, activationsManager, rtn, true );
+            RuleAgendaItem agendaItem = getRuleAgendaItem( reteEvaluator, rtn, true );
             RuleExecutor executor = agendaItem.getRuleExecutor();
 
             if ( leftTuple != null && leftTuple.getInputOtnId().equals(otnId) ) {
@@ -74,7 +74,7 @@ public class AlphaTerminalNode extends LeftInputAdapterNode {
                 leftTuple.reAdd();
                 if ( context.getModificationMask().intersects( rtn.getInferredMask()) ) {
                     leftTuple.setPropagationContext( context );
-                    PhreakRuleTerminalNode.doLeftTupleUpdate( rtn, executor, activationsManager, (RuleTerminalNodeLeftTuple) leftTuple );
+                    PhreakRuleTerminalNode.doLeftTupleUpdate( reteEvaluator, rtn, executor, activationsManager, (RuleTerminalNodeLeftTuple) leftTuple );
                     if (leftTuple.isFullMatch()) {
                         ((InternalMatch) leftTuple).setActive(true);
                     }
@@ -86,7 +86,7 @@ public class AlphaTerminalNode extends LeftInputAdapterNode {
 
                     autoFocusIfNeeded(rtn, agendaItem, activationsManager);
 
-                    PhreakRuleTerminalNode.doLeftTupleInsert( rtn, executor, activationsManager, agendaItem, (RuleTerminalNodeLeftTuple) leftTuple );
+                    PhreakRuleTerminalNode.doLeftTupleInsert( reteEvaluator, rtn, executor, activationsManager, agendaItem, (RuleTerminalNodeLeftTuple) leftTuple );
                 }
             }
         }
@@ -108,10 +108,10 @@ public class AlphaTerminalNode extends LeftInputAdapterNode {
         if (((InternalMatch)leftTuple).isMatched()) {
             leftTuple.setStagedType(Tuple.DELETE);
         }
-        PhreakRuleTerminalNode.doLeftDelete( activationsManager, getRuleAgendaItem( reteEvaluator, activationsManager, rtn, false ).getRuleExecutor(), (RuleTerminalNodeLeftTuple) leftTuple );
+        PhreakRuleTerminalNode.doLeftDelete( activationsManager, getRuleAgendaItem( reteEvaluator, rtn, false ).getRuleExecutor(), (RuleTerminalNodeLeftTuple) leftTuple );
     }
 
-    public static RuleAgendaItem getRuleAgendaItem(ReteEvaluator reteEvaluator, ActivationsManager activationsManager, TerminalNode rtn, boolean linkPmem ) {
+    public static RuleAgendaItem getRuleAgendaItem(ReteEvaluator reteEvaluator, TerminalNode rtn, boolean linkPmem ) {
         PathMemory pathMemory = reteEvaluator.getNodeMemory( rtn );
         if (linkPmem) {
             pathMemory.doLinkRule( );

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/CompositeDefaultAgenda.java
@@ -106,11 +106,6 @@ public class CompositeDefaultAgenda implements Externalizable, InternalAgenda {
     }
 
     @Override
-    public ReteEvaluator getReteEvaluator() {
-        return agendas[0].getWorkingMemory();
-    }
-
-    @Override
     public AgendaGroupsManager getAgendaGroupsManager() {
         return agendas[0].getAgendaGroupsManager();
     }

--- a/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
+++ b/drools-kiesession/src/main/java/org/drools/kiesession/agenda/DefaultAgenda.java
@@ -162,8 +162,8 @@ public class DefaultAgenda implements InternalAgenda {
 
          // for fully parallel execution the parallelism is implemented at the level of CompositeDefaultAgenda
          this.groupEvaluator = ruleBaseConf.isParallelEvaluation() && !ruleBaseConf.isParallelExecution() ?
-                 new ParallelGroupEvaluator( kieBase, this ) :
-                 new SequentialGroupEvaluator( kieBase, this );
+                 new ParallelGroupEvaluator( kieBase, workingMemory, this ) :
+                 new SequentialGroupEvaluator( kieBase, workingMemory, this );
 
         this.propagationList = createPropagationList();
     }
@@ -284,7 +284,7 @@ public class DefaultAgenda implements InternalAgenda {
         for ( RuleAgendaItem item : ((InternalAgendaGroup)systemRuleFlowGroup).getActivations() ) {
             // The lazy RuleAgendaItem must be fully evaluated, to see if there is a rule match
             RuleExecutor ruleExecutor = item.getRuleExecutor();
-            ruleExecutor.evaluateNetwork(this);
+            ruleExecutor.evaluateNetwork(workingMemory, this);
             TupleList list = ruleExecutor.getActiveMatches();
             for (RuleTerminalNodeLeftTuple lt = (RuleTerminalNodeLeftTuple) list.getFirst(); lt != null; lt = (RuleTerminalNodeLeftTuple) lt.getNext()) {
                 if ( ruleName.equals( lt.getRule().getName() ) && ( lt.checkProcessInstance( workingMemory, processInstanceId ) )) {
@@ -338,11 +338,6 @@ public class DefaultAgenda implements InternalAgenda {
         InternalAgendaGroup agendaGroup = getAgendaGroupsManager().getAgendaGroup( name );
         agendaGroup.setAutoFocusActivator( ctx );
         return getAgendaGroupsManager().setFocus( agendaGroup );
-    }
-
-    @Override
-    public ReteEvaluator getReteEvaluator() {
-        return this.workingMemory;
     }
 
     @Override
@@ -501,7 +496,7 @@ public class DefaultAgenda implements InternalAgenda {
             RuleAgendaItem item = eager.removeFirst();
             if (item.isRuleInUse()) { // this rule could have been removed by an incremental compilation
                 evaluateQueriesForRule( item );
-                item.getRuleExecutor().evaluateNetwork( this );
+                item.getRuleExecutor().evaluateNetwork(workingMemory, this);
             }
         }
     }
@@ -512,7 +507,7 @@ public class DefaultAgenda implements InternalAgenda {
             for (QueryImpl query : rule.getDependingQueries()) {
                 RuleAgendaItem queryAgendaItem = queries.remove(query);
                 if (queryAgendaItem != null) {
-                    queryAgendaItem.getRuleExecutor().evaluateNetwork(this);
+                    queryAgendaItem.getRuleExecutor().evaluateNetwork(workingMemory, this);
                 }
             }
         }

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufInputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufInputMarshaller.java
@@ -755,7 +755,7 @@ public class ProtobufInputMarshaller {
 
         public void evaluateRNEAs(final InternalWorkingMemory wm) {
             for ( RuleAgendaItem rai : rneaToFire ) {
-                rai.getRuleExecutor().evaluateNetworkIfDirty( );
+                rai.getRuleExecutor().evaluateNetworkIfDirty(wm);
             }
         }
 
@@ -769,7 +769,7 @@ public class ProtobufInputMarshaller {
         public void fireRNEAs(final InternalWorkingMemory wm) {
             for ( RuleAgendaItem rai : rneaToFire ) {
                 RuleExecutor ruleExecutor = rai.getRuleExecutor();
-                ruleExecutor.evaluateNetworkIfDirty( );
+                ruleExecutor.evaluateNetworkIfDirty(wm);
                 ruleExecutor.removeRuleAgendaItemWhenEmpty( );
             }
             rneaToFire.clear();

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufOutputMarshaller.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/ProtobufOutputMarshaller.java
@@ -239,7 +239,7 @@ public class ProtobufOutputMarshaller {
             // this must clone as re-evaluation will under underlying Collection
             for ( RuleAgendaItem activation : new ArrayList<>(wm.getAgenda().getAgendaGroupsManager().getActivations())) {
                 // evaluate it
-                activation.getRuleExecutor().evaluateNetworkIfDirty( );
+                activation.getRuleExecutor().evaluateNetworkIfDirty(wm);
                 activation.getRuleExecutor().removeRuleAgendaItemWhenEmpty( );
             }
             dirty = false;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExecutionFlowControlTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExecutionFlowControlTest.java
@@ -483,26 +483,26 @@ public class ExecutionFlowControlTest {
         agenda.getAgendaGroupsManager().setFocus( group1 );
         assertThat(group1.size()).isEqualTo(1);
         RuleAgendaItem ruleItem1 = group1.getActivations().iterator().next();
-        ruleItem1.getRuleExecutor().evaluateNetwork(wm.getAgenda());
+        ruleItem1.getRuleExecutor().evaluateNetwork(wm, wm.getAgenda());
         assertThat(ruleItem1.getRuleExecutor().getActiveMatches().size()).isEqualTo(3);
 
-        ruleItem1.getRuleExecutor().fire(agenda);
+        ruleItem1.getRuleExecutor().fire(wm, agenda);
         assertThat(group1.size()).isEqualTo(1);
         assertThat(ruleItem1.getRuleExecutor().getActiveMatches().size()).isEqualTo(2);
 
         ksession.update( brieHandle, brie );
         assertThat(group1.size()).isEqualTo(1);
-        ruleItem1.getRuleExecutor().evaluateNetwork(wm.getAgenda());
+        ruleItem1.getRuleExecutor().evaluateNetwork(wm, wm.getAgenda());
         assertThat(ruleItem1.getRuleExecutor().getActiveMatches().size()).isEqualTo(2);
 
         InternalAgendaGroup group2 = agenda.getAgendaGroupsManager().getAgendaGroup( "group2" );
         agenda.getAgendaGroupsManager().setFocus( group2);
         assertThat(group2.size()).isEqualTo(1);
         RuleAgendaItem ruleItem2 = group2.getActivations().iterator().next();
-        ruleItem2.getRuleExecutor().evaluateNetwork(wm.getAgenda());
+        ruleItem2.getRuleExecutor().evaluateNetwork(wm, wm.getAgenda());
         assertThat(ruleItem2.getRuleExecutor().getActiveMatches().size()).isEqualTo(3);
 
-        ruleItem2.getRuleExecutor().fire(agenda);
+        ruleItem2.getRuleExecutor().fire(wm, agenda);
         assertThat(group2.size()).isEqualTo(1);
         assertThat(ruleItem2.getRuleExecutor().getActiveMatches().size()).isEqualTo(2);
 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

Another relatively simple PR, moving the code into the direction of breaking the dependencies for ReteEvaluator. 

In this PR I have removed the getReteEvaluator from the ActivationsManager interface. 

This is because the implementations of the  ActivationsManager are created inside the implementations of the ReteEvaluator.

Sso it should not be their responsibility to provide ReteEvaluator to the other objects.

The objects that need a reference to the ReteEvaluator now have it directly at creation time.

  
