### PR TITLE
[incubator-kie-drools-6540] Revisit DRL10 test

### DIFF
--- a/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
+++ b/drools-drl/drools-drl-parser-tests/src/test/java/org/drools/drl/parser/antlr4/MiscDRLParserTest.java
@@ -4544,6 +4544,30 @@ class MiscDRLParserTest {
     }
 
     @Test
+    void namedConsequenceThenWithSpace() {
+        final String text =
+                """
+                        rule R1
+                          when
+                            Person( $age : age > 10 )
+                            if( $age == 21 ) break [ Do2 ]
+                          then
+                            result.add("R1 Default Consequence: $age = " + $age);
+                          then[ Do2 ]
+                            result.add("R1 Do2 Consequence: $age = " + $age);
+                        end
+                        """;
+        PackageDescr packageDescr = parseAndGetPackageDescr(text);
+        RuleDescr ruleDescr = packageDescr.getRules().get(0);
+        ConditionalBranchDescr conditionalBranchDescr = (ConditionalBranchDescr) ruleDescr.getLhs().getDescrs().get(1);
+        assertThat(conditionalBranchDescr.getCondition().getContent().toString()).isEqualTo("$age == 21");
+        assertThat(conditionalBranchDescr.getConsequence().getName()).isEqualTo("Do2");
+
+        assertThat(ruleDescr.getConsequence()).asString().isEqualToIgnoringWhitespace("result.add(\"R1 Default Consequence: $age = \" + $age);");
+        assertThat(ruleDescr.getNamedConsequences().get("Do2")).asString().isEqualToIgnoringWhitespace("result.add(\"R1 Do2 Consequence: $age = \" + $age);");
+    }
+
+    @Test
     void namedConsequenceNestedIf() {
         final String text =
                 "rule R1 dialect \"mvel\" when\n" +

--- a/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Lexer.g4
+++ b/drools-drl/drools-drl-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Lexer.g4
@@ -202,7 +202,7 @@ RHS_STRING_LITERAL
     | ('\'' ( DrlEscapeSequence | ~('\\'|'\'') )* '\'') { setText( normalizeString( getText() ) ); }
     ;
 
-RHS_NAMED_CONSEQUENCE_THEN : DRL_THEN LBRACK IDENTIFIER RBRACK ;
+RHS_NAMED_CONSEQUENCE_THEN : DRL_THEN [ ]* LBRACK [ ]* IDENTIFIER [ ]* RBRACK ;
 
 RHS_CHUNK
     : ~[ "'()[\]{},;\t\r\n\u000C]+ // ;}) could be a delimitter proceding 'end'. ()[]{},; are delimiters to match RHS_STRING_LITERAL

--- a/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/Antlr4ParserStringUtils.java
+++ b/drools-drl/drools-drl-parser/src/main/java/org/drools/drl/parser/antlr4/Antlr4ParserStringUtils.java
@@ -75,14 +75,18 @@ public class Antlr4ParserStringUtils {
     }
 
     /**
-     * Extract name from "then[name]" of RHS_NAMED_CONSEQUENCE_THEN
+     * Extract name from "then[name]" or "then [ name ]" of RHS_NAMED_CONSEQUENCE_THEN
      */
     public static String extractNamedConsequenceName(String namedConsequenceThen) {
-        if (namedConsequenceThen.toLowerCase().startsWith("then[") && namedConsequenceThen.endsWith("]")) {
-            return namedConsequenceThen.substring("then[".length(), namedConsequenceThen.length() - 1);
+        // The token format is: then<optional_spaces>[<identifier>]
+        // We need to extract the identifier between [ and ]
+        int openBracket = namedConsequenceThen.indexOf('[');
+        int closeBracket = namedConsequenceThen.indexOf(']');
+
+        if (namedConsequenceThen.toLowerCase().startsWith("then") && openBracket > 0 && closeBracket > openBracket) {
+            return namedConsequenceThen.substring(openBracket + 1, closeBracket).trim();
         } else {
-            throw new DRLParserException("namedConsequenceThen has to be surrounded by 'then[', ']' : " + namedConsequenceThen);
+            throw new DRLParserException("namedConsequenceThen has to be in format 'then[name]' or 'then [ name ]' : " + namedConsequenceThen);
         }
     }
-
 }

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/RuleCodegenTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/project/RuleCodegenTest.java
@@ -36,6 +36,7 @@ import org.drools.drl.extensions.DecisionTableFactory;
 import org.drools.drl.extensions.DecisionTableProvider;
 import org.drools.io.FileSystemResource;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -130,6 +131,7 @@ public class RuleCodegenTest {
         assertRules(2, 1, generatedFiles.size() - externalizedLambda - legacyApiFiles);
     }
 
+    @DisabledIfSystemProperty(named = "drools.drl.antlr4.parser.enabled", matches = "true") // this test uses half-constraint which is not supported by DRL10
     @ParameterizedTest
     @MethodSource("org.drools.model.codegen.project.RuleCodegenTest#contextBuilders")
     public void generateCepRegexRule(DroolsModelBuildContext.Builder contextBuilder) {


### PR DESCRIPTION
- Closes https://github.com/apache/incubator-kie-drools/issues/6540

Fix 1) `NamedConsequencesTest.testConditionalBreak_defaultBreakDefault` : Fail to parse a named consequence with space (e.g. `then[ Do2 ]`)
Fix 2) `RuleCodegenTest.generateCepRegexRule` : Failed because of half-constraint which DRL10 doesn't support. Applying `@DisabledIfSystemProperty` is fine.

Confirmed that tests pass with `-DenableNewParser` in https://github.com/apache/incubator-kie-drools/pull/6564