### PR TITLE
[kie-issues#2217]Update Netty version from 4.1.128.Final to 4.1.129.Final

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -72,7 +72,7 @@
     <version.info.picocli>4.7.5</version.info.picocli>
     <version.io.micrometer>1.14.12</version.io.micrometer>
     <version.io.quarkus>3.20.3</version.io.quarkus>
-    <version.io.netty>4.1.128.Final</version.io.netty>
+    <version.io.netty>4.1.129.Final</version.io.netty>
     <version.io.smallrye.openapi.core>4.0.12</version.io.smallrye.openapi.core>
     <version.io.smallrye.config.core>3.11.4</version.io.smallrye.config.core>
     <version.org.apache.kafka>3.9.1</version.org.apache.kafka>


### PR DESCRIPTION
Updated Netty version from 4.1.128.Final to 4.1.129.Final
Closes https://github.com/apache/incubator-kie-issues/issues/2217
RELATED PR: https://github.com/apache/incubator-kie-kogito-runtimes/pull/4170
