### PR TITLE
Fix for optaplanner test failures

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
@@ -33,8 +33,8 @@ import org.drools.core.reteoo.TupleMemory;
 import org.drools.core.util.FastIterator;
 
 import static org.drools.core.phreak.PhreakJoinNode.updateChildLeftTuple;
+import static org.drools.core.phreak.PhreakNodeOperations.doUpdatesExistentialReorderLeftMemory;
 import static org.drools.core.phreak.PhreakNodeOperations.doUpdatesExistentialReorderRightMemory;
-import static org.drools.core.phreak.PhreakNodeOperations.doUpdatesReorderLeftMemory;
 import static org.drools.core.phreak.PhreakNodeOperations.findLeftTupleBlocker;
 import static org.drools.core.phreak.PhreakNodeOperations.unlinkAndDeleteChildLeftTuple;
 import static org.drools.core.phreak.PhreakNodeOperations.useLeftMemory;
@@ -75,7 +75,7 @@ public class PhreakExistsNode {
         }
 
         if (srcLeftTuples.getUpdateFirst() != null )  {
-            doUpdatesReorderLeftMemory(bm, srcLeftTuples);
+            doUpdatesExistentialReorderLeftMemory(bm, srcLeftTuples);
         }
 
         if ( srcRightTuples.getUpdateFirst() != null ) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
@@ -34,8 +34,8 @@ import org.drools.core.reteoo.TupleMemory;
 import org.drools.core.util.FastIterator;
 
 import static org.drools.core.phreak.PhreakJoinNode.updateChildLeftTuple;
+import static org.drools.core.phreak.PhreakNodeOperations.doUpdatesExistentialReorderLeftMemory;
 import static org.drools.core.phreak.PhreakNodeOperations.doUpdatesExistentialReorderRightMemory;
-import static org.drools.core.phreak.PhreakNodeOperations.doUpdatesReorderLeftMemory;
 import static org.drools.core.phreak.PhreakNodeOperations.findLeftTupleBlocker;
 import static org.drools.core.phreak.PhreakNodeOperations.unlinkAndDeleteChildLeftTuple;
 import static org.drools.core.phreak.PhreakNodeOperations.useLeftMemory;
@@ -80,7 +80,7 @@ public class PhreakNotNode {
 
         if (srcLeftTuples.getUpdateFirst() != null) {
             // must happen before right inserts, so it can find left tuples to block.
-            doUpdatesReorderLeftMemory(bm, srcLeftTuples);
+            doUpdatesExistentialReorderLeftMemory(bm, srcLeftTuples);
         }
 
         if ( srcRightTuples.getUpdateFirst() != null) {


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

This fixes the issue with optaplanner tests. 

The root cause is an error in migrating static methods from RuleNetworkEvaluator to PhreakNodeOperations.


