### PR TITLE
[kie-issues#2175] kie-benchmarks are failing due to DMN

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
@@ -60,6 +60,13 @@ public class EvaluationContextImpl implements EvaluationContext {
         this(cl, eventsManager, 32, feelDialect, dmnVersion);
     }
 
+    /**
+     * Creates a new {@code EvaluationContextImpl} instance aligned with the latest DMN specification
+     */
+    public EvaluationContextImpl(ClassLoader cl, FEELEventListenersManager eventsManager, FEELDialect feelDialect) {
+        this(cl, eventsManager, 32, feelDialect, DMNVersion.getLatest());
+    }
+
     public EvaluationContextImpl(ClassLoader cl, FEELEventListenersManager eventsManager, int size, FEELDialect feelDialect, DMNVersion dmnVersion) {
         this(cl, eventsManager, new ArrayDeque<>(), feelDialect, dmnVersion);
         // we create a rootFrame to hold all the built in functions

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
@@ -64,7 +64,7 @@ public class EvaluationContextImpl implements EvaluationContext {
      * Creates a new {@code EvaluationContextImpl} instance aligned with the latest DMN specification
      */
     public EvaluationContextImpl(ClassLoader cl, FEELEventListenersManager eventsManager, FEELDialect feelDialect) {
-        this(cl, eventsManager, 32, feelDialect, DMNVersion.getLatest());
+        this(cl, eventsManager, feelDialect, DMNVersion.getLatest());
     }
 
     public EvaluationContextImpl(ClassLoader cl, FEELEventListenersManager eventsManager, int size, FEELDialect feelDialect, DMNVersion dmnVersion) {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvaluationContextTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvaluationContextTestUtil.java
@@ -18,7 +18,6 @@
  */
 package org.kie.dmn.feel.util;
 
-import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.FEELDialect;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvaluationContextTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvaluationContextTestUtil.java
@@ -32,11 +32,11 @@ public class EvaluationContextTestUtil {
 
     public static EvaluationContext newEmptyEvaluationContext(FEELEventListenersManager mgr) {
         // Defaulting FEELDialect to FEEL
-        return new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), mgr, FEELDialect.FEEL, DMNVersion.getLatest());
+        return new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), mgr, FEELDialect.FEEL);
     }
 
     public static EvaluationContext newEmptyEvaluationContext() {
         // Defaulting FEELDialect to FEEL
-        return new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, FEELDialect.FEEL, DMNVersion.getLatest());
+        return new EvaluationContextImpl(ClassLoaderUtil.findDefaultClassLoader(), null, FEELDialect.FEEL);
     }
 }


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/2175

Added new constructor in EvaluationContextImpl to target latest DMN version.