### PR TITLE
Fixing error in rule execution of WaltzDbBenchmark

### DIFF
--- a/drools-examples/src/main/java/org/drools/benchmark/waltzdb/WaltzDbBenchmark.java
+++ b/drools-examples/src/main/java/org/drools/benchmark/waltzdb/WaltzDbBenchmark.java
@@ -117,12 +117,12 @@ public class WaltzDbBenchmark {
             while ( line != null ) {
                 Matcher m = pat.matcher( line );
                 if ( m.matches() ) {
-                    Label l = new Label( m.group( 1 ),
-                                         m.group( 2 ),
-                                         m.group( 3 ),
-                                         m.group( 4 ),
-                                         m.group( 5 ),
-                                         m.group( 6 ) );
+                    Label l = new Label(m.group( 3 ),
+                                        m.group( 1 ),
+                                        m.group( 2 ),
+                                        m.group( 4 ),
+                                        m.group( 5 ),
+                                        m.group( 6 ) );
                     result.add( l );
                 }
                 line = reader.readLine();

--- a/drools-examples/src/main/resources/org/drools/benchmark/waltzdb/waltzdb.drl
+++ b/drools-examples/src/main/resources/org/drools/benchmark/waltzdb/waltzdb.drl
@@ -189,7 +189,7 @@ end
 rule "initial_boundary_junction_arrow"
     when
         $stage : Stage( value == Stage.FIND_INITIAL_BOUNDARY )
-        $junction : Junction( type == "3j", name == "arrow", $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3 )
+        $junction : Junction( type == "3j", $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3 )
         $edge1 : Edge( p1 == $basePoint, p2 == $p1 )
         $edge2 : Edge( p1 == $basePoint, p2 == $p2 )
         $edge3 : Edge( p1 == $basePoint, p2 == $p3 ) //@FIXME, is this correct? I changed edge2 to edge3
@@ -253,7 +253,7 @@ end
 rule "second_boundary_junction_arrow"
     when
         $stage : Stage( value == Stage.FIND_SECOND_BOUDARY )
-        $junction : Junction( type == "3j", name == "arrow", $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3 )
+        $junction : Junction( type == "3j", $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3 )
         Edge( p1 == $basePoint, p2 == $p1 )
         Edge( p1 == $basePoint, p2 == $p2 )
         Edge( p1 == $basePoint, p2 == $p3 )
@@ -307,8 +307,8 @@ end
 rule "visit_3j_0"
     when
         Stage( value == Stage.VISITING_3J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
-        Label(name == $name, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
+        Label(type == $type, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
         EdgeLabel( p1 == $p1, p2 == $basePoint, labelName == $n1 )
         EdgeLabel( p1 == $p2, p2 == $basePoint, labelName == $n2 )
         EdgeLabel( p1 == $p3, p2 == $basePoint, labelName == $n3 )
@@ -344,8 +344,8 @@ end
 rule "visit_3j_1"
     when
         Stage( value == Stage.VISITING_3J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
-        Label( name == $name, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
+        Label( type == $type, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
         not ( EdgeLabel( p1 == $p1, p2 == $basePoint ) )
         EdgeLabel( p1 == $p2, p2 == $basePoint, labelName == $n2 )
         EdgeLabel( p1 == $p3, p2 == $basePoint, labelName == $n3 )
@@ -381,8 +381,8 @@ end
 rule "visit_3j_2"
     when
         Stage( value == Stage.VISITING_3J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
-        Label( name == $name, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
+        Label( type == $type, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
         EdgeLabel( p1 == $p1, p2 == $basePoint, labelName == $n1 )
         not ( EdgeLabel( p1 == $p2, p2 == $basePoint ) )
         EdgeLabel( p1 == $p3, p2 == $basePoint, labelName == $n3 )
@@ -418,8 +418,8 @@ end
 rule "visit_3j_3"
     when
         Stage( value == Stage.VISITING_3J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
-        Label( name == $name, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
+        Label( type == $type, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
         not ( EdgeLabel( p1 == $p1, p2 == $basePoint ) )
         not ( EdgeLabel( p1 == $p2, p2 == $basePoint ) )
         EdgeLabel( p1 == $p3, p2 == $basePoint, labelName == $n3 )
@@ -455,8 +455,8 @@ end
 rule "visit_3j_4"
     when
         Stage( value == Stage.VISITING_3J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
-        Label( name == $name, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
+        Label( type == $type, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
         EdgeLabel( p1 == $p1, p2 == $basePoint, labelName == $n1 )
         EdgeLabel( p1 == $p2, p2 == $basePoint, labelName == $n2 )
         not ( EdgeLabel( p1 == $p3, p2 == $basePoint) )
@@ -492,8 +492,8 @@ end
 rule "visit_3j_5"
     when
         Stage( value == Stage.VISITING_3J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
-        Label(name == $name, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
+        Label(type == $type, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
         not ( EdgeLabel( p1 == $p1, p2 == $basePoint ) )
         EdgeLabel( p1 == $p2, p2 == $basePoint, labelName == $n2 )
         not ( EdgeLabel( p1 == $p3, p2 == $basePoint ) )
@@ -529,8 +529,8 @@ end
 rule "visit_3j_6"
     when
         Stage( value == Stage.VISITING_3J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
-        Label( name == $name, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
+        Label( type == $type, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
         EdgeLabel( p1 == $p1, p2 == $basePoint, labelName == $n1 )
         not ( EdgeLabel( p1 == $p2, p2 == $basePoint ) )
         not ( EdgeLabel( p1 == $p3, p2 == $basePoint ) )
@@ -566,8 +566,8 @@ end
 rule "visit_3j_7"
     when
         Stage( value == Stage.VISITING_3J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
-        Label( name == $name, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, $p3 : p3, visited == "now" )
+        Label( type == $type, $id : id, $n1 : n1, $n2 : n2, $n3 : n3 )
         not ( EdgeLabel( p1 == $p1, p2 == $basePoint ) )
         not ( EdgeLabel( p1 == $p2, p2 == $basePoint ) )
         not ( EdgeLabel( p1 == $p3, p2 == $basePoint ) )
@@ -621,8 +621,8 @@ end
 rule "visit_2j_0"
     when
         Stage( value == Stage.VISITING_2J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, visited == "now" )
-        Label(name == $name, $id : id, $n1 : n1, $n2 : n2 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, visited == "now" )
+        Label(type == $type, $id : id, $n1 : n1, $n2 : n2 )
         EdgeLabel( p1 == $p1, p2 == $basePoint, labelName == $n1 )
         EdgeLabel( p1 == $p2, p2 == $basePoint, labelName == $n2 )
         not ( EdgeLabel( p1 == $basePoint, labelId == $id ) )
@@ -652,8 +652,8 @@ end
 rule "visit_2j_1"
     when
         Stage( value == Stage.VISITING_2J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, visited == "now" )
-        Label( name == $name, $id : id, $n1 : n1, $n2 : n2 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, visited == "now" )
+        Label( type == $type, $id : id, $n1 : n1, $n2 : n2 )
         not ( EdgeLabel( p1 == $p1, p2 == $basePoint ) )
         EdgeLabel( p1 == $p2, p2 == $basePoint, labelName == $n2 )
         not ( EdgeLabel( p1 == $basePoint, labelId == $id) )
@@ -683,8 +683,8 @@ end
 rule "visit_2j_2"
     when
         Stage( value == Stage.VISITING_2J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, visited == "now" )
-        Label( name == $name, $id : id, $n1 : n1, $n2 : n2 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, visited == "now" )
+        Label( type == $type, $id : id, $n1 : n1, $n2 : n2 )
         EdgeLabel( p1 == $p1, p2 == $basePoint, labelName == $n1 )
         not ( EdgeLabel( p1 == $p2, p2 == $basePoint) )
         not ( EdgeLabel( p1 == $basePoint, labelId == $id) )
@@ -715,8 +715,8 @@ end
 rule "visit_2j_3"
     when
         Stage( value == Stage.VISITING_2J )
-        Junction( $name : name, $basePoint : basePoint, $p1 : p1, $p2 : p2, visited == "now" )
-        Label(name == $name, $id : id, $n1 : n1, $n2 : n2 )
+        Junction( $type : type, $basePoint : basePoint, $p1 : p1, $p2 : p2, visited == "now" )
+        Label(type == $type, $id : id, $n1 : n1, $n2 : n2 )
         not ( EdgeLabel( p1 == $p1, p2 == $basePoint ) )
         not ( EdgeLabel( p1 == $p2, p2 == $basePoint ) )
         not ( EdgeLabel( p1 == $basePoint, labelId == $id ) )


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

**Thank you for submitting this pull request**

**NOTE!:** Double-check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

* [link](https://www.example.com)

**Issue**: _(please edit the GitHub Issues link if it exists)_

* [link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
