### PR TITLE
Apache 10.2.0 release: Cleaning up code used for testing pipelines

### DIFF
--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -39,9 +39,6 @@ git:
   - name: 10.1.x
     seed:
       branch: seed-drools-10.1.x
-  - name: 2.2.x
-    seed:
-      branch: seed-drools-2.2.x
 seed:
   config_file:
     git:


### PR DESCRIPTION
In preparation for the 10.2.0 release, I created the 2.2.x branch to run tests on the CI. With the release to soon come, these are no longer needed.