### PR TITLE
[incubator-kie-drools-6539] Parser throws exception if condition has …

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/DRLExprParserTest.java
@@ -22,9 +22,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.drools.drl.ast.descr.AtomicExprDescr;
+import org.drools.drl.ast.descr.BaseDescr;
 import org.drools.drl.ast.descr.BindingDescr;
 import org.drools.drl.ast.descr.ConnectiveType;
 import org.drools.drl.ast.descr.ConstraintConnectiveDescr;
+import org.drools.drl.ast.descr.ExprConstraintDescr;
 import org.drools.drl.ast.descr.RelationalExprDescr;
 import org.drools.drl.parser.DrlExprParser;
 import org.drools.drl.parser.DrlParser;
@@ -619,5 +621,14 @@ class DRLExprParserTest {
 
         AtomicExprDescr right = (AtomicExprDescr) rel.getRight();
         assertThat(right.getExpression()).isEqualTo("$list");
+    }
+
+    @Test
+    void octalDigit() {
+        final String source = "age == 013";
+        ConstraintConnectiveDescr result = parser.parse(source);
+        RelationalExprDescr relationalExprDescr = (RelationalExprDescr) result.getDescrs().get(0);
+        AtomicExprDescr right = (AtomicExprDescr) relationalExprDescr.getRight();
+        assertThat(right.getExpression()).isEqualTo("013");
     }
 }

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Expressions.g4
@@ -113,6 +113,7 @@ literal
     :	STRING_LITERAL  {	helper.emit($STRING_LITERAL, DroolsEditorType.STRING_CONST);	}
     |	DRL_STRING_LITERAL  {	helper.emit($DRL_STRING_LITERAL, DroolsEditorType.STRING_CONST);	}
     |	DECIMAL_LITERAL {	helper.emit($DECIMAL_LITERAL, DroolsEditorType.NUMERIC_CONST);	}
+    |   OCT_LITERAL     {	helper.emit($OCT_LITERAL, DroolsEditorType.NUMERIC_CONST);	}
     |	DRL_BIG_INTEGER_LITERAL {	helper.emit($DRL_BIG_INTEGER_LITERAL, DroolsEditorType.NUMERIC_CONST);	}
     |	HEX_LITERAL     {	helper.emit($HEX_LITERAL, DroolsEditorType.NUMERIC_CONST);	}
     |	FLOAT_LITERAL   {	helper.emit($FLOAT_LITERAL, DroolsEditorType.NUMERIC_CONST);	}

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CompilerTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CompilerTest.java
@@ -43,7 +43,9 @@ import org.drools.model.codegen.execmodel.domain.Result;
 import org.drools.model.codegen.execmodel.domain.StockTick;
 import org.drools.model.codegen.execmodel.domain.Toy;
 import org.drools.model.codegen.execmodel.domain.Woman;
+import org.drools.modelcompiler.util.EvaluationUtil;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -3336,5 +3338,23 @@ public class CompilerTest extends BaseModelTest {
         public int someMethod() {
             return 4;
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void octalDigit(RUN_TYPE runType) {
+        final String str =
+                "package org.example\n" +
+                        "import " + Person.class.getCanonicalName() + ";" +
+                        "rule r1 when\n" +
+                        "    Person( age == 013 )\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieSession ksession = getKieSession(runType, str);
+
+        ksession.insert(new Person("John", 11)); // Octal 013 = Decimal 11
+        int fired = ksession.fireAllRules();
+        assertThat(fired).isEqualTo(1);
     }
 }


### PR DESCRIPTION
…number with leading zeros (DRL10)

- https://github.com/apache/incubator-kie-drools/issues/6539

Fixed by including `OCT_LITERAL` as `literal`.

Note that leading zero number is octal digits. For example `013` in octal is `11` in decimal, which behavior is the same as DRL6 and plain Java.
