### PR TITLE
[incubator-kie-drools-6573] Disable generation of REST endpoints for …

### DIFF
--- a/drools-model/drools-codegen-common/pom.xml
+++ b/drools-model/drools-codegen-common/pom.xml
@@ -63,6 +63,11 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <scope>test</scope>

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/QuarkusDroolsModelBuildContext.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/QuarkusDroolsModelBuildContext.java
@@ -42,7 +42,8 @@ public class QuarkusDroolsModelBuildContext extends AbstractDroolsModelBuildCont
 
     @Override
     public boolean hasRest() {
-        return hasRest;
+        return hasRest &&
+                "true".equalsIgnoreCase(getApplicationProperty(KOGITO_GENERATE_REST).orElse("true"));
     }
 
     @Override

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/SpringBootDroolsModelBuildContext.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/SpringBootDroolsModelBuildContext.java
@@ -42,7 +42,8 @@ public class SpringBootDroolsModelBuildContext extends AbstractDroolsModelBuildC
 
     @Override
     public boolean hasRest() {
-        return hasRest;
+        return hasRest &&
+                "true".equalsIgnoreCase(getApplicationProperty(KOGITO_GENERATE_REST).orElse("true"));
     }
 
     @Override

--- a/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/context/DroolsModelBuildContextTest.java
+++ b/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/context/DroolsModelBuildContextTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.codegen.common.context;
+
+import java.util.Properties;
+
+import org.drools.codegen.common.DroolsModelBuildContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DroolsModelBuildContextTest {
+
+    @Test
+    void quarkusHasRestDefaultTrue() {
+        DroolsModelBuildContext context = QuarkusDroolsModelBuildContext.builder()
+                .withClassAvailabilityResolver(className -> true)
+                .build();
+        assertThat(context.hasRest()).isTrue();
+    }
+
+    @Test
+    void quarkusHasRestExplicitTrue() {
+        Properties props = new Properties();
+        props.setProperty(DroolsModelBuildContext.KOGITO_GENERATE_REST, "true");
+        DroolsModelBuildContext context = QuarkusDroolsModelBuildContext.builder()
+                .withClassAvailabilityResolver(className -> true)
+                .withApplicationProperties(props)
+                .build();
+        assertThat(context.hasRest()).isTrue();
+    }
+
+    @Test
+    void quarkusHasRestDisabledByProperty() {
+        Properties props = new Properties();
+        props.setProperty(DroolsModelBuildContext.KOGITO_GENERATE_REST, "false");
+        DroolsModelBuildContext context = QuarkusDroolsModelBuildContext.builder()
+                .withClassAvailabilityResolver(className -> true)
+                .withApplicationProperties(props)
+                .build();
+        assertThat(context.hasRest()).isFalse();
+    }
+
+    @Test
+    void quarkusHasRestClassNotAvailable() {
+        DroolsModelBuildContext context = QuarkusDroolsModelBuildContext.builder()
+                .withClassAvailabilityResolver(className -> false)
+                .build();
+        assertThat(context.hasRest()).isFalse();
+    }
+
+    @Test
+    void springBootHasRestDefaultTrue() {
+        DroolsModelBuildContext context = SpringBootDroolsModelBuildContext.builder()
+                .withClassAvailabilityResolver(className -> true)
+                .build();
+        assertThat(context.hasRest()).isTrue();
+    }
+
+    @Test
+    void springBootHasRestExplicitTrue() {
+        Properties props = new Properties();
+        props.setProperty(DroolsModelBuildContext.KOGITO_GENERATE_REST, "true");
+        DroolsModelBuildContext context = SpringBootDroolsModelBuildContext.builder()
+                .withClassAvailabilityResolver(className -> true)
+                .withApplicationProperties(props)
+                .build();
+        assertThat(context.hasRest()).isTrue();
+    }
+
+    @Test
+    void springBootHasRestDisabledByProperty() {
+        Properties props = new Properties();
+        props.setProperty(DroolsModelBuildContext.KOGITO_GENERATE_REST, "false");
+        DroolsModelBuildContext context = SpringBootDroolsModelBuildContext.builder()
+                .withClassAvailabilityResolver(className -> true)
+                .withApplicationProperties(props)
+                .build();
+        assertThat(context.hasRest()).isFalse();
+    }
+
+    @Test
+    void springBootHasRestClassNotAvailable() {
+        DroolsModelBuildContext context = SpringBootDroolsModelBuildContext.builder()
+                .withClassAvailabilityResolver(className -> false)
+                .build();
+        assertThat(context.hasRest()).isFalse();
+    }
+}

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/pom.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.drools</groupId>
+    <artifactId>drools-quarkus-extension</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+
+  <name>Drools :: Quarkus Extension :: Integration Test :: Ruleunits :: No REST</name>
+  <artifactId>drools-quarkus-ruleunit-integration-test-norest</artifactId>
+
+  <properties>
+    <java.module.name>org.drools.quarkus.ruleunit.integrationtest.norest</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-quarkus-ruleunits</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-xml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-xml-impl</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- this is used implicitly by quarkus tests so let's make Maven aware of it -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-quarkus-ruleunits-deployment</artifactId>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${version.io.quarkus}</version>
+          <configuration>
+            <noDeps>true</noDeps>
+            <skip>${skipTests}</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <useModulePath>false</useModulePath>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/*Test.java</exclude>
+            <exclude>**/Native*</exclude>
+          </excludes>
+          <argLine>-Xmx2048m -Xmx4g</argLine>
+          <systemPropertyVariables>
+            <maven.repo.local>${session.request.localRepositoryPath.path}</maven.repo.local>
+            <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>ban-blacklisted-dependencies</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <fail>false</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/src/main/resources/application.properties
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/src/main/resources/application.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+kogito.generate.rest=false

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/src/main/resources/org/drools/quarkus/ruleunit/test/AlertingService.drl
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/src/main/resources/org/drools/quarkus/ruleunit/test/AlertingService.drl
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.drools.quarkus.ruleunit.test;
+unit AlertingService;
+
+import org.drools.ruleunits.api.DataStream;
+import org.drools.ruleunits.api.RuleUnitData
+
+
+declare Event
+   type:  String
+   value: int
+end
+
+declare Alert
+  severity: String
+  message:  String
+end
+
+declare AlertingService extends RuleUnitData
+   eventData: DataStream<Event>
+   alertData: DataStream<Alert>
+end
+
+
+rule IncomingEvent when
+   // matches when a temperature higher than 30 °C is registered (OOPath syntax)
+   $e : /eventData [ type == "temperature", value >= 30 ]
+then
+   alertData.append( new Alert( "warning", $e.toString() ) );
+end
+
+query Warnings
+   alerts: /alertData [ severity == "warning" ]
+end

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/src/test/java/org/drools/quarkus/ruleunit/test/DisableRestEndpointIT.java
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/src/test/java/org/drools/quarkus/ruleunit/test/DisableRestEndpointIT.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.quarkus.ruleunit.test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+@QuarkusIntegrationTest
+public class DisableRestEndpointIT {
+
+    @Test
+    public void testWarningsEndpointNotGenerated() {
+        String payload = "{ \"eventData\": [{ \"type\": \"temperature\", \"value\" : 40 }] }";
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(payload)
+                .when()
+                .post("/warnings/first")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/drools-quarkus-extension/pom.xml
+++ b/drools-quarkus-extension/pom.xml
@@ -46,6 +46,7 @@
     <module>drools-quarkus-integration-test-hotreload</module>
     <module>drools-quarkus-integration-test-multimodule</module>
     <module>drools-quarkus-ruleunit-integration-test</module>
+    <module>drools-quarkus-ruleunit-integration-test-norest</module>
     <module>drools-quarkus-quickstart-test</module>
     <module>drools-quarkus-examples</module>
   </modules>


### PR DESCRIPTION
- https://github.com/apache/incubator-kie-drools/issues/6573

`String KOGITO_GENERATE_REST = "kogito.generate.rest";` (default: true) exists in `DroolsModelBuildContext` and setting to `false` works with kogito use cases. However, it doesn't work with drools+quarkus use case. 