### PR TITLE
[incubator-kie-drools-6549] Drop unused drools soft keywords

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -1828,23 +1828,6 @@ class MiscDRLParserTest {
     }
 
     @Test
-    void attributeRefract() {
-        final String source = "rule Test refract when Person() then end";
-
-        PackageDescr pkg = parseAndGetPackageDescr(
-                source);
-
-        RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
-
-        assertThat(rule.getName()).isEqualTo("Test");
-        Map<String, AttributeDescr> attributes = rule.getAttributes();
-        assertThat(attributes).hasSize(1);
-        AttributeDescr refract = attributes.get("refract");
-        assertThat(refract).isNotNull();
-        assertThat(refract.getValue()).isEqualTo("true");
-    }
-
-    @Test
     void enabledExpression() {
         final RuleDescr rule = parseAndGetFirstRuleDescrFromFile(
                 "rule_enabled_expression.drl");

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Expressions.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Expressions.g4
@@ -289,8 +289,6 @@ drlKeywords returns [Token token]
     | DRL_NO_LOOP
     | DRL_AUTO_FOCUS
     | DRL_LOCK_ON_ACTIVE
-    | DRL_REFRACT
-    | DRL_DIRECT
     | DRL_ACTIVATION_GROUP
     | DRL_RULEFLOW_GROUP
     | DRL_DATE_EFFECTIVE

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Lexer.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Lexer.g4
@@ -113,8 +113,6 @@ DRL_ENABLED : 'enabled';
 DRL_NO_LOOP : 'no-loop';
 DRL_AUTO_FOCUS : 'auto-focus';
 DRL_LOCK_ON_ACTIVE : 'lock-on-active';
-DRL_REFRACT : 'refract';
-DRL_DIRECT : 'direct';
 DRL_ACTIVATION_GROUP : 'activation-group';
 DRL_RULEFLOW_GROUP : 'ruleflow-group';
 DRL_DATE_EFFECTIVE : 'date-effective';

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Parser.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Parser.g4
@@ -461,7 +461,7 @@ drlAnnotation
 // attributes := (ATTRIBUTES COLON?)? [ attribute ( COMMA? attribute )* ]
 attributes : (DRL_ATTRIBUTES COLON?)? attribute ( COMMA? attribute )* ;
 attribute : name=( DRL_SALIENCE | DRL_ENABLED ) conditionalAttributeValue #expressionAttribute
-          | name=( DRL_NO_LOOP | DRL_AUTO_FOCUS | DRL_LOCK_ON_ACTIVE | DRL_REFRACT | DRL_DIRECT ) BOOL_LITERAL? #booleanAttribute
+          | name=( DRL_NO_LOOP | DRL_AUTO_FOCUS | DRL_LOCK_ON_ACTIVE ) BOOL_LITERAL? #booleanAttribute
           | name=( DRL_ACTIVATION_GROUP | DRL_RULEFLOW_GROUP | DRL_DATE_EFFECTIVE | DRL_DATE_EXPIRES | DRL_DIALECT ) DRL_STRING_LITERAL #stringAttribute
           | name=DRL_CALENDARS DRL_STRING_LITERAL ( COMMA DRL_STRING_LITERAL )* #stringListAttribute
           | name=DRL_TIMER ( DECIMAL_LITERAL | LPAREN chunk RPAREN ) #intOrChunkAttribute

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DroolsParserExceptionFactory.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/DroolsParserExceptionFactory.java
@@ -203,8 +203,6 @@ public class DroolsParserExceptionFactory {
                 return "function";
             case QUERY :
                 return "query";
-            case TEMPLATE :
-                return "template";
             case RULE :
                 return "rule";
             case RULE_ATTRIBUTE :

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/LexerHelper.java
@@ -45,9 +45,7 @@ public class LexerHelper {
                                                                       DroolsSoftKeywords.DIALECT,
                                                                       DroolsSoftKeywords.CALENDARS,
                                                                       DroolsSoftKeywords.TIMER,
-                                                                      DroolsSoftKeywords.DURATION,
-                                                                      DroolsSoftKeywords.REFRACT,
-                                                                      DroolsSoftKeywords.DIRECT);
+                                                                      DroolsSoftKeywords.DURATION);
 
     private final CharStream input;
     private int lookAheadCounter;

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/ParserHelper.java
@@ -338,11 +338,7 @@ public class ParserHelper {
                validateText( text2Validate,
                              DroolsSoftKeywords.TIMER ) ||
                validateText( text2Validate,
-                             DroolsSoftKeywords.DURATION ) ||
-               validateText( text2Validate,
-                             DroolsSoftKeywords.REFRACT ) ||
-               validateText( text2Validate,
-                             DroolsSoftKeywords.DIRECT );
+                             DroolsSoftKeywords.DURATION );
     }
 
     public void reportError(Object offendingSymbol, int line, int charPositionInLine, String message, RecognitionException ex ) {

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL5Parser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL5Parser.java
@@ -1353,9 +1353,6 @@ public class DRL5Parser extends AbstractDRLParser implements DRLParser {
                                            DroolsSoftKeywords.ACTIVE ) ) {
                 attribute = booleanAttribute( as,
                                               new String[]{DroolsSoftKeywords.LOCK, "-", DroolsSoftKeywords.ON, "-", DroolsSoftKeywords.ACTIVE} );
-            } else if ( helper.validateIdentifierKey( DroolsSoftKeywords.REFRACT ) ) {
-                attribute = booleanAttribute( as,
-                                              new String[]{ DroolsSoftKeywords.REFRACT } );
             } else if ( helper.validateIdentifierKey( DroolsSoftKeywords.AGENDA ) &&
                         helper.validateLT( 2,
                                            "-" ) &&

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6Parser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6Parser.java
@@ -1545,12 +1545,6 @@ public class DRL6Parser extends AbstractDRLParser implements DRLParser {
                             DroolsSoftKeywords.ACTIVE)) {
                 attribute = booleanAttribute(as,
                         new String[]{DroolsSoftKeywords.LOCK, "-", DroolsSoftKeywords.ON, "-", DroolsSoftKeywords.ACTIVE});
-            } else if (helper.validateIdentifierKey(DroolsSoftKeywords.REFRACT)) {
-                attribute = booleanAttribute(as,
-                        new String[]{DroolsSoftKeywords.REFRACT});
-            } else if (helper.validateIdentifierKey(DroolsSoftKeywords.DIRECT)) {
-                attribute = booleanAttribute(as,
-                        new String[]{DroolsSoftKeywords.DIRECT});
             } else if (helper.validateIdentifierKey(DroolsSoftKeywords.AGENDA) &&
                     helper.validateLT(2,
                             "-") &&

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6StrictParser.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DRL6StrictParser.java
@@ -1582,12 +1582,6 @@ public class DRL6StrictParser extends AbstractDRLParser implements DRLParser {
                             DroolsSoftKeywords.ACTIVE)) {
                 attribute = booleanAttribute(as,
                         new String[]{DroolsSoftKeywords.LOCK, "-", DroolsSoftKeywords.ON, "-", DroolsSoftKeywords.ACTIVE});
-            } else if (helper.validateIdentifierKey(DroolsSoftKeywords.REFRACT)) {
-                attribute = booleanAttribute(as,
-                        new String[]{DroolsSoftKeywords.REFRACT});
-            } else if (helper.validateIdentifierKey(DroolsSoftKeywords.DIRECT)) {
-                attribute = booleanAttribute(as,
-                        new String[]{DroolsSoftKeywords.DIRECT});
             } else if (helper.validateIdentifierKey(DroolsSoftKeywords.AGENDA) &&
                     helper.validateLT(2,
                             "-") &&

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsParaphraseTypes.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsParaphraseTypes.java
@@ -31,7 +31,6 @@ public enum DroolsParaphraseTypes {
     GLOBAL, 
     FUNCTION, 
     QUERY, 
-    TEMPLATE, 
     RULE, 
     RULE_ATTRIBUTE, 
     PATTERN, 

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsParserExceptionFactory.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsParserExceptionFactory.java
@@ -336,8 +336,6 @@ public class DroolsParserExceptionFactory {
                 return "function";
             case QUERY :
                 return "query";
-            case TEMPLATE :
-                return "template";
             case RULE :
                 return "rule";
             case RULE_ATTRIBUTE :

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSentenceType.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSentenceType.java
@@ -32,7 +32,6 @@ public enum DroolsSentenceType {
     IMPORT_STATEMENT, 
 	GLOBAL, 
 	FUNCTION, 
-	TEMPLATE, 
 	TYPE_DECLARATION, 
 	RULE, 
 	QUERY, 

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSoftKeywords.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/DroolsSoftKeywords.java
@@ -43,8 +43,6 @@ public class DroolsSoftKeywords {
     public static final String DURATION     = "duration";
     public static final String TIMER        = "timer";
     public static final String CALENDARS    = "calendars";
-    public static final String REFRACT      = "refract";
-    public static final String DIRECT       = "direct";
     public static final String PACKAGE      = "package";
     public static final String UNIT         = "unit";
     public static final String IMPORT       = "import";
@@ -54,7 +52,6 @@ public class DroolsSoftKeywords {
     public static final String ATTRIBUTES   = "attributes";
     public static final String RULE         = "rule";
     public static final String EXTEND       = "extends";
-    public static final String TEMPLATE     = "template";
     public static final String WHEN         = "when";
     public static final String THEN         = "then";
     public static final String QUERY        = "query";

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ParserHelper.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/lang/ParserHelper.java
@@ -349,11 +349,7 @@ public class ParserHelper {
                validateText( text2Validate,
                              DroolsSoftKeywords.TIMER ) ||
                validateText( text2Validate,
-                             DroolsSoftKeywords.DURATION ) ||
-               validateText( text2Validate,
-                             DroolsSoftKeywords.REFRACT ) ||
-               validateText( text2Validate,
-                             DroolsSoftKeywords.DIRECT );
+                             DroolsSoftKeywords.DURATION );
     }
 
     public void reportError( RecognitionException ex ) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/RuleParserTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/RuleParserTest.java
@@ -1751,25 +1751,6 @@ public class RuleParserTest {
     }
 
     @Test
-    public void testAttributeRefract() throws Exception {
-        final String source = "rule Test refract when Person() then end";
-
-        PackageDescr pkg = (PackageDescr) parse( "compilationUnit",
-                                                 source );
-
-        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
-        RuleDescr rule = pkg.getRules().get(0);
-
-        assertThat(rule.getName()).isEqualTo("Test");
-        Map<String, AttributeDescr> attributes = rule.getAttributes();
-        assertThat(attributes.size()).isEqualTo(1);
-        AttributeDescr refract = attributes.get( "refract" );
-        assertThat(refract).isNotNull();
-        assertThat(refract.getValue()).isEqualTo("true");
-
-    }
-
-    @Test
     public void testEnabledExpression() throws Exception {
         final RuleDescr rule = (RuleDescr) parseResource( "rule",
                                                           "rule_enabled_expression.drl" );


### PR DESCRIPTION
- Fixes https://github.com/apache/incubator-kie-drools/issues/6549

    - `refract` : Not used. There is a test case to parse `refract` as a rule attribute, but actually `refract` has no effect.
    - `direct` : Not used. (`@activationListener('direct')` is not related)
    - `template` : Not used. `drools-template` uses a word `template`, but it is not related to the `DroolsSoftKeyword.TEMPLATE`