### PR TITLE
[incubator-kie-issues#2178] handle functionItem in ItemDefinition 

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -290,7 +290,7 @@ public class DMNCompilerImpl implements DMNCompiler {
     private void processItemDefinitions(DMNCompilerContext ctx, DMNModelImpl model, Definitions dmndefs) {
         dmndefs.normalize();
         
-        List<ItemDefinition> ordered = new ItemDefinitionDependenciesSorter(model.getNamespace()).sort(dmndefs.getItemDefinition());
+        List<ItemDefinition> ordered = new ItemDefinitionDependenciesSorter(model.getNamespace()).sort(dmndefs.getItemDefinition(), model.getDMNVersion());
         
         Set<String> names = new HashSet<>();
         for (ItemDefinition id : ordered) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesSorter.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesSorter.java
@@ -95,12 +95,10 @@ public class ItemDefinitionDependenciesSorter {
         if (typeRef.equals(qname2)) {
             return true;
         }
-        if (typeRef.getLocalPart().equals(qname2.getLocalPart())) {
+        if (typeRef.getLocalPart().endsWith(qname2.getLocalPart())) {
             if (typeRef.getNamespaceURI().isEmpty() || qname2.getNamespaceURI().isEmpty() || typeRef.getNamespaceURI().equals(qname2.getNamespaceURI())) {
                 return true;
             }
-        }
-        if (typeRef.getLocalPart().endsWith(qname2.getLocalPart())) {
             for (String nsKey : o1.recurseNsKeys()) {
                 String ns = o1.getNamespaceURI(nsKey);
                 if (ns == null || !ns.equals(qname2.getNamespaceURI())) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesSorter.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesSorter.java
@@ -79,7 +79,7 @@ public class ItemDefinitionDependenciesSorter {
         if ( o1.getTypeRef() != null ) {
             return o1.getTypeRef();
         }
-        if (dmnVersion != null && dmnVersion.getDmnVersion() > DMNVersion.V1_2.getDmnVersion()) {
+        if (dmnVersion.getDmnVersion() > DMNVersion.V1_2.getDmnVersion()) {
             FunctionItem fi = o1.getFunctionItem();
             if (fi != null && fi.getOutputTypeRef() != null) {
                 return fi.getOutputTypeRef();

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesSorter.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesSorter.java
@@ -91,12 +91,12 @@ public class ItemDefinitionDependenciesSorter {
     private static boolean recurseFind(ItemDefinition o1, QName qname2, DMNVersion dmnVersion) {
         QName typeRef = retrieveTypeRef(o1, dmnVersion);
         return (typeRef != null)
-                ? extFastEqUsingNSPrefix(o1, typeRef, qname2)
+                ? matchesQNameUsingNamespacePrefixes(o1, typeRef, qname2)
                 : o1.getItemComponent().stream()
                 .anyMatch(component -> recurseFind(component, qname2, dmnVersion));
     }
     
-    private static boolean extFastEqUsingNSPrefix(ItemDefinition o1, QName typeRef, QName qname2) {
+    private static boolean matchesQNameUsingNamespacePrefixes(ItemDefinition o1, QName typeRef, QName qname2) {
         if (typeRef.equals(qname2)) {
             return true;
         }
@@ -121,7 +121,7 @@ public class ItemDefinitionDependenciesSorter {
 
     private static boolean directFind(ItemDefinition o1, QName qname2) {
         if ( o1.getTypeRef() != null ) {
-            return extFastEqUsingNSPrefix(o1, o1.getTypeRef(), qname2);
+            return matchesQNameUsingNamespacePrefixes(o1, o1.getTypeRef(), qname2);
         }
         for ( ItemDefinition ic : o1.getItemComponent() ) {
             if ( ic.getTypeRef() == null ) {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
@@ -29,8 +29,9 @@ import javax.xml.namespace.QName;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.model.api.ItemDefinition;
-import org.kie.dmn.model.v1_1.TItemDefinition;
+import org.kie.dmn.model.v1_6.TItemDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,7 +174,7 @@ public class ItemDefinitionDependenciesGeneratedTest {
     }
 
     private List<ItemDefinition> orderingStrategy(final List<ItemDefinition> ins) {
-        return new ItemDefinitionDependenciesSorter(TEST_NS).sort(ins);
+        return new ItemDefinitionDependenciesSorter(TEST_NS).sort(ins, DMNVersion.V1_4);
     }
 
     @MethodSource("generateParameters")

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
@@ -174,7 +174,7 @@ public class ItemDefinitionDependenciesGeneratedTest {
     }
 
     private List<ItemDefinition> orderingStrategy(final List<ItemDefinition> ins) {
-        return new ItemDefinitionDependenciesSorter(TEST_NS).sort(ins, DMNVersion.V1_4);
+        return new ItemDefinitionDependenciesSorter(TEST_NS).sort(ins, DMNVersion.getLatest());
     }
 
     @MethodSource("generateParameters")

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
@@ -276,13 +276,13 @@ class ItemDefinitionDependenciesTest {
         ItemDefinition functionReturningDateList = new TItemDefinition();
         ItemDefinition dateList = new TItemDefinition();
         FunctionItem functionItem = new TFunctionItem();
-        functionItem.setOutputTypeRef(QName.valueOf("dateList"));
+        functionItem.setOutputTypeRef(new QName("dateList"));
 
         functionReturningDateList.setName("functionReturningDateList");
         functionReturningDateList.setFunctionItem(functionItem);
 
         dateList.setName("dateList");
-        dateList.setTypeRef(QName.valueOf("date"));
+        dateList.setTypeRef(new QName(TEST_NS, "date"));
 
         ItemDefinitionDependenciesSorter sorter = new ItemDefinitionDependenciesSorter(TEST_NS);
         List<ItemDefinition> input = Arrays.asList(functionReturningDateList, dateList);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
@@ -233,7 +233,7 @@ class ItemDefinitionDependenciesTest {
 
     @Test
     void testTypeRefWhenPresent() {
-        QName expected = new QName("ns", "date");
+        QName expected = new QName(TEST_NS, "date");
         ItemDefinition item = new TItemDefinition();
         item.setTypeRef(expected);
 
@@ -253,7 +253,7 @@ class ItemDefinitionDependenciesTest {
     void testRetrieveTypeRefFromFunctionItem() {
         ItemDefinition id = new TItemDefinition();
         FunctionItem fi = new TFunctionItem();
-        QName type = new QName("ns", "date");
+        QName type = new QName(TEST_NS, "date");
         fi.setOutputTypeRef(type);
         id.setFunctionItem(fi);
         QName result = retrieveTypeRef(id, TEST_NS, DMNVersion.V1_3);
@@ -264,7 +264,7 @@ class ItemDefinitionDependenciesTest {
     void retrieveTypeRef_withUnsupportedDMNVersion() {
         ItemDefinition id = new TItemDefinition();
         FunctionItem fi = new TFunctionItem();
-        QName type = new QName("ns", "date");
+        QName type = new QName(TEST_NS, "date");
         fi.setOutputTypeRef(type);
         id.setFunctionItem(fi);
         QName result = retrieveTypeRef(id, TEST_NS, DMNVersion.V1_2);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
@@ -237,7 +237,7 @@ class ItemDefinitionDependenciesTest {
         ItemDefinition item = new TItemDefinition();
         item.setTypeRef(expected);
 
-        QName result = retrieveTypeRef(item, DMNVersion.V1_2);
+        QName result = retrieveTypeRef(item, TEST_NS, DMNVersion.V1_2);
         assertThat(expected).isEqualTo(result);
     }
 
@@ -245,7 +245,7 @@ class ItemDefinitionDependenciesTest {
     void testTypeRefNull() {
         ItemDefinition item = new TItemDefinition();
 
-        QName result = retrieveTypeRef(item, DMNVersion.V1_2);
+        QName result = retrieveTypeRef(item, TEST_NS, DMNVersion.V1_2);
         assertThat(result).isNull();
     }
 
@@ -256,7 +256,7 @@ class ItemDefinitionDependenciesTest {
         QName type = new QName("ns", "date");
         fi.setOutputTypeRef(type);
         id.setFunctionItem(fi);
-        QName result = retrieveTypeRef(id, DMNVersion.V1_3);
+        QName result = retrieveTypeRef(id, TEST_NS, DMNVersion.V1_3);
         assertThat(type).isEqualTo(result);
     }
 
@@ -267,7 +267,7 @@ class ItemDefinitionDependenciesTest {
         QName type = new QName("ns", "date");
         fi.setOutputTypeRef(type);
         id.setFunctionItem(fi);
-        QName result = retrieveTypeRef(id, DMNVersion.V1_2);
+        QName result = retrieveTypeRef(id, TEST_NS, DMNVersion.V1_2);
         assertThat(result).isNull();
     }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
@@ -271,4 +271,25 @@ class ItemDefinitionDependenciesTest {
         assertThat(result).isNull();
     }
 
+    @Test
+    public void testFunctionItemTypeRefDependency() {
+        ItemDefinition functionReturningDateList = new TItemDefinition();
+        ItemDefinition dateList = new TItemDefinition();
+        FunctionItem functionItem = new TFunctionItem();
+        functionItem.setOutputTypeRef(QName.valueOf("dateList"));
+
+        functionReturningDateList.setName("functionReturningDateList");
+        functionReturningDateList.setFunctionItem(functionItem);
+
+        dateList.setName("dateList");
+        dateList.setTypeRef(QName.valueOf("date"));
+
+        ItemDefinitionDependenciesSorter sorter = new ItemDefinitionDependenciesSorter(TEST_NS);
+        List<ItemDefinition> input = Arrays.asList(functionReturningDateList, dateList);
+        List<ItemDefinition> sorted = sorter.sort(input, DMNVersion.V1_6);
+
+        assertThat(sorted).hasSize(2);
+        assertThat(sorted.indexOf(dateList)).isLessThan(sorted.indexOf(functionReturningDateList));
+    }
+
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
@@ -250,14 +250,6 @@ class ItemDefinitionDependenciesTest {
     }
 
     @Test
-    void testRetrieveTypeRef_dmnVersionNull() {
-        ItemDefinition item = new TItemDefinition();
-
-        QName result = retrieveTypeRef(item, null);
-        assertThat(result).isNull();
-    }
-
-    @Test
     void testRetrieveTypeRefFromFunctionItem() {
         ItemDefinition id = new TItemDefinition();
         FunctionItem fi = new TFunctionItem();

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesTest.java
@@ -24,8 +24,9 @@ import java.util.List;
 import javax.xml.namespace.QName;
 
 import org.junit.jupiter.api.Test;
+import org.kie.dmn.api.core.DMNVersion;
 import org.kie.dmn.model.api.ItemDefinition;
-import org.kie.dmn.model.v1_1.TItemDefinition;
+import org.kie.dmn.model.v1_6.TItemDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,7 +52,7 @@ class ItemDefinitionDependenciesTest {
     }
 
     private List<ItemDefinition> orderingStrategy(final List<ItemDefinition> ins) {
-        return new ItemDefinitionDependenciesSorter(TEST_NS).sort(ins);
+        return new ItemDefinitionDependenciesSorter(TEST_NS).sort(ins, DMNVersion.V1_2);
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELDialect.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELDialect.java
@@ -72,6 +72,7 @@ public enum FEELDialect {
         toReturn.add(org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase.URI_FEEL);
         toReturn.add(org.kie.dmn.model.v1_4.KieDMNModelInstrumentedBase.URI_FEEL);
         toReturn.add(org.kie.dmn.model.v1_5.KieDMNModelInstrumentedBase.URI_FEEL);
+        toReturn.add(org.kie.dmn.model.v1_6.KieDMNModelInstrumentedBase.URI_FEEL);
         return toReturn;
     }
 }


### PR DESCRIPTION
Closes : https://github.com/apache/incubator-kie-issues/issues/2178
This PR aims to ensure that the type reference for functionItem is correctly retrieved and processed.

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
