### PR TITLE
[kie-issues#2110] BiLinear join node

### DIFF
--- a/drools-base/src/main/java/org/drools/base/reteoo/NodeTypeEnums.java
+++ b/drools-base/src/main/java/org/drools/base/reteoo/NodeTypeEnums.java
@@ -82,6 +82,7 @@ public class NodeTypeEnums {
     // LeftTupleSource, LefTTupleSink, LeftTupleNode, BetaNode
     public static final int BetaNode                = (320 << shift) | TupleSourceMask | TupleSinkMask | BetaMask | TupleNodeMask | MemoryFactoryMask;
     public static final int JoinNode                = (330 << shift) | TupleSourceMask | TupleSinkMask | BetaMask | TupleNodeMask | MemoryFactoryMask;
+    public static final int BiLinearJoinNode        = (335 << shift) | TupleSourceMask | TupleSinkMask | BetaMask | TupleNodeMask | MemoryFactoryMask;
     public static final int NotNode                 = (340 << shift) | TupleSourceMask | TupleSinkMask | BetaMask | TupleNodeMask | MemoryFactoryMask;
     public static final int ExistsNode              = (350 << shift) | TupleSourceMask | TupleSinkMask | BetaMask | TupleNodeMask | MemoryFactoryMask;
     public static final int AccumulateNode          = (360 << shift) | TupleSourceMask | TupleSinkMask | BetaMask | TupleNodeMask | MemoryFactoryMask;

--- a/drools-base/src/main/java/org/drools/base/rule/Pattern.java
+++ b/drools-base/src/main/java/org/drools/base/rule/Pattern.java
@@ -76,6 +76,8 @@ public class Pattern implements RuleConditionElement, AcceptsClassObjectType, Ex
 
     private BitMask positiveWatchMask;
     private BitMask negativeWatchMask;
+    private String tailHash;
+    private String currentHash;
 
     public Pattern() {
         this(0, null);
@@ -134,6 +136,8 @@ public class Pattern implements RuleConditionElement, AcceptsClassObjectType, Ex
         passive = in.readBoolean();
         hasNegativeConstraint = in.readBoolean();
         xPath = (XpathConstraint) in.readObject();
+        tailHash = (String) in.readObject();
+        currentHash = (String) in.readObject();
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
@@ -151,6 +155,8 @@ public class Pattern implements RuleConditionElement, AcceptsClassObjectType, Ex
         out.writeBoolean( passive );
         out.writeBoolean(hasNegativeConstraint);
         out.writeObject(xPath);
+        out.writeObject(tailHash);
+        out.writeObject(currentHash);
     }
     
     public void setClassObjectType(ClassObjectType objectType) {
@@ -174,6 +180,8 @@ public class Pattern implements RuleConditionElement, AcceptsClassObjectType, Ex
                                            identifier,
                                            this.declaration != null && this.declaration.isInternalFact());
         clone.listenedProperties = listenedProperties;
+        clone.tailHash = this.tailHash;
+        clone.currentHash = this.currentHash;
         if ( this.getSource() != null ) {
             clone.setSource( (PatternSource) this.getSource().clone() );
             if ( source instanceof From ) {
@@ -563,5 +571,21 @@ public class Pattern implements RuleConditionElement, AcceptsClassObjectType, Ex
 
     private static boolean isIterable(Class<?> clazz) {
         return Iterable.class.isAssignableFrom( clazz ) || clazz.isArray();
+    }
+
+    public void setTailHash(String tailHash) {
+        this.tailHash = tailHash;
+    }
+
+    public String getTailHash() {
+        return tailHash;
+    }
+
+    public void setCurrentHash(String currentHash) {
+        this.currentHash = currentHash;
+    }
+
+    public String getCurrentHash() {
+        return currentHash;
     }
 }

--- a/drools-core/src/main/java/org/drools/core/common/BiLinearBetaConstraints.java
+++ b/drools-core/src/main/java/org/drools/core/common/BiLinearBetaConstraints.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.common;
+
+import org.drools.base.base.ObjectType;
+import org.drools.base.base.ValueResolver;
+import org.drools.base.reteoo.BaseTuple;
+import org.drools.base.rule.Pattern;
+import org.drools.base.rule.constraint.BetaConstraint;
+import org.drools.core.RuleBaseConfiguration;
+import org.drools.core.reteoo.BetaMemory;
+import org.drools.core.reteoo.Tuple;
+import org.drools.core.reteoo.builder.BuildContext;
+import org.drools.util.bitmask.BitMask;
+import org.kie.api.runtime.rule.FactHandle;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * BiLinearBetaConstraints wraps standard BetaConstraints for BiLinearJoinNode.
+ * This is a thin wrapper that delegates all operations to the wrapped constraints.
+ */
+public class BiLinearBetaConstraints implements BetaConstraints<Object> {
+
+    private BetaConstraints wrappedConstraints;
+    private boolean isEmpty;
+
+    public BiLinearBetaConstraints() {
+        // Required for Externalizable deserialization
+    }
+
+    public BiLinearBetaConstraints(BetaConstraints wrappedConstraints) {
+        this.wrappedConstraints = wrappedConstraints;
+        this.isEmpty = (wrappedConstraints instanceof EmptyBetaConstraints) || wrappedConstraints.isEmpty();
+    }
+
+    @Override
+    public void init(BuildContext context, int betaNodeType) {
+        wrappedConstraints.init(context, betaNodeType);
+    }
+
+    @Override
+    public void initIndexes(int depth, int betaNodeType, RuleBaseConfiguration config) {
+        wrappedConstraints.initIndexes(depth, betaNodeType, config);
+    }
+
+    @Override
+    public Object createContext() {
+        return wrappedConstraints.createContext();
+    }
+
+    @Override
+    public boolean isIndexed() {
+        return wrappedConstraints.isIndexed();
+    }
+
+    @Override
+    public int getIndexCount() {
+        return wrappedConstraints.getIndexCount();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return isEmpty;
+    }
+
+    /**
+     * Returns true if no constraint evaluation is needed (empty constraints).
+     * This allows callers to skip expensive context setup in inner loops.
+     */
+    public boolean isUnconstrainedJoin() {
+        return isEmpty;
+    }
+
+    @Override
+    public BetaMemory createBetaMemory(RuleBaseConfiguration config, int betaNodeType) {
+        return wrappedConstraints.createBetaMemory(config, betaNodeType);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void updateFromTuple(Object context, ValueResolver valueResolver, Tuple tuple) {
+        wrappedConstraints.updateFromTuple(context, valueResolver, tuple);
+    }
+
+    @Override
+    public void updateFromFactHandle(Object context, ValueResolver valueResolver, FactHandle handle) {
+        throw new UnsupportedOperationException("BiLinear joins do not use updateFromFactHandle");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void resetTuple(Object context) {
+        wrappedConstraints.resetTuple(context);
+    }
+
+    @Override
+    public void resetFactHandle(Object context) {
+        throw new UnsupportedOperationException("BiLinear joins do not use resetFactHandle");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean isAllowedCachedLeft(Object context, FactHandle handle) {
+        if (isEmpty) {
+            return true;
+        }
+        return wrappedConstraints.isAllowedCachedLeft(context, handle);
+    }
+
+    @Override
+    public boolean isAllowedCachedRight(BaseTuple tuple, Object context) {
+        throw new UnsupportedOperationException("BiLinear joins do not use isAllowedCachedRight");
+    }
+
+    @Override
+    public BetaConstraint[] getConstraints() {
+        return wrappedConstraints.getConstraints();
+    }
+
+    @Override
+    public BetaConstraints getOriginalConstraint() {
+        return wrappedConstraints.getOriginalConstraint();
+    }
+
+    @Override
+    public <T> T cloneIfInUse() {
+        BetaConstraints clonedWrapped = (BetaConstraints) wrappedConstraints.cloneIfInUse();
+        BiLinearBetaConstraints cloned = new BiLinearBetaConstraints(clonedWrapped);
+        return (T) cloned;
+    }
+
+    @Override
+    public BitMask getListenedPropertyMask(Pattern pattern, ObjectType modifiedType, List<String> settableProperties) {
+        return wrappedConstraints.getListenedPropertyMask(pattern, modifiedType, settableProperties);
+    }
+
+    @Override
+    public boolean isLeftUpdateOptimizationAllowed() {
+        return wrappedConstraints.isLeftUpdateOptimizationAllowed();
+    }
+
+    @Override
+    public void registerEvaluationContext(BuildContext buildContext) {
+        wrappedConstraints.registerEvaluationContext(buildContext);
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeObject(wrappedConstraints);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        wrappedConstraints = (BetaConstraints) in.readObject();
+        this.isEmpty = (wrappedConstraints instanceof EmptyBetaConstraints) || wrappedConstraints.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "BiLinearBetaConstraints{" +
+                "wrapped=" + wrappedConstraints +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof BiLinearBetaConstraints)) {
+            return false;
+        }
+        BiLinearBetaConstraints other = (BiLinearBetaConstraints) obj;
+        return Objects.equals(wrappedConstraints, other.wrappedConstraints);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(wrappedConstraints);
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/common/SuperCacheFixer.java
+++ b/drools-core/src/main/java/org/drools/core/common/SuperCacheFixer.java
@@ -25,6 +25,7 @@ import org.drools.core.reteoo.AccumulateRight;
 import org.drools.core.reteoo.AlphaTerminalNode;
 import org.drools.core.reteoo.AsyncReceiveNode;
 import org.drools.core.reteoo.AsyncSendNode;
+import org.drools.core.reteoo.BiLinearJoinNode;
 import org.drools.core.reteoo.ConditionalBranchNode;
 import org.drools.core.reteoo.EvalConditionNode;
 import org.drools.core.reteoo.ExistsNode;
@@ -69,6 +70,7 @@ public class SuperCacheFixer {
             case NodeTypeEnums.NotNode: return (NotNode) s;
             case NodeTypeEnums.FromNode: return (FromNode) s;
             case NodeTypeEnums.JoinNode: return (JoinNode) s;
+            case NodeTypeEnums.BiLinearJoinNode: return (BiLinearJoinNode) s;
             case NodeTypeEnums.EvalConditionNode: return (EvalConditionNode) s;
             case NodeTypeEnums.AsyncReceiveNode: return (AsyncReceiveNode) s;
             case NodeTypeEnums.AsyncSendNode: return (AsyncSendNode) s;
@@ -107,6 +109,7 @@ public class SuperCacheFixer {
             case NodeTypeEnums.NotNode: return (NotNode) n;
             case NodeTypeEnums.FromNode: return (FromNode) n;
             case NodeTypeEnums.JoinNode: return (JoinNode) n;
+            case NodeTypeEnums.BiLinearJoinNode: return (BiLinearJoinNode) n;
             case NodeTypeEnums.EvalConditionNode: return (EvalConditionNode) n;
             case NodeTypeEnums.AsyncReceiveNode: return (AsyncReceiveNode) n;
             case NodeTypeEnums.AsyncSendNode: return (AsyncSendNode) n;
@@ -130,6 +133,7 @@ public class SuperCacheFixer {
             case NodeTypeEnums.ExistsNode: return ((ExistsNode) s).getInputOtnId();
             case NodeTypeEnums.NotNode: return ((NotNode) s).getInputOtnId();
             case NodeTypeEnums.JoinNode: return ((JoinNode) s).getInputOtnId();
+            case NodeTypeEnums.BiLinearJoinNode: return ((BiLinearJoinNode) s).getInputOtnId();
             case NodeTypeEnums.FromNode: return ((FromNode) s).getInputOtnId();
             case NodeTypeEnums.EvalConditionNode: return ((EvalConditionNode) s).getInputOtnId();
             case NodeTypeEnums.AsyncReceiveNode: return ((AsyncReceiveNode) s).getInputOtnId();
@@ -167,6 +171,7 @@ public class SuperCacheFixer {
             case NodeTypeEnums.ExistsNode: return  ((ExistsNode) s).getLeftTupleSource();
             case NodeTypeEnums.NotNode: return  ((NotNode) s).getLeftTupleSource();
             case NodeTypeEnums.JoinNode: return  ((JoinNode) s).getLeftTupleSource();
+            case NodeTypeEnums.BiLinearJoinNode: return  ((BiLinearJoinNode) s).getLeftTupleSource();
             case NodeTypeEnums.FromNode: return  ((FromNode) s).getLeftTupleSource();
             case NodeTypeEnums.EvalConditionNode: return  ((EvalConditionNode) s).getLeftTupleSource();
             case NodeTypeEnums.AsyncReceiveNode: return  ((AsyncReceiveNode) s).getLeftTupleSource();

--- a/drools-core/src/main/java/org/drools/core/phreak/BiLinearRoutingHelper.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/BiLinearRoutingHelper.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.phreak;
+
+import org.drools.core.common.Memory;
+import org.drools.core.common.TupleSets;
+import org.drools.core.reteoo.BetaMemory;
+import org.drools.core.reteoo.PathMemory;
+import org.drools.core.reteoo.SegmentMemory;
+import org.drools.core.reteoo.TupleImpl;
+import org.drools.core.reteoo.builder.BiLinearDetector;
+
+import java.util.List;
+
+public final class BiLinearRoutingHelper {
+
+    private BiLinearRoutingHelper() {
+    }
+
+    /**
+     * Check if tuples should be routed to BiLinearJoinNode's right memory instead of left memory.
+     * This happens when the source segment's tip node is a BiLinearJoinNode's second left input.
+     */
+    public static boolean shouldRouteToBiLinearRightMemory(SegmentMemory sourceSegment, SegmentMemory targetSegment) {
+        if (!BiLinearDetector.isBiLinearEnabled()) {
+            return false;
+        }
+
+        SegmentMemory.SegmentPrototype proto = targetSegment.getSegmentPrototype();
+
+        return proto.hasBiLinearNode() &&
+               sourceSegment.getTipNode().getId() == proto.getBiLinearSecondInputId();
+    }
+
+    /**
+     * Routes a single peer tuple insert to BiLinearJoinNode's right memory.
+     * Used when processing peer inserts for segments that need BiLinear right memory routing.
+     * Also links the BiLinearJoinNode in its segment when the first insert arrives.
+     */
+    public static void routePeerToBiLinearRightMemory(SegmentMemory targetSegment, TupleImpl peerTuple) {
+        BetaMemory bm = getBiLinearBetaMemory(targetSegment);
+        TupleSets rightTuples = bm.getStagedRightTuples();
+
+        // Link the BiLinearJoinNode when the first tuple arrives at its right memory.
+        // This is needed because BiLinear has two left inputs - when the second input
+        // receives tuples from peers, we need to link the node in the consumer segment.
+        if (rightTuples.isEmpty()) {
+            bm.setNodeDirtyWithoutNotify();
+            targetSegment.linkNode(bm.getNodePosMaskBit());
+        }
+
+        rightTuples.addInsert(peerTuple);
+        notifySegmentAndPaths(targetSegment);
+    }
+
+    /**
+     * Routes a single peer tuple update to BiLinearJoinNode's right memory.
+     * Used when processing peer updates for segments that need BiLinear right memory routing.
+     */
+    public static void routePeerUpdateToBiLinearRightMemory(SegmentMemory targetSegment, TupleImpl peerTuple) {
+        TupleSets rightTuples = getBiLinearRightTuples(targetSegment);
+        // Only stage if not already staged; if insert, leave as insert
+        if (peerTuple.getStagedType() == TupleImpl.NONE) {
+            rightTuples.addUpdate(peerTuple);
+            notifySegmentAndPaths(targetSegment);
+        }
+    }
+
+    /**
+     * Routes a single peer tuple delete to BiLinearJoinNode's right memory.
+     * Used when processing peer deletes for segments that need BiLinear right memory routing.
+     */
+    public static void routePeerDeleteToBiLinearRightMemory(SegmentMemory targetSegment, TupleImpl peerTuple) {
+        TupleSets rightTuples = getBiLinearRightTuples(targetSegment);
+        rightTuples.addDelete(peerTuple);
+        notifySegmentAndPaths(targetSegment);
+    }
+
+    private static BetaMemory getBiLinearBetaMemory(SegmentMemory targetSegment) {
+        SegmentMemory.SegmentPrototype proto = targetSegment.getSegmentPrototype();
+        int biLinearIndex = proto.getBiLinearNodeIndex();
+        Memory[] nodeMemories = targetSegment.getNodeMemories();
+        return (BetaMemory) nodeMemories[biLinearIndex];
+    }
+
+    private static TupleSets getBiLinearRightTuples(SegmentMemory targetSegment) {
+        BetaMemory bm = getBiLinearBetaMemory(targetSegment);
+
+        if (bm.getStagedRightTuples().isEmpty()) {
+            bm.setNodeDirtyWithoutNotify();
+        }
+
+        return bm.getStagedRightTuples();
+    }
+
+    private static void notifySegmentAndPaths(SegmentMemory targetSegment) {
+        targetSegment.notifyRuleLinkSegment();
+
+        List<PathMemory> pathMems = targetSegment.getPathMemories();
+        for (PathMemory pmem : pathMems) {
+            pmem.getOrCreateRuleAgendaItem();
+            pmem.queueRuleAgendaItem();
+        }
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/EagerPhreakBuilder.java
@@ -836,7 +836,7 @@ public class EagerPhreakBuilder implements PhreakBuilder {
         }
 
         private static void deleteFactsFromRightInput(InternalWorkingMemory wm, BetaNode bn) {
-            BaseNode source = bn.getRightInput();
+            BaseNode source = bn.getRightInput().asBaseNode();
             if (source.getType() == NodeTypeEnums.WindowNode) {
                 WindowNode.WindowMemory memory = (WindowNode.WindowMemory) wm.getNodeMemories().peekNodeMemory(source);
                 if (memory != null) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBiLinearJoinNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBiLinearJoinNode.java
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.phreak;
+
+import org.drools.core.common.ReteEvaluator;
+import org.drools.core.common.TupleSets;
+import org.drools.core.reteoo.BetaMemory;
+import org.drools.core.common.BiLinearBetaConstraints;
+import org.drools.core.reteoo.BiLinearJoinNode;
+import org.drools.core.reteoo.BiLinearRuleTerminalNodeLeftTuple;
+import org.drools.core.reteoo.LeftTupleSink;
+import org.drools.core.reteoo.TupleImpl;
+import org.drools.core.reteoo.TupleMemory;
+import org.drools.core.util.FastIterator;
+
+import static org.drools.core.phreak.PhreakJoinNode.updateChildLeftTuple;
+
+/**
+ * Phreak processor for BiLinearJoinNode that handles joining two left input networks.
+ * Unlike traditional joins that have one left and one right input, BiLinearJoinNode
+ * has two left inputs that get joined together.
+ */
+public class PhreakBiLinearJoinNode {
+
+    private final ReteEvaluator reteEvaluator;
+
+    public PhreakBiLinearJoinNode(ReteEvaluator reteEvaluator) {
+        this.reteEvaluator = reteEvaluator;
+    }
+
+    public void doNode(BiLinearJoinNode biLinearJoinNode,
+                       LeftTupleSink sink,
+                       BetaMemory bm,
+                       TupleSets srcLeftTuples,
+                       TupleSets stagedLeftTuples,
+                       TupleSets trgLeftTuples) {
+
+        // Get tuples from second left input (stored in "right" memory for BiLinear)
+        TupleSets srcRightTuples = bm.getStagedRightTuples().takeAll();
+
+        if (srcRightTuples.getDeleteFirst() != null) {
+            doRightDeletes(bm, srcRightTuples, trgLeftTuples, stagedLeftTuples);
+        }
+        if (srcLeftTuples.getDeleteFirst() != null) {
+            doLeftDeletes(bm, srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+        }
+
+        // Process updates from both inputs (must happen before inserts)
+        if (srcRightTuples.getUpdateFirst() != null) {
+            doRightUpdates(bm, srcRightTuples, trgLeftTuples, stagedLeftTuples);
+        }
+        if (srcLeftTuples.getUpdateFirst() != null) {
+            doLeftUpdates(srcLeftTuples, trgLeftTuples, stagedLeftTuples);
+        }
+
+        // Process inserts from both inputs
+        if (srcRightTuples.getInsertFirst() != null) {
+            doRightInserts(biLinearJoinNode, sink, bm, srcRightTuples, trgLeftTuples);
+        }
+        if (srcLeftTuples.getInsertFirst() != null) {
+            doLeftInserts(biLinearJoinNode, sink, bm, srcLeftTuples, trgLeftTuples);
+        }
+
+        srcRightTuples.resetAll();
+        srcLeftTuples.resetAll();
+    }
+
+    /**
+     * Process left tuple inserts for BiLinearJoinNode.
+     * This method joins tuples from the primary left input with tuples from the second left input.
+     */
+    public void doLeftInserts(BiLinearJoinNode biLinearJoinNode,
+                              LeftTupleSink sink,
+                              BetaMemory<?> bm,
+                              TupleSets srcLeftTuples,
+                              TupleSets trgLeftTuples) {
+
+        TupleMemory ltm = bm.getLeftTupleMemory();   // Memory for first left input
+        TupleMemory rtm = bm.getRightTupleMemory();  // Memory for second left input (treated as "right" for memory purposes)
+        Object context = bm.getContext();
+
+        BiLinearBetaConstraints biLinearConstraints = biLinearJoinNode.getBiLinearConstraints();
+
+        if (biLinearConstraints == null) {
+            throw new IllegalStateException("BiLinearJoinNode must have BiLinearBetaConstraints but got null");
+        }
+
+        for (TupleImpl leftTuple = srcLeftTuples.getInsertFirst(); leftTuple != null; ) {
+            TupleImpl next = leftTuple.getStagedNext();
+
+            boolean useLeftMemory = PhreakNodeOperations.useLeftMemory(biLinearJoinNode, leftTuple);
+
+            if (useLeftMemory) {
+                ltm.add(leftTuple);
+            }
+
+            if (rtm != null && rtm.size() > 0) {
+                FastIterator<TupleImpl> it = biLinearJoinNode.getSecondNetworkIterator(rtm);
+                TupleImpl firstSecondTuple = biLinearJoinNode.getFirstSecondNetworkTuple(leftTuple, rtm, it);
+
+                if (biLinearConstraints.isUnconstrainedJoin()) {
+                    for (TupleImpl secondLeftTuple = firstSecondTuple;
+                         secondLeftTuple != null;
+                         secondLeftTuple = it != null ? it.next(secondLeftTuple) : null) {
+                        insertBiLinearChildTuple(trgLeftTuples,
+                                               leftTuple,
+                                               secondLeftTuple,
+                                               sink);
+                    }
+                } else {
+                    biLinearConstraints.updateFromTuple(context, reteEvaluator, leftTuple);
+
+                    for (TupleImpl secondLeftTuple = firstSecondTuple;
+                         secondLeftTuple != null;
+                         secondLeftTuple = it != null ? it.next(secondLeftTuple) : null) {
+
+                        boolean isAllowed = biLinearConstraints.isAllowedCachedLeft(context,
+                                                                          secondLeftTuple.getFactHandle());
+
+                        if (isAllowed) {
+                            insertBiLinearChildTuple(trgLeftTuples,
+                                                   leftTuple,
+                                                   secondLeftTuple,
+                                                   sink);
+                        }
+                    }
+                }
+            }
+
+            leftTuple.clearStaged();
+            leftTuple = next;
+        }
+
+        biLinearConstraints.resetTuple(context);
+    }
+
+    public void doLeftDeletes(BetaMemory<?> bm,
+                              TupleSets srcLeftTuples,
+                              TupleSets trgLeftTuples,
+                              TupleSets stagedLeftTuples) {
+
+        TupleMemory ltm = bm.getLeftTupleMemory();
+
+        for (TupleImpl leftTuple = srcLeftTuples.getDeleteFirst(); leftTuple != null; ) {
+            TupleImpl next = leftTuple.getStagedNext();
+
+            if (leftTuple.getMemory() != null) {
+                ltm.remove(leftTuple);
+            }
+
+            if (leftTuple.getFirstChild() != null) {
+                TupleImpl childLeftTuple = leftTuple.getFirstChild();
+                while (childLeftTuple != null) {
+                    TupleImpl nextChild = childLeftTuple.getHandleNext();
+                    PhreakNodeOperations.unlinkAndDeleteChildLeftTuple(trgLeftTuples, stagedLeftTuples, childLeftTuple);
+                    childLeftTuple = nextChild;
+                }
+            }
+
+            leftTuple.clearStaged();
+            leftTuple = next;
+        }
+    }
+
+    /**
+     * Process left tuple updates for BiLinearJoinNode.
+     * Since BiLinear joins are unconstrained, no constraint re-evaluation is needed.
+     * We simply propagate the update to all existing children.
+     */
+    public void doLeftUpdates(TupleSets srcLeftTuples,
+                              TupleSets trgLeftTuples,
+                              TupleSets stagedLeftTuples) {
+
+        for (TupleImpl leftTuple = srcLeftTuples.getUpdateFirst(); leftTuple != null; ) {
+            TupleImpl next = leftTuple.getStagedNext();
+
+            // Propagate update to all children
+            for (TupleImpl child = leftTuple.getFirstChild(); child != null;
+                 child = child.getHandleNext()) {
+                child.setPropagationContext(leftTuple.getPropagationContext());
+                updateChildLeftTuple(child, stagedLeftTuples, trgLeftTuples);
+            }
+
+            leftTuple.clearStaged();
+            leftTuple = next;
+        }
+    }
+
+    /**
+     * Process second left input (right memory) inserts for BiLinearJoinNode.
+     * This method joins tuples from the second left input with tuples from the primary left input.
+     */
+    public void doRightInserts(BiLinearJoinNode biLinearJoinNode,
+                               LeftTupleSink sink,
+                               BetaMemory<?> bm,
+                               TupleSets srcRightTuples,
+                               TupleSets trgLeftTuples) {
+
+        TupleMemory ltm = bm.getLeftTupleMemory();   // Memory for first left input
+        TupleMemory rtm = bm.getRightTupleMemory();  // Memory for second left input
+        Object context = bm.getContext();
+
+        BiLinearBetaConstraints biLinearConstraints = biLinearJoinNode.getBiLinearConstraints();
+
+        if (biLinearConstraints == null) {
+            throw new IllegalStateException("BiLinearJoinNode must have BiLinearBetaConstraints but got null");
+        }
+
+        for (TupleImpl rightTuple = srcRightTuples.getInsertFirst(); rightTuple != null; ) {
+            TupleImpl next = rightTuple.getStagedNext();
+
+            boolean useRightMemory = biLinearJoinNode.isLeftTupleMemoryEnabled();
+
+            if (useRightMemory) {
+                rtm.add(rightTuple);
+            }
+
+            if (ltm != null && ltm.size() > 0) {
+                FastIterator<TupleImpl> it = biLinearJoinNode.getLeftIterator(ltm);
+                TupleImpl firstLeftTuple = biLinearJoinNode.getFirstLeftTuple(rightTuple, ltm, it);
+
+                for (TupleImpl leftTuple = firstLeftTuple;
+                     leftTuple != null;
+                     leftTuple = it.next(leftTuple)) {
+
+                    boolean useLeftMemory = PhreakNodeOperations.useLeftMemory(biLinearJoinNode, leftTuple);
+
+                    biLinearConstraints.updateFromTuple(context, reteEvaluator, leftTuple);
+                    boolean isAllowed = biLinearConstraints.isAllowedCachedLeft(context,
+                                                                      rightTuple.getFactHandle());
+
+                    if (isAllowed) {
+                        insertBiLinearChildTuple(trgLeftTuples,
+                                               leftTuple,
+                                               rightTuple,
+                                               sink);
+                    }
+                }
+            }
+
+            rightTuple.clearStaged();
+            rightTuple = next;
+        }
+
+        biLinearConstraints.resetTuple(context);
+    }
+
+    /**
+     * Process second left input (right memory) deletes for BiLinearJoinNode.
+     */
+    public void doRightDeletes(BetaMemory<?> bm,
+                               TupleSets srcRightTuples,
+                               TupleSets trgLeftTuples,
+                               TupleSets stagedLeftTuples) {
+
+        TupleMemory ltm = bm.getLeftTupleMemory();
+        TupleMemory rtm = bm.getRightTupleMemory();
+
+        for (TupleImpl rightTuple = srcRightTuples.getDeleteFirst(); rightTuple != null; ) {
+            TupleImpl next = rightTuple.getStagedNext();
+
+            if (rightTuple.getMemory() != null) {
+                rtm.remove(rightTuple);
+            }
+
+            if (ltm != null && ltm.size() > 0) {
+                FastIterator<TupleImpl> it = ltm.fastIterator();
+                for (TupleImpl leftTuple = ltm.getFirst(null); leftTuple != null; leftTuple = it.next(leftTuple)) {
+                    // Check each child of this left tuple
+                    TupleImpl childTuple = leftTuple.getFirstChild();
+                    while (childTuple != null) {
+                        TupleImpl nextChild = childTuple.getHandleNext();
+                        if (childTuple instanceof BiLinearRuleTerminalNodeLeftTuple) {
+                            BiLinearRuleTerminalNodeLeftTuple biLinearChild = (BiLinearRuleTerminalNodeLeftTuple) childTuple;
+                            if (biLinearChild.getSecondNetworkTuple() == rightTuple) {
+                                childTuple.setPropagationContext(rightTuple.getPropagationContext());
+                                PhreakNodeOperations.unlinkAndDeleteChildLeftTuple(trgLeftTuples, stagedLeftTuples, childTuple);
+                            }
+                        }
+                        childTuple = nextChild;
+                    }
+                }
+            }
+
+            rightTuple.clearStaged();
+            rightTuple = next;
+        }
+    }
+
+    /**
+     * Process second left input (right memory) updates for BiLinearJoinNode.
+     * Since BiLinear joins are unconstrained, no constraint re-evaluation is needed.
+     * We find all children that reference the updated right tuple and propagate the update.
+     */
+    public void doRightUpdates(BetaMemory<?> bm,
+                               TupleSets srcRightTuples,
+                               TupleSets trgLeftTuples,
+                               TupleSets stagedLeftTuples) {
+
+        TupleMemory ltm = bm.getLeftTupleMemory();
+
+        for (TupleImpl rightTuple = srcRightTuples.getUpdateFirst(); rightTuple != null; ) {
+            TupleImpl next = rightTuple.getStagedNext();
+
+            if (ltm != null && ltm.size() > 0) {
+                FastIterator<TupleImpl> it = ltm.fastIterator();
+                for (TupleImpl leftTuple = ltm.getFirst(null); leftTuple != null; leftTuple = it.next(leftTuple)) {
+                    // Check each child of this left tuple
+                    TupleImpl childTuple = leftTuple.getFirstChild();
+                    while (childTuple != null) {
+                        TupleImpl nextChild = childTuple.getHandleNext();
+                        if (childTuple instanceof BiLinearRuleTerminalNodeLeftTuple) {
+                            BiLinearRuleTerminalNodeLeftTuple biLinearChild = (BiLinearRuleTerminalNodeLeftTuple) childTuple;
+                            if (biLinearChild.getSecondNetworkTuple() == rightTuple) {
+                                childTuple.setPropagationContext(rightTuple.getPropagationContext());
+                                updateChildLeftTuple(childTuple, stagedLeftTuples, trgLeftTuples);
+                            }
+                        }
+                        childTuple = nextChild;
+                    }
+                }
+            }
+
+            rightTuple.clearStaged();
+            rightTuple = next;
+        }
+    }
+
+    /**
+     * Creates a new child tuple that represents the join result of two left inputs.
+     * This is the key difference from traditional joins - we're combining two left tuples.
+     *
+     * BiLinearJoinNode only supports terminal sinks (RuleTerminalNode, QueryTerminalNode).
+     * The network builder ensures BiLinearJoinNode is only created when the sink is terminal.
+     */
+    private void insertBiLinearChildTuple(TupleSets trgLeftTuples,
+                                        TupleImpl firstLeftTuple,
+                                        TupleImpl secondLeftTuple,
+                                        LeftTupleSink sink) {
+
+        TupleImpl childTuple = new BiLinearRuleTerminalNodeLeftTuple(
+            firstLeftTuple,
+            secondLeftTuple,
+            sink
+        );
+
+        childTuple.setPropagationContext(firstLeftTuple.getPropagationContext());
+
+        trgLeftTuples.addInsert(childTuple);
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNetworkNodeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNetworkNodeFactory.java
@@ -25,6 +25,8 @@ public interface PhreakNetworkNodeFactory extends KieService {
 
     PhreakJoinNode createPhreakJoinNode(ReteEvaluator reteEvaluator);
 
+    PhreakBiLinearJoinNode createPhreakBiLinearJoinNode(ReteEvaluator reteEvaluator);
+
     PhreakEvalNode createPhreakEvalNode(ReteEvaluator reteEvaluator);
 
     PhreakFromNode createPhreakFromNode(ReteEvaluator reteEvaluator);

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNetworkNodeFactoryImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNetworkNodeFactoryImpl.java
@@ -28,6 +28,11 @@ public class PhreakNetworkNodeFactoryImpl implements PhreakNetworkNodeFactory {
     }
 
     @Override
+    public PhreakBiLinearJoinNode createPhreakBiLinearJoinNode(ReteEvaluator reteEvaluator) {
+        return new PhreakBiLinearJoinNode(reteEvaluator);
+    }
+
+    @Override
     public PhreakEvalNode createPhreakEvalNode(ReteEvaluator reteEvaluator) {
         return new PhreakEvalNode(reteEvaluator);
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluatorImpl.java
@@ -42,6 +42,7 @@ import org.drools.core.reteoo.AsyncSendNode;
 import org.drools.core.reteoo.AsyncSendNode.AsyncSendMemory;
 import org.drools.core.reteoo.BetaMemory;
 import org.drools.core.reteoo.BetaNode;
+import org.drools.core.reteoo.BiLinearJoinNode;
 import org.drools.core.reteoo.ConditionalBranchNode;
 import org.drools.core.reteoo.ConditionalBranchNode.ConditionalBranchMemory;
 import org.drools.core.reteoo.EvalConditionNode;
@@ -72,12 +73,18 @@ import org.drools.core.reteoo.TupleImpl;
 import org.drools.core.reteoo.TupleToObjectNode;
 import org.drools.core.util.LinkedList;
 
+import static org.drools.core.phreak.BiLinearRoutingHelper.routePeerToBiLinearRightMemory;
+import static org.drools.core.phreak.BiLinearRoutingHelper.routePeerUpdateToBiLinearRightMemory;
+import static org.drools.core.phreak.BiLinearRoutingHelper.routePeerDeleteToBiLinearRightMemory;
+import static org.drools.core.phreak.BiLinearRoutingHelper.shouldRouteToBiLinearRightMemory;
+
 import static org.drools.core.common.TupleSetsImpl.createLeftTupleTupleSets;
 
 public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
 
     
     private final PhreakJoinNode         pJoinNode;
+    private final PhreakBiLinearJoinNode pBiLinearJoinNode;
     private final PhreakEvalNode         pEvalNode;
     private final PhreakFromNode         pFromNode;
     private final PhreakReactiveFromNode pReactiveFromNode;
@@ -103,6 +110,7 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         this.nodeMemories = nodeMemories;
         this.segmentMemorySupport = segmentMemorySupport;
         pJoinNode   = PhreakNetworkNodeFactory.Factory.get().createPhreakJoinNode(reteEvaluator);
+        pBiLinearJoinNode = PhreakNetworkNodeFactory.Factory.get().createPhreakBiLinearJoinNode(reteEvaluator);
         pEvalNode   = PhreakNetworkNodeFactory.Factory.get().createPhreakEvalNode(reteEvaluator);
         pFromNode   = PhreakNetworkNodeFactory.Factory.get().createPhreakFromNode(reteEvaluator);
         pReactiveFromNode = PhreakNetworkNodeFactory.Factory.get().createPhreakReactiveFromNode(reteEvaluator);
@@ -522,9 +530,15 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         sc.traceSwitchOnBetaNodes(bm);
 
         LeftTupleSinkNode sink = sc.getFirstLeftTupleSink();
-        switch (sc.getCurrentNode().getType()) {
+        int nodeType = sc.getCurrentNode().getType();
+        switch (nodeType) {
             case NodeTypeEnums.JoinNode: {
                 pJoinNode.doNode((JoinNode) sc.getCurrentNode(), sink, bm,
+                        sc.getSourceTuples(), sc.getStagedLeftTuples(), trgTuples);
+                break;
+            }
+            case NodeTypeEnums.BiLinearJoinNode: {
+                pBiLinearJoinNode.doNode((BiLinearJoinNode) sc.getCurrentNode(), sink, bm,
                         sc.getSourceTuples(), sc.getStagedLeftTuples(), trgTuples);
                 break;
             }
@@ -689,9 +703,9 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         if (leftTuples.isEmpty()) {
             return;
         }
-        
+
         segmentMemorySupport.initializeChildSegmentsIfNeeded(sourceSegment);
-                
+
         processPeers(sourceSegment, leftTuples);
 
         Iterator<SegmentMemory> peersIterator = sourceSegment.getPeersWithDataDrivenPathMemoriesIterator();
@@ -704,7 +718,17 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
                     // skip flushing segments that have only inserts staged and the path is not linked
                     continue;
                 }
-                forceFlushLeftTuple(dataDrivenPmem, smem, smem.getStagedLeftTuples());
+
+                // For BiLinear paths, start evaluation from segment 0 to pick up consumer segment updates.
+                // The BiLinear right memory already has peer updates staged via processPeers/BiLinearRoutingHelper.
+                if (shouldRouteToBiLinearRightMemory(sourceSegment, smem)) {
+                    SegmentMemory segment0 = dataDrivenPmem.getSegmentMemories()[0];
+                    if (segment0 != null) {
+                        forceFlushLeftTuple(dataDrivenPmem, segment0, segment0.getStagedLeftTuples().takeAll());
+                    }
+                } else {
+                    forceFlushLeftTuple(dataDrivenPmem, smem, smem.getStagedLeftTuples());
+                }
                 forceFlushWhenSubnetwork(dataDrivenPmem);
             }
         }
@@ -713,16 +737,16 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
     private static void processPeers(SegmentMemory sourceSegment, TupleSets leftTuples) {
         SegmentMemory firstSmem = sourceSegment.getFirst();
 
-        processPeerDeletes( leftTuples.getDeleteFirst(), firstSmem );
-        processPeerDeletes( leftTuples.getNormalizedDeleteFirst(), firstSmem );
-        processPeerUpdates( leftTuples, firstSmem );
-        processPeerInserts( leftTuples, firstSmem );
+        processPeerDeletes( leftTuples.getDeleteFirst(), firstSmem, sourceSegment );
+        processPeerDeletes( leftTuples.getNormalizedDeleteFirst(), firstSmem, sourceSegment );
+        processPeerUpdates( leftTuples, firstSmem, sourceSegment );
+        processPeerInserts( leftTuples, firstSmem, sourceSegment );
 
         firstSmem.getStagedLeftTuples().addAll( leftTuples );
         leftTuples.resetAll();
     }
 
-    private static void processPeerInserts(TupleSets leftTuples, SegmentMemory firstSmem) {
+    private static void processPeerInserts(TupleSets leftTuples, SegmentMemory firstSmem, SegmentMemory sourceSegment) {
         for (TupleImpl leftTuple = leftTuples.getInsertFirst(); leftTuple != null; leftTuple =  leftTuple.getStagedNext()) {
             SegmentMemory smem = firstSmem.getNext();
             if ( smem != null ) {
@@ -734,15 +758,25 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
                     for (; smem != null; smem = smem.getNext()) {
                         LeftTupleSink sink = smem.getSinkFactory();
                         peer = TupleFactory.createPeer(sink, peer); // pctx is set during peer cloning
-                        smem.getStagedLeftTuples().addInsert( peer );
+                        // Check if this peer segment needs BiLinear right memory routing
+                        if (shouldRouteToBiLinearRightMemory(sourceSegment, smem)) {
+                            routePeerToBiLinearRightMemory(smem, peer);
+                        } else {
+                            smem.getStagedLeftTuples().addInsert( peer );
+                        }
                     }
                 } else {
                     TupleImpl peer = leftTuple.getPeer();
                     // peers exist, so update them as an insert, which also handles staged clashing.
                     for (; smem != null; smem = smem.getNext()) {
                         peer.setPropagationContext( leftTuple.getPropagationContext() );
-                        // ... and update the staged LeftTupleSets according to its current staged state
-                        updateChildLeftTupleDuringInsert(peer, smem.getStagedLeftTuples(), smem.getStagedLeftTuples());
+                        // Check if this peer segment needs BiLinear right memory routing
+                        if (shouldRouteToBiLinearRightMemory(sourceSegment, smem)) {
+                            routePeerToBiLinearRightMemory(smem, peer);
+                        } else {
+                            // ... and update the staged LeftTupleSets according to its current staged state
+                            updateChildLeftTupleDuringInsert(peer, smem.getStagedLeftTuples(), smem.getStagedLeftTuples());
+                        }
                         peer = peer.getPeer();
                     }
                 }
@@ -750,15 +784,20 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         }
     }
 
-    private static void processPeerUpdates(TupleSets leftTuples, SegmentMemory firstSmem) {
+    private static void processPeerUpdates(TupleSets leftTuples, SegmentMemory firstSmem, SegmentMemory sourceSegment) {
         for (TupleImpl leftTuple = leftTuples.getUpdateFirst(); leftTuple != null; leftTuple = leftTuple.getStagedNext()) {
             SegmentMemory smem = firstSmem.getNext();
             if ( smem != null ) {
                 for ( TupleImpl peer = leftTuple.getPeer(); peer != null; peer = peer.getPeer() ) {
-                    // only stage, if not already staged, if insert, leave as insert
-                    if ( peer.getStagedType() == LeftTuple.NONE ) {
-                        peer.setPropagationContext( leftTuple.getPropagationContext() );
-                        smem.getStagedLeftTuples().addUpdate( peer );
+                    peer.setPropagationContext( leftTuple.getPropagationContext() );
+                    // Check if this peer segment needs BiLinear right memory routing
+                    if (shouldRouteToBiLinearRightMemory(sourceSegment, smem)) {
+                        routePeerUpdateToBiLinearRightMemory(smem, peer);
+                    } else {
+                        // only stage, if not already staged, if insert, leave as insert
+                        if ( peer.getStagedType() == LeftTuple.NONE ) {
+                            smem.getStagedLeftTuples().addUpdate( peer );
+                        }
                     }
 
                     smem = smem.getNext();
@@ -789,15 +828,20 @@ public class RuleNetworkEvaluatorImpl implements RuleNetworkEvaluator {
         }
     }
 
-    private static void processPeerDeletes(TupleImpl leftTuple, SegmentMemory firstSmem) {
+    private static void processPeerDeletes(TupleImpl leftTuple, SegmentMemory firstSmem, SegmentMemory sourceSegment) {
         for (; leftTuple != null; leftTuple = leftTuple.getStagedNext()) {
             SegmentMemory smem = firstSmem.getNext();
             if ( smem != null ) {
                 for ( TupleImpl peer = leftTuple.getPeer(); peer != null; peer = peer.getPeer() ) {
                     peer.setPropagationContext( leftTuple.getPropagationContext() );
-                    TupleSets stagedLeftTuples = smem.getStagedLeftTuples();
-                    // if the peer is already staged as insert or update the LeftTupleSets will reconcile it internally
-                    stagedLeftTuples.addDelete( peer );
+                    // Check if this peer segment needs BiLinear right memory routing
+                    if (shouldRouteToBiLinearRightMemory(sourceSegment, smem)) {
+                        routePeerDeleteToBiLinearRightMemory(smem, peer);
+                    } else {
+                        TupleSets stagedLeftTuples = smem.getStagedLeftTuples();
+                        // if the peer is already staged as insert or update the LeftTupleSets will reconcile it internally
+                        stagedLeftTuples.addDelete( peer );
+                    }
                     smem = smem.getNext();
                 }
             }

--- a/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
@@ -96,7 +96,7 @@ public abstract class AbstractTerminalNode extends BaseNode implements TerminalN
         initDeclaredMask(context);
         initInferredMask();
 
-        Map<String, Declaration> decls = this.subrule.getOuterDeclarations();
+        Map<String, Declaration> decls = getDeclarationsForInit();
         this.allDeclarations = decls.values().toArray( new Declaration[decls.size()] );
         initDeclarations(decls, context);
 
@@ -105,6 +105,10 @@ public abstract class AbstractTerminalNode extends BaseNode implements TerminalN
             current = current.getLeftTupleSource();
         }
         startTupleSource = current;
+    }
+
+    protected Map<String, Declaration> getDeclarationsForInit() {
+        return this.subrule.getOuterDeclarations();
     }
 
     abstract void initDeclarations(Map<String, Declaration> decls, BuildContext context);

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
@@ -63,7 +63,7 @@ public abstract class BetaNode extends LeftTupleSource
     protected static final Logger log = LoggerFactory.getLogger(BetaNode.class);
     protected static final boolean isLogTraceEnabled = log.isTraceEnabled();
 
-    protected RightInputAdapterNode rightInput;
+    protected BetaRightInput rightInput;
 
     protected BetaConstraints constraints;
 
@@ -97,7 +97,7 @@ public abstract class BetaNode extends LeftTupleSource
      */
     protected BetaNode(final int id,
              final LeftTupleSource leftInput,
-             final RightInputAdapterNode rightInput,
+             final BetaRightInput<BetaNode> rightInput,
              final BetaConstraints constraints,
              final BuildContext context) {
         super(id, context);
@@ -182,7 +182,7 @@ public abstract class BetaNode extends LeftTupleSource
         }
     }
 
-    public RightInputAdapterNode getRightInput() {
+    public BetaRightInput getRightInput() {
         return this.rightInput;
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaRightInput.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaRightInput.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo;
+
+import org.drools.base.common.RuleBasePartitionId;
+import org.drools.base.reteoo.BaseTerminalNode;
+import org.drools.core.common.*;
+import org.drools.core.reteoo.builder.BuildContext;
+import org.drools.util.bitmask.BitMask;
+import org.kie.api.definition.rule.Rule;
+
+public interface BetaRightInput<T extends BetaNode> extends ObjectSinkNode, RightTupleSink{
+    void setBetaNode(T betaNode);
+
+    void setPartitionId(BuildContext context, RuleBasePartitionId partitionId);
+
+    void initInferredMask();
+
+    boolean inputIsTupleToObjectNode();
+
+    ObjectSource getParent();
+
+    ObjectTypeNode getObjectTypeNode();
+
+    void doAttach(BuildContext context);
+
+    void networkUpdated(UpdateContext updateContext);
+
+    void initDeclaredMask(BuildContext context);
+
+    void assertObject(InternalFactHandle factHandle, PropagationContext context, ReteEvaluator reteEvaluator);
+
+    void removeAssociatedTerminal(BaseTerminalNode terminalNode);
+
+    void addAssociatedTerminal(BaseTerminalNode terminalNode);
+
+    boolean removeAssociation(Rule rule, RuleRemovalContext context);
+
+    void addAssociation(Rule rule, BuildContext context);
+
+    boolean isRightInputPassive();
+
+    BaseNode asBaseNode();
+
+    void updateSink(ObjectSink sink, PropagationContext context, InternalWorkingMemory workingMemory);
+
+    BitMask getDeclaredMask();
+
+    BitMask getInferredMask();
+
+    BitMask getNegativeMask();
+
+    /**
+     * Returns true if this is a BiLinear right input (wrapping a LeftTupleSource instead of ObjectSource).
+     * BiLinear inputs require special handling during rule removal since they don't have an ObjectSource parent.
+     */
+    default boolean isBiLinear() {
+        return false;
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/BiLinearDeclarationOffsetHelper.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BiLinearDeclarationOffsetHelper.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.drools.base.rule.Declaration;
+import org.drools.base.rule.GroupElement;
+import org.drools.base.rule.Pattern;
+import org.drools.base.rule.RuleConditionElement;
+
+/**
+ * Helper for adjusting declaration tuple indices when a rule uses BiLinearJoinNode.
+ *
+ * When a rule shares a network segment via BiLinear optimization, declarations
+ * from the second network have tupleIndex values relative to that network (0, 1, ...)
+ * rather than the combined tuple (firstNetworkSize, firstNetworkSize+1, ...).
+ *
+ * This helper creates offset-adjusted declarations for correct tuple access.
+ */
+public class BiLinearDeclarationOffsetHelper {
+
+    private final int firstNetworkSize;
+    private final Map<Pattern, Integer> patternExpectedPositions;
+
+    public BiLinearDeclarationOffsetHelper(GroupElement subrule, int firstNetworkSize) {
+        this.firstNetworkSize = firstNetworkSize;
+        this.patternExpectedPositions = new HashMap<>();
+        collectPatternsInOrder(subrule, 0);
+    }
+
+    public Map<String, Declaration> createOffsetDeclarations(Map<String, Declaration> originalDecls) {
+        Map<String, Declaration> result = new HashMap<>();
+        for (Map.Entry<String, Declaration> entry : originalDecls.entrySet()) {
+            Declaration adjusted = adjustIfNeeded(entry.getValue());
+            result.put(entry.getKey(), adjusted);
+        }
+        return result;
+    }
+
+    private Declaration adjustIfNeeded(Declaration original) {
+        Pattern pattern = original.getPattern();
+        if (pattern == null) {
+            return original;
+        }
+
+        Integer expectedPos = patternExpectedPositions.get(pattern);
+        if (expectedPos == null) {
+            return original;
+        }
+
+        // Pattern needs offset if:
+        // 1. Expected position >= firstNetworkSize (logically in second network)
+        // 2. Current tupleIndex < firstNetworkSize (shared pattern, not yet offset)
+        boolean needsOffset = expectedPos >= firstNetworkSize
+                           && pattern.getTupleIndex() < firstNetworkSize;
+        if (!needsOffset) {
+            return original;
+        }
+
+        int offset = expectedPos - pattern.getTupleIndex();
+        return createOffsetDeclaration(original, offset);
+    }
+
+    private Declaration createOffsetDeclaration(Declaration original, int offset) {
+        Pattern originalPattern = original.getPattern();
+
+        Pattern offsetPattern = new Pattern(
+            originalPattern.getPatternId(),
+            originalPattern.getTupleIndex() + offset,
+            originalPattern.getObjectIndex() + offset,
+            originalPattern.getObjectType(),
+            original.getIdentifier()
+        );
+
+        Declaration offsetDecl = new Declaration(
+            original.getIdentifier(),
+            original.getExtractor(),
+            offsetPattern
+        );
+        offsetDecl.setDeclarationClass(original.getDeclarationClass());
+
+        return offsetDecl;
+    }
+
+    private int collectPatternsInOrder(RuleConditionElement element, int currentPosition) {
+        if (element instanceof Pattern) {
+            patternExpectedPositions.put((Pattern) element, currentPosition);
+            return currentPosition + 1;
+        } else if (element instanceof GroupElement) {
+            GroupElement ge = (GroupElement) element;
+            for (RuleConditionElement child : ge.getChildren()) {
+                currentPosition = collectPatternsInOrder(child, currentPosition);
+            }
+        }
+        return currentPosition;
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/BiLinearJoinNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BiLinearJoinNode.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo;
+
+import org.drools.base.reteoo.NodeTypeEnums;
+import org.drools.core.common.BetaConstraints;
+import org.drools.core.common.BiLinearBetaConstraints;
+import org.drools.core.reteoo.builder.BiLinearLeftInputWrapper;
+import org.drools.core.reteoo.builder.BuildContext;
+import org.drools.core.util.FastIterator;
+import org.kie.api.definition.rule.Rule;
+
+public class BiLinearJoinNode extends JoinNode {
+
+    private static final long serialVersionUID = 510l;
+
+    public BiLinearJoinNode() {
+    }
+
+    public BiLinearJoinNode(final int id,
+                           final LeftTupleSource leftInput,
+                           final BetaConstraints constraints,
+                           final BuildContext context) {
+        super(id, leftInput, new BiLinearLeftInputWrapper(), createBiLinearConstraints(constraints), context);
+    }
+
+    /**
+     * Override setPartitionId to handle LeftTupleSource as second input instead of ObjectSource.
+     * BiLinear has LeftTupleSource as second input, not ObjectSource, so we need special handling.
+     */
+    @Override
+    public void setPartitionId(BuildContext context, org.drools.base.common.RuleBasePartitionId partitionId) {
+        LeftTupleSource secondInput = getSecondLeftInput();
+        if (secondInput != null) {
+            org.drools.base.common.RuleBasePartitionId parentId = secondInput.getPartitionId();
+            if (parentId != org.drools.base.common.RuleBasePartitionId.MAIN_PARTITION && !parentId.equals(partitionId)) {
+                this.partitionId = parentId;
+                rightInput.setPartitionId(context, this.partitionId);
+                context.setPartitionId(this.partitionId);
+                leftInput.setSourcePartitionId(context, this.partitionId);
+                return;
+            }
+        }
+        this.partitionId = partitionId;
+    }
+
+    private static BetaConstraints createBiLinearConstraints(BetaConstraints originalConstraints) {
+        return new BiLinearBetaConstraints(originalConstraints);
+    }
+
+    public LeftTupleSource getSecondLeftInput() {
+        return ((org.drools.core.reteoo.builder.BiLinearLeftInputWrapper) rightInput).getWrappedSecondLeftInput();
+    }
+
+    public int getFirstNetworkSize() {
+        return getLeftTupleSource().getObjectCount();
+    }
+
+    public void linkOutsideLeftInput(LeftTupleSource secondLeftInput) {
+
+        ((org.drools.core.reteoo.builder.BiLinearLeftInputWrapper) rightInput).setWrappedSecondLeftInput(secondLeftInput);
+
+        if (secondLeftInput != null && !secondLeftInput.equals(getLeftTupleSource())) {
+            secondLeftInput.addTupleSink(this);
+        }
+
+        this.setObjectCount(leftInput.getObjectCount() + secondLeftInput.getObjectCount());
+    }
+
+    public void unlinkSecondLeftInput() {
+        LeftTupleSource secondInput = getSecondLeftInput();
+        if (secondInput != null && !secondInput.equals(getLeftTupleSource())) {
+            secondInput.removeTupleSink(this);
+        }
+        ((org.drools.core.reteoo.builder.BiLinearLeftInputWrapper) rightInput).setWrappedSecondLeftInput(null);
+    }
+
+    @Override
+    public boolean doRemove(RuleRemovalContext context, ReteooBuilder builder) {
+        if (!isInUse()) {
+            // Remove from first left input (standard BetaNode behavior)
+            getLeftTupleSource().removeTupleSink(this);
+
+            // Also remove from second left input (BiLinear-specific)
+            LeftTupleSource secondInput = getSecondLeftInput();
+            if (secondInput != null && !secondInput.equals(getLeftTupleSource())) {
+                secondInput.removeTupleSink(this);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean removeAssociation(Rule rule, RuleRemovalContext context) {
+        boolean result = super.removeAssociation(rule, context);
+
+        // If this node is no longer in use after removing the association,
+        // we need to clean up the second left input reference
+        if (!isInUse()) {
+            unlinkSecondLeftInput();
+        }
+
+        return result;
+    }
+
+    public BiLinearBetaConstraints getBiLinearConstraints() {
+        return (BiLinearBetaConstraints) getRawConstraints();
+    }
+
+    @Override
+    public int getType() {
+        return NodeTypeEnums.BiLinearJoinNode;
+    }
+
+    /**
+     * Get first tuple from second network.
+     */
+    public TupleImpl getFirstSecondNetworkTuple(final TupleImpl leftTuple,
+                                               final TupleMemory memory,
+                                               final FastIterator<TupleImpl> it) {
+        return memory.getFirst(leftTuple);
+    }
+
+    public FastIterator<TupleImpl> getSecondNetworkIterator(TupleMemory memory) {
+        return memory.fastIterator();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+
+        if (!(object instanceof BiLinearJoinNode) || this.hashCode() != object.hashCode()) {
+            return false;
+        }
+
+        BiLinearJoinNode other = (BiLinearJoinNode) object;
+
+        return this.getClass() == other.getClass() &&
+               this.constraints.equals(other.constraints) &&
+               this.rightInput.equals(other.rightInput) &&
+               this.leftInput.getId() == other.leftInput.getId();
+    }
+
+    @Override
+    public String toString() {
+        return "[BiLinearJoinNode(" + this.getId() + ") - " +
+               "FirstInput: " + (getLeftTupleSource() != null ? getLeftTupleSource().getId() : "null") +
+               ", SecondInput: " + (getSecondLeftInput() != null ? getSecondLeftInput().getId() : "null") +
+                "]";
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/BiLinearRuleTerminalNodeLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BiLinearRuleTerminalNodeLeftTuple.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo;
+
+import org.drools.base.rule.Declaration;
+import org.kie.api.runtime.rule.FactHandle;
+
+/**
+ * BiLinearRuleTerminalNodeLeftTuple is a specialized terminal tuple for BiLinearJoinNode.
+ * It extends RuleTerminalNodeLeftTuple to be compatible with PhreakRuleTerminalNode,
+ * while also providing cross-network fact access like BiLinearTuple.
+ *
+ * This allows rules using BiLinearJoinNode to access variables from both input networks
+ * in their consequences.
+ */
+public class BiLinearRuleTerminalNodeLeftTuple extends RuleTerminalNodeLeftTuple {
+
+    private static final long serialVersionUID = 540l;
+
+    private final TupleImpl firstNetworkTuple;
+    private final TupleImpl secondNetworkTuple;
+
+    private final int firstSize;
+    private final int secondSize;
+    private final int size;
+
+    private transient BiLinearParentView[] parentViewCache;
+
+    public BiLinearRuleTerminalNodeLeftTuple(TupleImpl firstNetworkTuple,
+                                            TupleImpl secondNetworkTuple,
+                                            Sink sink) {
+        super();
+        setSink(sink);
+
+        this.firstNetworkTuple = firstNetworkTuple;
+        this.secondNetworkTuple = secondNetworkTuple;
+
+        this.firstSize = firstNetworkTuple != null ? firstNetworkTuple.size() : 0;
+        this.secondSize = secondNetworkTuple != null ? secondNetworkTuple.size() : 0;
+        this.size = this.firstSize + this.secondSize;
+
+        setIndex(size - 1);
+
+        // Set handle to the last fact in the chain (from second network)
+        if (secondNetworkTuple != null) {
+            setFactHandle(secondNetworkTuple.getFactHandle());
+        }
+
+        // Link to firstNetworkTuple (A+B) as left parent for delete propagation
+        // When A+B is deleted, this child will be found and deleted via the handleNext chain
+        if (firstNetworkTuple != null) {
+            setLeftParent(firstNetworkTuple);
+            // Link into left parent's child list
+            if (firstNetworkTuple.getLastChild() != null) {
+                setHandlePrevious(firstNetworkTuple.getLastChild());
+                getHandlePrevious().setHandleNext(this);
+            } else {
+                firstNetworkTuple.setFirstChild(this);
+            }
+            firstNetworkTuple.setLastChild(this);
+        }
+    }
+
+    /**
+     * Override get to provide cross-network access.
+     * Index mapping:
+     * - 0 to firstNetworkSize-1: First network facts
+     * - firstNetworkSize to firstNetworkSize+secondNetworkSize-1: Second network facts
+     */
+    @Override
+    public FactHandle get(int index) {
+        if (index < firstSize) {
+            return firstNetworkTuple.get(index);
+        }
+
+        // Second network range
+        if (index < size) {
+            int secondNetworkIndex = index - firstSize;
+            return secondNetworkTuple.get(secondNetworkIndex);
+        }
+
+        throw new IndexOutOfBoundsException("Tuple index " + index + " is out of bounds. " +
+            "First network size: " + firstSize + ", Second network size: " + secondSize);
+    }
+
+    @Override
+    public FactHandle get(Declaration declaration) {
+        return get(declaration.getTupleIndex());
+    }
+
+    @Override
+    public Object getObject(int index) {
+        FactHandle handle = get(index);
+        return handle != null ? handle.getObject() : null;
+    }
+
+    @Override
+    public Object getObject(Declaration declaration) {
+        return getObject(declaration.getTupleIndex());
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    /**
+     * Returns the second network tuple (e.g., C+D in a BiLinear join of A+B with C+D).
+     * This is used by BiLinearJoinNode.doRightDeletes to find children that reference
+     * a deleted second network tuple.
+     */
+    public TupleImpl getSecondNetworkTuple() {
+        return secondNetworkTuple;
+    }
+
+    @Override
+    public TupleImpl getParent() {
+        int currentIdx = getIndex();
+        if (currentIdx <= 0) {
+            return null;
+        }
+        return getOrCreateParentView(currentIdx - 1);
+    }
+
+    private BiLinearParentView getOrCreateParentView(int viewIndex) {
+        if (viewIndex < 0) {
+            return null;
+        }
+
+        // Lazy initialize the cache array
+        if (parentViewCache == null) {
+            parentViewCache = new BiLinearParentView[size];
+        }
+
+        BiLinearParentView cached = parentViewCache[viewIndex];
+        if (cached == null) {
+            cached = new BiLinearParentView(this, viewIndex);
+            parentViewCache[viewIndex] = cached;
+        }
+        return cached;
+    }
+
+    /**
+     * Inner class providing virtual parent view for index traversal.
+     */
+    private static class BiLinearParentView extends TupleImpl {
+        private final BiLinearRuleTerminalNodeLeftTuple biLinearTuple;
+        private final int viewIndex;
+
+        BiLinearParentView(BiLinearRuleTerminalNodeLeftTuple biLinearTuple, int viewIndex) {
+            this.biLinearTuple = biLinearTuple;
+            this.viewIndex = viewIndex;
+        }
+
+        @Override
+        public int getIndex() {
+            return viewIndex;
+        }
+
+        @Override
+        public org.drools.core.common.InternalFactHandle getFactHandle() {
+            return (org.drools.core.common.InternalFactHandle) biLinearTuple.get(viewIndex);
+        }
+
+        @Override
+        public TupleImpl getParent() {
+            if (viewIndex <= 0) {
+                return null;
+            }
+            return biLinearTuple.getOrCreateParentView(viewIndex - 1);
+        }
+
+        @Override
+        public FactHandle get(int index) {
+            return biLinearTuple.get(index);
+        }
+
+        @Override
+        public FactHandle get(Declaration declaration) {
+            return biLinearTuple.get(declaration);
+        }
+
+        @Override
+        public org.drools.core.common.InternalFactHandle getOriginalFactHandle() {
+            org.drools.core.common.InternalFactHandle fh = getFactHandle();
+            if (fh != null && fh.isEvent()) {
+                org.drools.core.common.InternalFactHandle linkedFH =
+                    ((org.drools.core.common.DefaultEventHandle)fh).getLinkedFactHandle();
+                return linkedFH != null ? linkedFH : fh;
+            }
+            return fh;
+        }
+
+        @Override
+        public ObjectTypeNodeId getInputOtnId() {
+            return biLinearTuple.getInputOtnId();
+        }
+
+        @Override
+        public boolean isLeftTuple() {
+            return true;
+        }
+
+        @Override
+        public void reAdd() {
+            // No-op for view
+        }
+    }
+
+    @Override
+    public Object[] toObjects() {
+        return toObjects(false);
+    }
+
+    @Override
+    public Object[] toObjects(boolean reverse) {
+        int totalSize = size();
+        Object[] objects = new Object[totalSize];
+
+        int pos = 0;
+
+        // Add first network objects
+        if (firstNetworkTuple != null) {
+            Object[] firstObjects = firstNetworkTuple.toObjects(reverse);
+            System.arraycopy(firstObjects, 0, objects, pos, firstObjects.length);
+            pos += firstObjects.length;
+        }
+
+        // Add second network objects
+        if (secondNetworkTuple != null) {
+            Object[] secondObjects = secondNetworkTuple.toObjects(reverse);
+            System.arraycopy(secondObjects, 0, objects, pos, secondObjects.length);
+        }
+
+        if (reverse) {
+            // Reverse the array
+            for (int i = 0; i < totalSize / 2; i++) {
+                Object temp = objects[i];
+                objects[i] = objects[totalSize - 1 - i];
+                objects[totalSize - 1 - i] = temp;
+            }
+        }
+
+        return objects;
+    }
+
+    @Override
+    public FactHandle[] toFactHandles() {
+        int totalSize = size();
+        FactHandle[] handles = new FactHandle[totalSize];
+
+        int pos = 0;
+
+        // Add first network handles
+        if (firstNetworkTuple != null) {
+            FactHandle[] firstHandles = firstNetworkTuple.toFactHandles();
+            System.arraycopy(firstHandles, 0, handles, pos, firstHandles.length);
+            pos += firstHandles.length;
+        }
+
+        // Add second network handles
+        if (secondNetworkTuple != null) {
+            FactHandle[] secondHandles = secondNetworkTuple.toFactHandles();
+            System.arraycopy(secondHandles, 0, handles, pos, secondHandles.length);
+        }
+
+        return handles;
+    }
+
+    @Override
+    public String toString() {
+        return "BiLinearRuleTerminalNodeLeftTuple{" +
+                "firstNetwork=" + (firstNetworkTuple != null ? firstNetworkTuple.size() : 0) + " facts, " +
+                "secondNetwork=" + (secondNetworkTuple != null ? secondNetworkTuple.size() : 0) + " facts" +
+                '}';
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/CompositeLeftTupleSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/CompositeLeftTupleSinkAdapter.java
@@ -40,7 +40,17 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
     }
 
     public void addTupleSink(final LeftTupleSink sink) {
-        this.sinks.add( (LeftTupleSinkNode) sink );
+        LeftTupleSinkNode sinkNode = (LeftTupleSinkNode) sink;
+        
+        // Check if this exact sink instance is already registered
+        for (LeftTupleSinkNode existing = this.sinks.getFirst(); existing != null; existing = existing.getNextLeftTupleSinkNode()) {
+            if (existing == sinkNode) {
+                // Duplicate BiLinear shared node - skip to prevent corruption
+                return;
+            }
+        }
+        
+        this.sinks.add( sinkNode );
         sinkArray = null;
     }
 
@@ -67,10 +77,16 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
             return sinkArray;
         }
 
-        LeftTupleSink[] sinks = new LeftTupleSink[this.sinks.size()];
+        // Count actual nodes in case of list inconsistency (BiLinear shared nodes)
+        int actualCount = 0;
+        for ( LeftTupleSinkNode sink = this.sinks.getFirst(); sink != null; sink = sink.getNextLeftTupleSinkNode() ) {
+            actualCount++;
+        }
+        
+        LeftTupleSink[] sinks = new LeftTupleSink[actualCount];
 
         int i = 0;
-        for ( LeftTupleSinkNode sink = this.sinks.getFirst(); sink != null; sink = sink.getNextLeftTupleSinkNode() ) {
+        for ( LeftTupleSinkNode sink = this.sinks.getFirst(); sink != null && i < actualCount; sink = sink.getNextLeftTupleSinkNode() ) {
             sinks[i++] = sink;
         }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/ExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ExistsNode.java
@@ -56,7 +56,7 @@ public class ExistsNode extends BetaNode {
     }
     
     public String toString() {
-        BaseNode source = this.rightInput;
+        BaseNode source = this.rightInput.asBaseNode();
         while ( source != null && source.getClass() != ObjectTypeNode.class ) {
             source = source.getParent();
         }

--- a/drools-core/src/main/java/org/drools/core/reteoo/JoinNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/JoinNode.java
@@ -32,7 +32,7 @@ public class JoinNode extends BetaNode {
 
     public JoinNode(final int id,
                     final LeftTupleSource leftInput,
-                    final RightInputAdapterNode rightInput,
+                    final BetaRightInput rightInput,
                     final BetaConstraints binder,
                     final BuildContext context) {
         super( id,

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
@@ -85,6 +85,8 @@ public class ObjectTypeNode extends ObjectSource implements ObjectSink {
 
     /* reset counter when dirty */
     protected transient IdGenerator idGenerator;
+    private String tailHash;
+    private String currentHash;
 
     public int getOtnIdCounter() {
         return idGenerator.otnIdCounter;
@@ -126,6 +128,22 @@ public class ObjectTypeNode extends ObjectSource implements ObjectSink {
             partitionedSink.addObjectSink(objectSink, alphaNodeHashingThreshold, alphaNodeRangeIndexThreshold);
         }
         this.sink = partitionedSink;
+    }
+
+    public void setTailHash(String tailHash) {
+        this.tailHash = tailHash;
+    }
+
+    public String getTailHash() {
+        return tailHash;
+    }
+
+    public void setCurrentHash(String currentHash) {
+        this.currentHash = currentHash;
+    }
+
+    public String getCurrentHash() {
+        return currentHash;
     }
 
     private static class IdGenerator {

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
@@ -45,6 +45,7 @@ import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.MemoryFactory;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.PhreakBuilder;
+import org.drools.core.reteoo.builder.BiLinearDetector;
 import org.drools.core.reteoo.builder.ReteooRuleBuilder;
 import org.kie.api.definition.rule.Rule;
 
@@ -69,8 +70,8 @@ public class ReteooBuilder
 
     private transient RuleBuilder       ruleBuilder;
 
-    private IdGenerator nodeIdsGenerator = new IdGenerator(1);
-    private IdGenerator memoryIdsGenerator = new IdGenerator(1);
+    private IdGenerator nodeIdsGenerator = new IdGenerator();
+    private IdGenerator memoryIdsGenerator = new IdGenerator();
 
     // ------------------------------------------------------------
     // Constructors
@@ -100,11 +101,11 @@ public class ReteooBuilder
     /**
      * Add a <code>Rule</code> to the network.
      *
-     * @param rule     The rule to add.
+     * @param rule      The rule to add.
      * @throws InvalidPatternException
      */
-    public synchronized List<TerminalNode> addRule(final RuleImpl rule, Collection<InternalWorkingMemory> workingMemories) {
-        final List<TerminalNode> terminals = this.ruleBuilder.addRule( this.kBase, workingMemories, rule );
+    public synchronized List<TerminalNode> addRule(final RuleImpl rule, Collection<InternalWorkingMemory> workingMemories, BiLinearDetector.BiLinearContext biLinearContext) {
+        final List<TerminalNode> terminals = this.ruleBuilder.addRule( this.kBase, workingMemories, rule, biLinearContext);
 
         TerminalNode[] nodes = terminals.toArray( new TerminalNode[terminals.size()] );
         this.rules.put( rule.getFullyQualifiedName(), nodes );
@@ -228,18 +229,24 @@ public class ReteooBuilder
             if ( removed ) {
                 // reteoo requires to call remove on the OTN for tuples cleanup
                 if (NodeTypeEnums.isBetaNodeWithoutSubnetwork(node)) {
-                    alphas.add(((BetaNode) node).getRightInput().getParent());
+                    BetaRightInput rightInput = ((BetaNode) node).getRightInput();
+                    if (!rightInput.isBiLinear()) {
+                        alphas.add(rightInput.getParent());
+                    }
                 } else if (NodeTypeEnums.isLeftInputAdapterNode(node)) {
                     alphas.add(((LeftInputAdapterNode) node).getObjectSource());
                 }
 
                 if (NodeTypeEnums.isBetaNodeWithoutSubnetwork(node)) {
+                    BetaRightInput rightInput = ((BetaNode) node).getRightInput();
                     // this must be removed after alpha nodes are collected
-                    removeLeftTupleNode(wms, context, stillInUse, ((BetaNode) node).getRightInput());
+                    if (!rightInput.isBiLinear()) {
+                        removeLeftTupleNode(wms, context, stillInUse, rightInput.asBaseNode());
+                    }
                 } else if (NodeTypeEnums.isBetaNodeWithSubnetwork(node)) {
                     endNode = (PathEndNode) ((BetaNode) node).getRightInput().getParent();
                     // this must be removed after we have a reference to the TupleToObjectNode endnode
-                    removeLeftTupleNode(wms, context, stillInUse, ((BetaNode) node).getRightInput());
+                    removeLeftTupleNode(wms, context, stillInUse, ((BetaNode) node).getRightInput().asBaseNode());
                     removePath(wms, context, stillInUse, alphas, endNode, endNode.getStartTupleSource());
                 }
 
@@ -381,16 +388,13 @@ public class ReteooBuilder
     public static class IdGenerator implements Externalizable {
 
         private static final long serialVersionUID = 510l;
+        private static final int FIRST_ID = 1;
 
         private Queue<Integer>    recycledIds;
         private int               nextId;
 
         public IdGenerator() {
-            this(1);
-        }
-
-        public IdGenerator(final int firstId) {
-            this.nextId = firstId;
+            this.nextId = FIRST_ID;
             this.recycledIds = new ArrayDeque<>();
         }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
@@ -45,9 +45,8 @@ import static org.drools.base.reteoo.PropertySpecificUtil.isPropertyReactive;
 import static org.drools.core.phreak.PhreakNodeOperations.doUpdatesReorderChildLeftTuple;
 import static org.drools.core.reteoo.BetaNode.getBetaMemory;
 
-public abstract class RightInputAdapterNode<T extends  BetaNode> extends BaseNode
-        implements ObjectSinkNode,
-                   RightTupleSink {
+public abstract class RightInputAdapterNode<T extends BetaNode> extends BaseNode
+        implements BetaRightInput<T> {
 
     protected static final Logger    log               = LoggerFactory.getLogger(RightInputAdapterNode.class);
     protected static final boolean   isLogTraceEnabled = log.isTraceEnabled();
@@ -249,7 +248,7 @@ public abstract class RightInputAdapterNode<T extends  BetaNode> extends BaseNod
         }
     }
 
-    protected void initInferredMask() {
+    public void initInferredMask() {
         BaseNode unwrappedRight = getParent();
         if ( unwrappedRight.getType() == NodeTypeEnums.AlphaNode ) {
             AlphaNode alphaNode = (AlphaNode) unwrappedRight;
@@ -341,6 +340,11 @@ public abstract class RightInputAdapterNode<T extends  BetaNode> extends BaseNod
 
     public boolean isRightInputPassive() {
         return inputIsPassive;
+    }
+
+    @Override
+    public BaseNode asBaseNode() {
+        return this;
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleBuilder.java
@@ -26,10 +26,11 @@ import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.base.rule.WindowDeclaration;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.impl.InternalRuleBase;
+import org.drools.core.reteoo.builder.BiLinearDetector;
 
 public interface RuleBuilder {
 
-    List<TerminalNode> addRule(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, RuleImpl rule);
+    List<TerminalNode> addRule(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, RuleImpl rule, BiLinearDetector.BiLinearContext biLinearContext);
 
     void addEntryPoint(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, String id);
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SegmentMemory.java
@@ -32,6 +32,7 @@ import org.drools.core.common.SegmentMemorySupport;
 import org.drools.core.common.TupleSets;
 import org.drools.core.common.TupleSetsImpl;
 import org.drools.core.phreak.BuildtimeSegmentUtilities;
+import org.drools.core.reteoo.builder.BiLinearDetector;
 import org.drools.core.reteoo.AsyncReceiveNode.AsyncReceiveMemory;
 import org.drools.core.reteoo.QueryElementNode.QueryElementNodeMemory;
 import org.drools.core.reteoo.TupleToObjectNode.SubnetworkPathMemory;
@@ -106,7 +107,16 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public LeftTupleSink getSinkFactory() {
-        return (LeftTupleSink) proto.getRootNode();
+        LeftTupleNode rootNode = proto.getRootNode();
+
+        // LeftInputAdapterNode is a LeftTupleSource, not a LeftTupleSink
+        // Return the first actual sink child instead
+        if (rootNode instanceof LeftInputAdapterNode) {
+            LeftInputAdapterNode liaNode = (LeftInputAdapterNode) rootNode;
+            return liaNode.getSinkPropagator().getFirstLeftTupleSink();
+        }
+
+        return (LeftTupleSink) rootNode;
     }
 
     public Memory[] getNodeMemories() {
@@ -279,9 +289,6 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
     }
 
     public void addPathMemory(PathMemory pathMemory) {
-        if (pathMemories.contains(pathMemory)) {
-            System.out.println("!!!");
-        }
 
         pathMemories.add(pathMemory);
         if (getAllLinkedMaskTest() > 0 && isSegmentLinked()) {
@@ -682,6 +689,10 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
 
         PathEndNode[] pathEndNodes;
 
+        // BiLinear routing cache - set when nodesInSegment contains a BiLinearJoinNode
+        private int biLinearNodeIndex = -1;        // Index of BiLinearJoinNode in nodesInSegment, or -1 if none
+        private int biLinearSecondInputId = -1;    // Node ID of the BiLinearJoinNode's second left input
+
         public SegmentPrototype(LeftTupleNode rootNode, LeftTupleNode tipNode) {
             this.rootNode = rootNode;
             this.tipNode = tipNode;
@@ -793,6 +804,43 @@ public class SegmentMemory extends LinkedList<SegmentMemory>
 
         public void setNodesInSegment(LeftTupleNode[] nodesInSegment) {
             this.nodesInSegment = nodesInSegment;
+            // Detect BiLinearJoinNode and cache routing info
+            detectBiLinearNode(nodesInSegment);
+        }
+
+        private void detectBiLinearNode(LeftTupleNode[] nodes) {
+            this.biLinearNodeIndex = -1;
+            this.biLinearSecondInputId = -1;
+
+            if (!BiLinearDetector.isBiLinearEnabled() || nodes == null) {
+                return;
+            }
+
+            for (int i = 0; i < nodes.length; i++) {
+                if (nodes[i] instanceof BiLinearJoinNode biLinearNode) {
+                    LeftTupleSource secondInput = biLinearNode.getSecondLeftInput();
+                    if (secondInput != null) {
+                        this.biLinearNodeIndex = i;
+                        this.biLinearSecondInputId = secondInput.getId();
+                        return;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Returns the index of BiLinearJoinNode in nodesInSegment, or -1 if none.
+         */
+        public int getBiLinearNodeIndex() {
+            return biLinearNodeIndex;
+        }
+
+        public int getBiLinearSecondInputId() {
+            return biLinearSecondInputId;
+        }
+
+        public boolean hasBiLinearNode() {
+            return biLinearNodeIndex >= 0;
         }
 
         public int getNodeTypesInSegment() {

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleFactory.java
@@ -27,6 +27,7 @@ public class TupleFactory {
         TupleImpl peer;
         switch(n.getType()) {
             case NodeTypeEnums.JoinNode:
+            case NodeTypeEnums.BiLinearJoinNode:
             case NodeTypeEnums.AccumulateNode:
             case NodeTypeEnums.QueryElementNode:
             case NodeTypeEnums.FromNode:
@@ -67,6 +68,7 @@ public class TupleFactory {
 
         switch(s.getType()) {
             case NodeTypeEnums.JoinNode:
+            case NodeTypeEnums.BiLinearJoinNode:
             case NodeTypeEnums.AccumulateNode:
             case NodeTypeEnums.QueryElementNode:
             case NodeTypeEnums.FromNode:
@@ -97,6 +99,7 @@ public class TupleFactory {
                                             final Sink s) {
         switch(s.getType()) {
             case NodeTypeEnums.JoinNode:
+            case NodeTypeEnums.BiLinearJoinNode:
             case NodeTypeEnums.AccumulateNode:
             case NodeTypeEnums.QueryElementNode:
             case NodeTypeEnums.FromNode:
@@ -128,6 +131,7 @@ public class TupleFactory {
                                             boolean leftTupleMemoryEnabled) {
         switch(s.getType()) {
             case NodeTypeEnums.JoinNode:
+            case NodeTypeEnums.BiLinearJoinNode:
             case NodeTypeEnums.AccumulateNode:
             case NodeTypeEnums.QueryElementNode:
             case NodeTypeEnums.FromNode:
@@ -157,6 +161,7 @@ public class TupleFactory {
                                             TupleImpl rightTuple,
                                             Sink s) {
         switch(s.getType()) {
+            case NodeTypeEnums.BiLinearJoinNode:
             case NodeTypeEnums.JoinNode:
             case NodeTypeEnums.AccumulateNode:
             case NodeTypeEnums.QueryElementNode:
@@ -190,6 +195,7 @@ public class TupleFactory {
                                             Sink s,
                                             boolean leftTupleMemoryEnabled) {
         switch(s.getType()) {
+            case NodeTypeEnums.BiLinearJoinNode:
             case NodeTypeEnums.JoinNode:
             case NodeTypeEnums.AccumulateNode:
             case NodeTypeEnums.QueryElementNode:

--- a/drools-core/src/main/java/org/drools/core/reteoo/TupleImpl.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TupleImpl.java
@@ -671,6 +671,10 @@ public abstract class TupleImpl implements Tuple<TupleImpl> {
         return this.index;
     }
 
+    protected void setIndex(int index) {
+        this.index = index;
+    }
+
     /* Had to add the set method because sink adapters must override
      * the tuple sink set when the tuple was created.
      */

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/BiLinearBuildHelper.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/BiLinearBuildHelper.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo.builder;
+
+import org.drools.base.rule.Pattern;
+import org.drools.core.reteoo.BiLinearJoinNode;
+
+import java.util.List;
+
+public class BiLinearBuildHelper {
+
+    public static boolean canUseBiLinearJoin(BuildContext context) {
+        if (!BiLinearDetector.isBiLinearEnabled()) {
+            return false;
+        }
+
+        BiLinearDetector.Pair matchingPair = findMatchingPair(context);
+        if (matchingPair == null) {
+            return false;
+        }
+
+        return context.getRule().getName().equals(matchingPair.consumerRuleName());
+    }
+
+    public static BiLinearDetector.Pair findMatchingPair(BuildContext context) {
+        String tailHash = getTailHash(context);
+        if (tailHash == null) {
+            return null;
+        }
+
+        List<BiLinearDetector.Pair> pairList = context.getBiLinearContext().sharedChains().get(tailHash);
+        if (pairList != null && !pairList.isEmpty()) {
+            String currentRuleName = context.getRule() != null ? context.getRule().getName() : null;
+
+            for (BiLinearDetector.Pair pair : pairList) {
+                if (currentRuleName != null && currentRuleName.equals(pair.consumerRuleName())) {
+                    return pair;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static String getTailHash(BuildContext context) {
+        if (context.getBiLinearContext() == null || context.getBiLinearContext().sharedChains().isEmpty()) {
+            return null;
+        }
+
+        List<Pattern> patterns = context.getPatterns();
+        if (patterns == null || patterns.isEmpty()) {
+            return null;
+        }
+
+        for (int i = patterns.size() - 1; i >= 0; i--) {
+            Pattern p = patterns.get(i);
+            String pTailHash = p.getTailHash();
+            if (pTailHash != null && context.getBiLinearContext().sharedChains().containsKey(pTailHash)) {
+                return pTailHash;
+            }
+        }
+
+        return null;
+    }
+
+    public static void registerBiLinearNode(BuildContext context, BiLinearJoinNode biLinearNode) {
+        String tailHash = getTailHash(context);
+        if (tailHash != null) {
+            context.getBiLinearContext().setBiLinearNode(tailHash, biLinearNode);
+        }
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/BiLinearDetector.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/BiLinearDetector.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo.builder;
+
+import org.drools.base.definitions.rule.impl.RuleImpl;
+import org.drools.base.rule.EvalCondition;
+import org.drools.base.rule.GroupElement;
+import org.drools.base.rule.Pattern;
+import org.drools.base.rule.RuleConditionElement;
+import org.drools.core.reteoo.BiLinearJoinNode;
+import org.drools.core.reteoo.LeftTupleSource;
+import org.kie.api.definition.rule.Rule;
+
+import java.util.*;
+
+public class BiLinearDetector {
+
+    static boolean biLinearEnabled =
+            Boolean.parseBoolean(System.getProperty("drools.bilinear.enabled", "false"));
+
+    public static BiLinearContext detectBiLinearOpportunities(Collection<? extends Rule> rules, String kieBaseId) {
+        if (!isBiLinearEnabled()) {
+            return new BiLinearContext(new HashMap<>(), new HashMap<>());
+        }
+
+        Map<String, List<Pair>> sharedChains = detectSharedPatternChains(rules, kieBaseId);
+
+        return new BiLinearContext(sharedChains, new HashMap<>());
+    }
+
+    public record BiLinearContext(Map<String, List<Pair>> sharedChains, Map<String, BiLinearLink> biLinearJoinNodes) {
+
+        public void setLink(String hash,
+                            LeftTupleSource remoteNode) {
+            BiLinearLink link = getLink(hash);
+            link.setRemoteNode(remoteNode);
+        }
+
+        public void setBiLinearNode(String hash,
+                                    BiLinearJoinNode biLinearNode) {
+            BiLinearLink link = getLink(hash);
+            link.linkSecondLeftInputForBiLinearJoinNode(biLinearNode);
+        }
+
+        private BiLinearLink getLink(String hash) {
+            return biLinearJoinNodes.computeIfAbsent(hash, k -> new BiLinearLink());
+        }
+    }
+
+
+    public static final class BiLinearLink {
+        private LeftTupleSource remoteNode;
+
+        public void linkSecondLeftInputForBiLinearJoinNode(BiLinearJoinNode biLinearJoinNode) {
+            if (remoteNode != null) {
+                biLinearJoinNode.linkOutsideLeftInput(remoteNode);
+            }
+        }
+
+        public void setRemoteNode(LeftTupleSource remoteNode) {
+            this.remoteNode = remoteNode;
+        }
+    }
+
+    private static Map<String, List<Pair>> detectSharedPatternChains(Collection<? extends Rule> rules, String kieBaseId) {
+        Map<String, List<ChainMatch>> chainMatches = new HashMap<>();
+
+        for (Rule r : rules) {
+            if (r instanceof RuleImpl rule) {
+                if (containsEval(rule)) {
+                    continue;
+                }
+
+                PatternChainHasher.ChainHashResult chainResult = PatternChainHasher.generateChainHashes(rule, kieBaseId);
+
+                if (chainResult.getTailHashes().isEmpty()) {
+                    continue;
+                }
+
+                for (PatternChainHasher.TailHash tailHash : chainResult.getTailHashes()) {
+                    String unscopedHash = tailHash.getHash();
+                    String scopedHash = kieBaseId != null && !kieBaseId.contains("::")
+                            ? kieBaseId + "::" + unscopedHash
+                            : kieBaseId + unscopedHash;
+
+                    chainMatches.computeIfAbsent(scopedHash, k -> new ArrayList<>())
+                              .add(new ChainMatch(rule, tailHash));
+                }
+            }
+        }
+
+        Map<String, List<Pair>> pairs = new HashMap<>();
+
+        for (Map.Entry<String, List<ChainMatch>> entry : chainMatches.entrySet()) {
+            List<ChainMatch> matches = entry.getValue();
+
+            if (matches.size() >= 2) {
+                ChainMatch firstMatch = matches.get(0);
+
+                if (isSameTypeChain(firstMatch.tailHash().getPatterns())) {
+                    continue;
+                }
+
+                for (int i = 0; i < matches.size(); i++) {
+                    for (int j = i + 1; j < matches.size(); j++) {
+                        ChainMatch match1 = matches.get(i);
+                        ChainMatch match2 = matches.get(j);
+
+                        if (match1.tailHash().isFullChain() && match2.tailHash().isFullChain()) {
+                            continue;
+                        }
+
+                        if (!match1.tailHash().isFullChain() && !match2.tailHash().isFullChain()) {
+                            continue;
+                        }
+
+                        if (match1.tailHash().isFullChain()) {
+                            if (match1.tailHash().getLength() >= 2) {
+                                pairs.computeIfAbsent(entry.getKey(), k -> new ArrayList<>())
+                                     .add(new Pair(match2, match2.rule().getName(), match1.rule().getName()));
+                            }
+                        } else {
+                            if (match2.tailHash().getLength() >= 2) {
+                                pairs.computeIfAbsent(entry.getKey(), k -> new ArrayList<>())
+                                     .add(new Pair(match1, match1.rule().getName(), match2.rule().getName()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Set<String> allConsumerRules = new HashSet<>();
+        for (List<Pair> pairList : pairs.values()) {
+            for (Pair pair : pairList) {
+                allConsumerRules.add(pair.consumerRuleName());
+            }
+        }
+
+        for (Map.Entry<String, List<Pair>> entry : pairs.entrySet()) {
+            entry.getValue().removeIf(pair -> allConsumerRules.contains(pair.providerRuleName()));
+        }
+
+        pairs.entrySet().removeIf(entry -> entry.getValue().isEmpty());
+
+        return pairs;
+    }
+
+    public record Pair(ChainMatch id, String consumerRuleName, String providerRuleName){
+        public int getChainLength() {
+            return id.tailHash().getLength();
+        }
+    }
+
+    private record ChainMatch(RuleImpl rule, PatternChainHasher.TailHash tailHash) {
+    }
+
+    public static boolean isBiLinearEnabled() {
+        return biLinearEnabled;
+    }
+
+    public static void setBiLinearEnabled(boolean enabled) {
+        biLinearEnabled = enabled;
+    }
+
+    private static boolean containsEval(RuleImpl rule) {
+        if (rule == null || rule.getLhs() == null) {
+            return false;
+        }
+        return containsEvalInRCE(rule.getLhs());
+    }
+
+    private static boolean containsEvalInRCE(RuleConditionElement rce) {
+        if (rce instanceof EvalCondition) {
+            return true;
+        }
+        if (rce instanceof GroupElement ge) {
+            for (RuleConditionElement child : ge.getChildren()) {
+                if (containsEvalInRCE(child)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isSameTypeChain(List<Pattern> patterns) {
+        if (patterns == null || patterns.size() < 2) {
+            return true;
+        }
+
+        String firstType = patterns.get(0).getObjectType().getClassName();
+        for (int i = 1; i < patterns.size(); i++) {
+            if (!patterns.get(i).getObjectType().getClassName().equals(firstType)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/BiLinearLeftInputWrapper.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/BiLinearLeftInputWrapper.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo.builder;
+
+import org.drools.base.common.NetworkNode;
+import org.drools.base.common.RuleBasePartitionId;
+import org.drools.base.reteoo.BaseTerminalNode;
+import org.drools.core.common.*;
+import org.drools.core.reteoo.*;
+import org.drools.util.bitmask.BitMask;
+import org.drools.util.bitmask.EmptyBitMask;
+import org.kie.api.definition.rule.Rule;
+
+import java.util.Objects;
+
+public class BiLinearLeftInputWrapper implements BetaRightInput {
+
+    private LeftTupleSource wrappedSecondLeftInput;
+    private BiLinearJoinNode betaNode;
+    public LeftTupleSource getWrappedSecondLeftInput() {
+        return wrappedSecondLeftInput;
+    }
+
+    public void setWrappedSecondLeftInput(LeftTupleSource source) {
+        this.wrappedSecondLeftInput = source;
+    }
+
+    @Override
+    public void setBetaNode(BetaNode betaNode) {
+        this.betaNode = (BiLinearJoinNode) betaNode;
+    }
+
+    @Override
+    public void setPartitionId(BuildContext context, RuleBasePartitionId partitionId) {
+
+    }
+
+    @Override
+    public void initInferredMask() {
+
+    }
+
+    @Override
+    public boolean inputIsTupleToObjectNode() {
+        return false;
+    }
+
+    @Override
+    public ObjectSource getParent() {
+        // BiLinear wraps LeftTupleSource, not ObjectSource
+        // BiLinearJoinNode overrides setPartitionId() to handle this properly
+        // Return null since LeftTupleSource cannot be cast to ObjectSource
+        return null;
+    }
+
+    @Override
+    public ObjectTypeNode getObjectTypeNode() {
+        return null;
+    }
+
+    @Override
+    public void doAttach(BuildContext context) {
+        // Register BiLinearJoinNode as sink on second left input
+        // Only register if it's different from first input to avoid duplicate registration
+        if (wrappedSecondLeftInput != null && betaNode != null &&
+            !wrappedSecondLeftInput.equals(betaNode.getLeftTupleSource())) {
+            wrappedSecondLeftInput.addTupleSink(betaNode, context);
+        }
+    }
+
+    @Override
+    public void networkUpdated(UpdateContext updateContext) {
+
+    }
+
+    @Override
+    public void initDeclaredMask(BuildContext context) {
+
+    }
+
+    @Override
+    public void assertObject(InternalFactHandle factHandle, PropagationContext context, ReteEvaluator reteEvaluator) {
+
+    }
+
+    @Override
+    public void modifyObject(InternalFactHandle factHandle, ModifyPreviousTuples modifyPreviousTuples, PropagationContext context, ReteEvaluator reteEvaluator) {
+
+    }
+
+    @Override
+    public void byPassModifyToBetaNode(InternalFactHandle factHandle, ModifyPreviousTuples modifyPreviousTuples, PropagationContext context, ReteEvaluator reteEvaluator) {
+
+    }
+
+    @Override
+    public void removeAssociatedTerminal(BaseTerminalNode terminalNode) {
+
+    }
+
+    @Override
+    public int getAssociatedTerminalsSize() {
+        return 0;
+    }
+
+    @Override
+    public boolean hasAssociatedTerminal(BaseTerminalNode terminalNode) {
+        return false;
+    }
+
+    @Override
+    public NetworkNode[] getSinks() {
+        return new NetworkNode[0];
+    }
+
+    @Override
+    public int getId() {
+        return 0;
+    }
+
+    @Override
+    public RuleBasePartitionId getPartitionId() {
+        return null;
+    }
+
+    @Override
+    public int getType() {
+        return 0;
+    }
+
+    @Override
+    public Rule[] getAssociatedRules() {
+        return new Rule[0];
+    }
+
+    @Override
+    public boolean isAssociatedWith(Rule rule) {
+        return false;
+    }
+
+    @Override
+    public void addAssociatedTerminal(BaseTerminalNode terminalNode) {
+
+    }
+
+    @Override
+    public boolean removeAssociation(Rule rule, RuleRemovalContext context) {
+        return false;
+    }
+
+    @Override
+    public void addAssociation(Rule rule, BuildContext context) {
+
+    }
+
+    @Override
+    public boolean isRightInputPassive() {
+        return false;
+    }
+
+    @Override
+    public BaseNode asBaseNode() {
+        return null;
+    }
+
+    @Override
+    public boolean isBiLinear() {
+        return true;
+    }
+
+    @Override
+    public void updateSink(ObjectSink sink, PropagationContext context, InternalWorkingMemory workingMemory) {
+
+    }
+
+    @Override
+    public BitMask getDeclaredMask() {
+        return EmptyBitMask.get();
+    }
+
+    @Override
+    public BitMask getInferredMask() {
+        return EmptyBitMask.get();
+    }
+
+    @Override
+    public BitMask getNegativeMask() {
+        return EmptyBitMask.get();
+    }
+
+    @Override
+    public ObjectSinkNode getNextObjectSinkNode() {
+        return null;
+    }
+
+    @Override
+    public void setNextObjectSinkNode(ObjectSinkNode next) {
+
+    }
+
+    @Override
+    public ObjectSinkNode getPreviousObjectSinkNode() {
+        return null;
+    }
+
+    @Override
+    public void setPreviousObjectSinkNode(ObjectSinkNode previous) {
+
+    }
+
+    @Override
+    public void setPartitionIdWithSinks(RuleBasePartitionId partitionId) {
+
+    }
+
+    @Override
+    public void retractRightTuple(TupleImpl rightTuple, PropagationContext context, ReteEvaluator reteEvaluator) {
+
+    }
+
+    @Override
+    public void modifyRightTuple(TupleImpl rightTuple, PropagationContext context, ReteEvaluator reteEvaluator) {
+
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof BiLinearLeftInputWrapper)) return false;
+
+        BiLinearLeftInputWrapper other = (BiLinearLeftInputWrapper) obj;
+        // If either wrappedSecondLeftInput is null, the node hasn't been linked yet.
+        // Consider them equal for node sharing purposes - the other fields in
+        // BiLinearJoinNode.equals (leftInput, constraints) determine real equality.
+        // The wrappedSecondLeftInput will be set later during linking.
+        if (this.wrappedSecondLeftInput == null || other.wrappedSecondLeftInput == null) {
+            return true;
+        }
+        return this.wrappedSecondLeftInput.getId() == other.wrappedSecondLeftInput.getId();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(wrappedSecondLeftInput);
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/BuildContext.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/BuildContext.java
@@ -110,6 +110,8 @@ public class BuildContext implements RuleBuildContext {
     private boolean                          terminated;
 
     private String                           consequenceName;
+    
+    private BiLinearDetector.BiLinearContext biLinearContext;
 
     private final Collection<InternalWorkingMemory> workingMemories;
 
@@ -448,6 +450,14 @@ public class BuildContext implements RuleBuildContext {
 
     public void setSubRuleIndex(int subRuleIndex) {
         this.subRuleIndex = subRuleIndex;
+    }
+
+    public void setBiLinearContext(BiLinearDetector.BiLinearContext biLinearContext) {
+        this.biLinearContext = biLinearContext;
+    }
+
+    public BiLinearDetector.BiLinearContext getBiLinearContext() {
+        return biLinearContext;
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/GroupElementBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/GroupElementBuilder.java
@@ -33,14 +33,16 @@ import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.BaseNode;
 import org.drools.core.common.BetaConstraints;
 import org.drools.core.common.TupleStartEqualsConstraint;
+import org.drools.base.rule.constraint.BetaConstraint;
+import org.drools.core.reteoo.BiLinearJoinNode;
 import org.drools.core.reteoo.CoreComponentFactory;
 import org.drools.core.reteoo.ExistsNode;
 import org.drools.core.reteoo.JoinNode;
 import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.NotNode;
+import org.drools.core.reteoo.ObjectSource;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.TupleToObjectNode;
-import org.drools.base.rule.constraint.BetaConstraint;
 import org.kie.api.definition.rule.Propagation;
 
 public class GroupElementBuilder
@@ -116,12 +118,23 @@ public class GroupElementBuilder
                 builder.build( context, utils, child );
                 buildTupleSource( context, utils, isTerminalAlpha( context, child ) );
             } else {
-
-                for (final RuleConditionElement child : ge.getChildren()) {
+                List<RuleConditionElement> children = ge.getChildren();
+                for (int i = 0; i < children.size(); i++) {
+                    final RuleConditionElement child = children.get(i);
                     final ReteooComponentBuilder builder = utils.getBuilderFor( child );
                     builder.build( context, utils, child );
                     buildTupleSource( context, utils, false );
                     buildJoinNode( context, utils );
+
+                    BaseNode lastNode = context.getLastNode();
+                    if (lastNode instanceof BiLinearJoinNode) {
+                        // Bilinear node uses nodes from another network part so we skip adding them here.
+                        BiLinearDetector.Pair matchingPair = BiLinearBuildHelper.findMatchingPair(context);
+                        if (matchingPair != null) {
+                            i += matchingPair.getChainLength() - 1;
+                        }
+                    }
+
                 }
             }
         }
@@ -158,23 +171,46 @@ public class GroupElementBuilder
         }
 
         public static void buildJoinNode(BuildContext context, BuildUtils utils) {
+
+            ObjectSource objectSource = context.getObjectSource();
             // if there was a previous tuple source, then a join node is needed
-            if (context.getObjectSource() != null && context.getTupleSource() != null) {
+            if (objectSource != null && context.getTupleSource() != null) {
                 // so, create the tuple source and clean up the constraints and object source
-                final BetaConstraints betaConstraints = utils.createBetaNodeConstraint( context,
-                                                                                        context.getBetaconstraints(),
-                                                                                        false );
 
-                JoinNode joinNode = CoreComponentFactory.get()
-                                           .getNodeFactoryService().buildJoinNode( context.getNextNodeId(),
-                                                                                   context.getTupleSource(),
-                                                                                   context.getObjectSource(),
-                                                                                   betaConstraints,
-                                                                                   context);
+                JoinNode joinNode = getJoinNode(context, utils);
 
-                context.setTupleSource( utils.attachNode( context, joinNode));
+                JoinNode attachedNode = utils.attachNode(context, joinNode);
+
+                // Register BiLinearJoinNode for linking only if it was actually attached (not shared/discarded)
+                if (joinNode instanceof BiLinearJoinNode biLinear && attachedNode == joinNode) {
+                    BiLinearBuildHelper.registerBiLinearNode(context, biLinear);
+                }
+
+                context.setTupleSource(attachedNode);
                 context.setBetaconstraints( null );
                 context.setObjectSource( null );
+            }
+        }
+
+        private static JoinNode getJoinNode(BuildContext context, BuildUtils utils) {
+
+            final BetaConstraints betaConstraints = utils.createBetaNodeConstraint(context,
+                    context.getBetaconstraints(),
+                    false);
+
+            if (BiLinearBuildHelper.canUseBiLinearJoin(context)) {
+                    return CoreComponentFactory.get()
+                            .getNodeFactoryService().buildBiLinearJoinNode(
+                                    betaConstraints,
+                                    context);
+            } else {
+                return CoreComponentFactory.get()
+                        .getNodeFactoryService().buildJoinNode(
+                                context.getNextNodeId(),
+                                context.getTupleSource(),
+                                context.getObjectSource(),
+                                betaConstraints,
+                                context);
             }
         }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/NodeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/NodeFactory.java
@@ -47,6 +47,7 @@ import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.EvalConditionNode;
 import org.drools.core.reteoo.ExistsNode;
 import org.drools.core.reteoo.FromNode;
+import org.drools.core.reteoo.BiLinearJoinNode;
 import org.drools.core.reteoo.JoinNode;
 import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.LeftTupleSource;
@@ -106,6 +107,9 @@ public interface NodeFactory {
                             ObjectSource rightInput,
                             BetaConstraints binder,
                             BuildContext context );
+
+    BiLinearJoinNode buildBiLinearJoinNode(BetaConstraints binder,
+                                           BuildContext context );
 
     NotNode buildNotNode( int id,
                           LeftTupleSource leftInput,

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
@@ -346,6 +346,10 @@ public class PatternBuilder
                                                  (EntryPointNode) context.getObjectSource(),
                                                  objectType,
                                                  context );
+
+        otn.setTailHash(pattern.getTailHash());
+        otn.setCurrentHash(pattern.getCurrentHash());
+
         if ( objectType.isEvent() && EventProcessingOption.STREAM.equals( context.getRuleBase().getRuleBaseConfiguration().getEventProcessingMode() ) ) {
             ExpirationSpec expirationSpec = getExpirationForType( context, objectType );
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternChainHasher.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternChainHasher.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo.builder;
+
+import org.drools.base.definitions.rule.impl.RuleImpl;
+import org.drools.base.rule.GroupElement;
+import org.drools.base.rule.Pattern;
+import org.drools.base.rule.RuleConditionElement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Generates combined hashes for pattern chains in rules, creating hashes for
+ * progressively shorter "tails" of the pattern sequence.
+ *
+ * For example, if a rule has patterns [A, B, C]:
+ * - Creates hash for [A, B, C] (full chain)
+ * - Creates hash for [B, C] (tail starting at position 1)
+ * - Creates hash for [C] (tail starting at position 2)
+ *
+ * This enables efficient matching of partial pattern sequences across rules.
+ */
+public class PatternChainHasher {
+
+    public static ChainHashResult generateChainHashes(RuleImpl rule, String kieBaseId) {
+        if (rule == null) {
+            return new ChainHashResult(Collections.emptyList());
+        }
+
+        List<Pattern> patterns = extractPatterns(rule);
+        return generateChainHashes(kieBaseId, patterns);
+    }
+
+    private static ChainHashResult generateChainHashes(String identifier, List<Pattern> patterns) {
+        if (patterns == null || patterns.isEmpty()) {
+            return new ChainHashResult(Collections.emptyList());
+        }
+
+        List<TailHash> tailHashList = new ArrayList<>();
+
+        // Generate hash for each tail starting from position i
+        for (int startIndex = 0; startIndex < patterns.size(); startIndex++) {
+            List<Pattern> tailPatterns = patterns.subList(startIndex, patterns.size());
+            String combinedHash = generateCombinedHash(tailPatterns);
+
+            tailHashList.add(new TailHash(tailPatterns.size(), patterns.size(), combinedHash, new ArrayList<>(tailPatterns)));
+
+            // Use "::" separator for proper scoping (KieBase::hash format)
+            String scopedHash = identifier.contains("::") ? identifier + combinedHash : identifier + "::" + combinedHash;
+
+            Pattern currentPattern = tailPatterns.get(0);
+            currentPattern.setTailHash(scopedHash);
+
+            // Generate currentHash: individual pattern hash + tail hash
+            String individualPatternHash = PatternHashComparator.generateNormalizedHash(currentPattern);
+            String currentHash = individualPatternHash + "::" + scopedHash;
+            currentPattern.setCurrentHash(currentHash);
+        }
+
+        return new ChainHashResult(tailHashList);
+    }
+
+    private static String generateCombinedHash(List<Pattern> patterns) {
+        if (patterns == null || patterns.isEmpty()) {
+            return "EMPTY_CHAIN";
+        }
+
+        StringBuilder chainHash = new StringBuilder();
+        chainHash.append("CHAIN[").append(patterns.size()).append("]:");
+
+        List<String> patternHashes = new ArrayList<>();
+        for (int i = 0; i < patterns.size(); i++) {
+            Pattern pattern = patterns.get(i);
+            String patternHash = PatternHashComparator.generateNormalizedHash(pattern);
+            // Include position information for ordering sensitivity
+            patternHashes.add("E" + i + ":" + patternHash);
+        }
+
+        chainHash.append(String.join("|", patternHashes));
+
+        return chainHash.toString();
+    }
+
+    private static List<Pattern> extractPatterns(RuleImpl rule) {
+        List<Pattern> patterns = new ArrayList<>();
+
+        if (rule != null && rule.getLhs() != null) {
+            collectPatterns(rule.getLhs(), patterns);
+        }
+
+        return patterns;
+    }
+
+    private static void collectPatterns(RuleConditionElement rce, List<Pattern> patterns) {
+        if (rce instanceof Pattern pattern) {
+            patterns.add(pattern);
+        } else if (rce instanceof GroupElement ge) {
+            // Only recurse into AND groups - EXISTS, NOT, OR create subnetworks
+            if (ge.isAnd()) {
+                for (RuleConditionElement child : ge.getChildren()) {
+                    collectPatterns(child, patterns);
+                }
+            }
+        }
+    }
+
+    public static class ChainHashResult {
+        private final List<TailHash> tailHashes;
+
+        public ChainHashResult(List<TailHash> tailHashes) {
+            this.tailHashes = Collections.unmodifiableList(tailHashes);
+        }
+
+        public List<TailHash> getTailHashes() {
+            return tailHashes;
+        }
+
+        @Override
+        public String toString() {
+            return "ChainHashResult{tailCount=" + tailHashes.size() + '}';
+        }
+    }
+
+    public static class TailHash {
+        private final int length;
+        private final int max;
+        private final String hash;
+        private final List<Pattern> patterns;
+
+        public TailHash(int length, int max, String hash, List<Pattern> patterns) {
+            this.length = length;
+            this.max = max;
+            this.hash = hash;
+            this.patterns = Collections.unmodifiableList(patterns);
+        }
+
+        public int getLength() {
+            return length;
+        }
+
+        public boolean isFullChain() {
+            return max == length;
+        }
+
+        public String getHash() {
+            return hash;
+        }
+
+        public List<Pattern> getPatterns() {
+            return patterns;
+        }
+
+        @Override
+        public String toString() {
+            return "TailHash{" +
+                    "length=" + length +
+                    ", hash='" + hash.substring(0, Math.min(50, hash.length())) + "...'" +
+                    '}';
+        }
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternHashComparator.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternHashComparator.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo.builder;
+
+import org.drools.base.rule.Declaration;
+import org.drools.base.rule.Pattern;
+import org.drools.base.rule.constraint.BetaConstraint;
+import org.drools.base.rule.constraint.Constraint;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+
+/**
+ * Compares patterns by creating normalized hashes that abstract away variable names
+ * while preserving the semantic structure of patterns and constraints.
+ *
+ * The hash generation process normalizes variable names to ensure that patterns
+ * with identical structure but different variable names are considered equal.
+ */
+public class PatternHashComparator {
+
+    private static final java.util.regex.Pattern FIELD_PATTERN = java.util.regex.Pattern.compile(
+            "(?:get|is)([A-Z][a-zA-Z0-9_]*)|\\b([a-z][a-zA-Z0-9_]*)\\s*[=<>!]|this\\.([a-zA-Z_][a-zA-Z0-9_]*)");
+
+    private static final java.util.regex.Pattern LITERAL_PATTERN = java.util.regex.Pattern.compile(
+            "\"([^\"]*)\"|'([^']*)'|(\\b\\d+\\.?\\d*\\b)|(\\btrue\\b|\\bfalse\\b|\\bnull\\b)|==\\s*([a-zA-Z_][a-zA-Z0-9_]*)");
+
+    private static final java.util.regex.Pattern FIELD_NAME_PATTERN = java.util.regex.Pattern.compile(
+            "([a-zA-Z_][a-zA-Z0-9_]*)(?=\\s*$|\\s*[\\(\\)\\[\\]])");
+
+    public static String generateNormalizedHash(Pattern pattern) {
+        if (pattern == null) {
+            return "null";
+        }
+
+        StringBuilder hash = new StringBuilder();
+
+        hash.append("TYPE:").append(pattern.getObjectType().getClassName());
+
+        List<String> normalizedConstraints = new ArrayList<>();
+
+        for (Constraint constraint : pattern.getConstraints()) {
+            String normalizedConstraint = normalizeConstraint(constraint);
+            normalizedConstraints.add(normalizedConstraint);
+        }
+
+        Collections.sort(normalizedConstraints);
+
+        if (!normalizedConstraints.isEmpty()) {
+            hash.append(";CONSTRAINTS:[");
+            for (int i = 0; i < normalizedConstraints.size(); i++) {
+                if (i > 0) {
+                    hash.append(",");
+                }
+                hash.append(normalizedConstraints.get(i));
+            }
+            hash.append("]");
+        }
+
+        return hash.toString();
+    }
+
+    /**
+     * Normalizes a constraint by replacing variable names with normalized placeholders
+     * while preserving field names, operators, and literal values.
+     */
+    private static String normalizeConstraint(Constraint constraint) {
+        StringBuilder normalized = new StringBuilder();
+
+        normalized.append(constraint.getClass().getSimpleName());
+
+        if (constraint instanceof BetaConstraint betaConstraint) {
+            normalized.append(":BETA");
+
+            // Add required declarations with normalized variable names
+            Declaration[] declarations = betaConstraint.getRequiredDeclarations();
+            if (declarations != null && declarations.length > 0) {
+                normalized.append(":DECLS[");
+
+                Map<String, String> variableMap = new HashMap<>();
+
+                for (int i = 0; i < declarations.length; i++) {
+                    if (i > 0) {
+                        normalized.append(",");
+                    }
+
+                    Declaration decl = declarations[i];
+                    String varName = decl.getIdentifier();
+                    String normalizedVar = variableMap.get(varName);
+                    if (normalizedVar == null) {
+                        normalizedVar = "VAR" + variableMap.size();
+                        variableMap.put(varName, normalizedVar);
+                    }
+
+                    normalized.append(normalizedVar).append(":");
+
+                    Class<?> declarationClass = decl.getDeclarationClass();
+                    normalized.append(declarationClass != null ? declarationClass.getSimpleName() : "UNKNOWN_TYPE");
+
+                    // Add field information if available
+                    if (decl.getExtractor() != null) {
+                        normalized.append(".").append(normalizeFieldName(decl.getExtractor().toString()));
+                    }
+                }
+
+                normalized.append("]");
+            }
+
+            normalized.append(":OP:").append(extractOperator(betaConstraint.toString()));
+
+        } else {
+            normalized.append(":ALPHA:");
+            normalized.append(extractDetailedAlphaConstraintInfo(constraint));
+        }
+
+        return normalized.toString();
+    }
+
+    /**
+     * Extracts detailed information from alpha constraints including field names,
+     * operators, and literal values while normalizing variable references.
+     */
+    private static String extractDetailedAlphaConstraintInfo(Constraint constraint) {
+        StringBuilder info = new StringBuilder();
+
+        String constraintStr = constraint.toString();
+
+        String fieldInfo = extractFieldInfo(constraintStr);
+        if (!fieldInfo.isEmpty()) {
+            info.append("FIELD:").append(fieldInfo);
+        }
+
+        String operator = extractOperator(constraintStr);
+        if (!operator.isEmpty()) {
+            info.append(":OP:").append(operator);
+        }
+
+        String valueInfo = extractValueInfo(constraintStr);
+        if (!valueInfo.isEmpty()) {
+            info.append(":VAL:").append(valueInfo);
+        }
+
+        if (info.isEmpty()) {
+            info.append(normalizeConstraintString(constraintStr));
+        }
+
+        return info.toString();
+    }
+
+    private static String extractFieldInfo(String constraintStr) {
+        Matcher matcher = FIELD_PATTERN.matcher(constraintStr);
+        if (matcher.find()) {
+            for (int i = 1; i <= matcher.groupCount(); i++) {
+                if (matcher.group(i) != null) {
+                    return matcher.group(i).toLowerCase();
+                }
+            }
+        }
+        return "";
+    }
+
+    private static String extractOperator(String constraintStr) {
+        if (constraintStr.contains("==")) return "EQUALS";
+        if (constraintStr.contains("!=")) return "NOT_EQUALS";
+        if (constraintStr.contains(">=")) return "GREATER_EQUAL";
+        if (constraintStr.contains("<=")) return "LESS_EQUAL";
+        if (constraintStr.contains(">")) return "GREATER";
+        if (constraintStr.contains("<")) return "LESS";
+        if (constraintStr.contains("matches")) return "MATCHES";
+        if (constraintStr.contains("contains")) return "CONTAINS";
+        if (constraintStr.contains("memberOf")) return "MEMBER_OF";
+        if (constraintStr.contains("soundslike")) return "SOUNDS_LIKE";
+        return "";
+    }
+
+    private static String extractValueInfo(String constraintStr) {
+        Matcher matcher = LITERAL_PATTERN.matcher(constraintStr);
+        TreeSet<String> foundValues = new TreeSet<>();
+
+        while (matcher.find()) {
+            for (int i = 1; i <= matcher.groupCount(); i++) {
+                if (matcher.group(i) != null) {
+                    foundValues.add("LIT:" + matcher.group(i));
+                }
+            }
+        }
+
+        return String.join(",", foundValues);
+    }
+
+    /**
+     * Normalizes a constraint string by replacing variable names with placeholders
+     * while preserving field names and literal values.
+     */
+    private static String normalizeConstraintString(String constraintStr) {
+        if (constraintStr == null) {
+            return "null";
+        }
+
+        String normalized = constraintStr.replaceAll("[a-zA-Z_][a-zA-Z0-9_]*\\.[a-zA-Z_][a-zA-Z0-9_]*\\.", "");
+
+        normalized = normalized.replaceAll("\\$[a-zA-Z_][a-zA-Z0-9_]*", "\\$VAR");
+
+        normalized = normalized.replaceAll("\\b[a-z][a-zA-Z0-9_]*(?=\\s*[=<>!])", "VAR");
+
+        normalized = normalized.replaceAll("\\s+", " ").trim();
+
+        return normalized;
+    }
+
+    private static String normalizeFieldName(String fieldStr) {
+        if (fieldStr == null) {
+            return "FIELD";
+        }
+
+        Matcher matcher = FIELD_NAME_PATTERN.matcher(fieldStr);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        return fieldStr.replaceAll("[^a-zA-Z0-9_]", "").trim();
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PhreakNodeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PhreakNodeFactory.java
@@ -41,6 +41,7 @@ import org.drools.core.common.BetaConstraints;
 import org.drools.core.reteoo.AccumulateNode;
 import org.drools.core.reteoo.AccumulateRight;
 import org.drools.core.reteoo.AlphaNode;
+import org.drools.core.reteoo.BiLinearJoinNode;
 import org.drools.core.reteoo.AlphaTerminalNode;
 import org.drools.core.reteoo.AsyncReceiveNode;
 import org.drools.core.reteoo.AsyncSendNode;
@@ -117,6 +118,15 @@ public class PhreakNodeFactory implements NodeFactory, Serializable {
     public JoinNode buildJoinNode( int id, LeftTupleSource leftInput, ObjectSource rightInput, BetaConstraints binder, BuildContext context ) {
         JoinRightAdapterNode joinRight = new JoinRightAdapterNode(id, rightInput, context);
         return new JoinNode(context.getNextNodeId(), leftInput, joinRight, binder, context );
+    }
+
+    public BiLinearJoinNode buildBiLinearJoinNode(BetaConstraints binder, BuildContext context) {
+        return new BiLinearJoinNode(
+                context.getNextNodeId(),
+                context.getTupleSource(),
+                binder,
+                context
+        );
     }
 
     public NotNode buildNotNode( int id, LeftTupleSource leftInput, ObjectSource rightInput, BetaConstraints binder, BuildContext context ) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/ReteooRuleBuilder.java
@@ -21,6 +21,7 @@ package org.drools.core.reteoo.builder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.drools.base.base.ClassObjectType;
 import org.drools.base.definitions.rule.impl.RuleImpl;
@@ -50,6 +51,7 @@ import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.UpdateContext;
 import org.drools.core.impl.InternalRuleBase;
 import org.drools.core.phreak.PhreakBuilder;
+import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.PathEndNode;
 import org.drools.core.reteoo.RuleBuilder;
 import org.drools.core.reteoo.TerminalNode;
@@ -109,7 +111,7 @@ public class ReteooRuleBuilder implements RuleBuilder {
      * @return a List<BaseNode> of terminal nodes for the rule             
      * @throws InvalidPatternException
      */
-    public List<TerminalNode> addRule(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, RuleImpl rule) throws InvalidPatternException {
+    public List<TerminalNode> addRule(InternalRuleBase kBase, Collection<InternalWorkingMemory> workingMemories, RuleImpl rule, BiLinearDetector.BiLinearContext biLinearContext) throws InvalidPatternException {
 
         // the list of terminal nodes
         final List<TerminalNode> termNodes = new ArrayList<>();
@@ -122,6 +124,8 @@ public class ReteooRuleBuilder implements RuleBuilder {
             final BuildContext context = new BuildContext( kBase, workingMemories );
             context.setRule( rule );
             context.setSubRuleIndex( i );
+
+            context.setBiLinearContext(biLinearContext);
 
             // if running in STREAM mode, calculate temporal distance for events
             if (EventProcessingOption.STREAM.equals( kBase.getRuleBaseConfiguration().getEventProcessingMode() )) {
@@ -162,6 +166,17 @@ public class ReteooRuleBuilder implements RuleBuilder {
         builder.build( context,
                        this.utils,
                        subrule );
+
+        for (Map.Entry<String, List<BiLinearDetector.Pair>> stringPairEntry : context.getBiLinearContext().sharedChains().entrySet()) {
+            for (BiLinearDetector.Pair pair : stringPairEntry.getValue()) {
+                if(pair.providerRuleName().equals(rule.getName())){
+
+                    if( context.getLastNode() instanceof LeftTupleSource lts){
+                        context.getBiLinearContext().setLink(stringPairEntry.getKey(), lts);
+                    }
+                }
+            }
+        }
 
         TerminalNode terminal;
         if (!context.isTerminated()) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/RuleOrderOptimizer.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/RuleOrderOptimizer.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.core.reteoo.builder;
+
+import org.drools.base.definitions.rule.impl.RuleImpl;
+import org.kie.api.definition.rule.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Optimizes rule build order to ensure BiLinear optimization succeeds.
+ *
+ * BiLinear optimization requires that rules defining shared patterns
+ * build before rules that reuse those patterns. This class analyzes
+ * BiLinear dependencies and reorders rules using topological sorting to satisfy
+ * these constraints.
+ *
+ * The reordering is transparent to users and maintains relative order of rules
+ * not involved in BiLinear optimization.
+ */
+public class RuleOrderOptimizer {
+
+    private static final Logger logger = LoggerFactory.getLogger(RuleOrderOptimizer.class);
+
+    public static Collection<? extends Rule> reorderForBiLinear(
+            Collection<? extends Rule> rules,
+            BiLinearDetector.BiLinearContext biLinearContext) {
+
+        if (!BiLinearDetector.isBiLinearEnabled()) {
+            return rules;
+        }
+
+        if (biLinearContext.sharedChains().isEmpty()) {
+            return rules;
+        }
+
+        Map<String, Set<String>> dependencyGraph = buildDependencyGraph(biLinearContext);
+
+        Map<String, RuleImpl> ruleMap = new HashMap<>();
+        List<RuleImpl> originalOrder = new ArrayList<>();
+        for (Rule rule : rules) {
+            if (rule instanceof RuleImpl ruleImpl) {
+                ruleMap.put(rule.getName(), ruleImpl);
+                originalOrder.add(ruleImpl);
+            }
+        }
+
+        return topologicalSort(originalOrder, ruleMap, dependencyGraph);
+    }
+
+    /**
+     * Builds a dependency graph from BiLinear pairs.
+     *
+     * For each Pair(chainId, consumerRuleName, providerRuleName):
+     *   - providerRule = creates the shared JoinNode (simpler pattern, e.g., C-D)
+     *   - consumerRule = uses BiLinearJoinNode linking to providerRule's JoinNode (complex pattern, e.g., A-B-C-D)
+     *   - providerRule MUST build before consumerRule (so consumerRule can link to providerRule's node)
+     *
+     * @param biLinearContext BiLinear context with detected pairs
+     * @return Adjacency list: consumerRule -> set of providerRules that must build before it
+     */
+    private static Map<String, Set<String>> buildDependencyGraph(
+            BiLinearDetector.BiLinearContext biLinearContext) {
+
+        Map<String, Set<String>> graph = new HashMap<>();
+
+        for (Map.Entry<String, List<BiLinearDetector.Pair>> entry : biLinearContext.sharedChains().entrySet()) {
+            for (BiLinearDetector.Pair pair : entry.getValue()) {
+                String consumerRule = pair.consumerRuleName();
+                String providerRule = pair.providerRuleName();
+
+                graph.computeIfAbsent(consumerRule, k -> new HashSet<>()).add(providerRule);
+
+                graph.putIfAbsent(providerRule, new HashSet<>());
+            }
+        }
+
+        return graph;
+    }
+
+    /**
+     * Algorithm:
+     * 1. Calculate in-degree for each rule (number of rules that must build before it)
+     * 2. Start with rules with in-degree 0 (no dependencies)
+     * 3. Process nodes in order, choosing from available rules based on original order
+     * 4. When a rule is processed, decrement in-degree of rules that depend on it
+     * 5. Detect and handle cycles gracefully
+     *
+     * Rules not involved in BiLinear are added in their original positions.
+     * The algorithm preserves relative order as much as possible (stable sort).
+     *
+     */
+    private static List<Rule> topologicalSort(
+            List<? extends Rule> originalOrder,
+            Map<String, RuleImpl> ruleMap,
+            Map<String, Set<String>> dependencyGraph) {
+
+        Map<String, Integer> inDegree = new HashMap<>();
+        Set<String> rulesInGraph = dependencyGraph.keySet();
+
+        Map<String, Set<String>> dependentsMap = new HashMap<>();
+        for (String ruleName : rulesInGraph) {
+            dependentsMap.put(ruleName, new HashSet<>());
+        }
+        for (Map.Entry<String, Set<String>> entry : dependencyGraph.entrySet()) {
+            String consumer = entry.getKey();
+            for (String provider : entry.getValue()) {
+                dependentsMap.computeIfAbsent(provider, k -> new HashSet<>()).add(consumer);
+            }
+        }
+
+        for (String ruleName : rulesInGraph) {
+            Set<String> dependencies = dependencyGraph.get(ruleName);
+            inDegree.put(ruleName, dependencies != null ? dependencies.size() : 0);
+        }
+
+        List<Rule> result = new ArrayList<>();
+        Set<String> remaining = new HashSet<>(rulesInGraph);
+
+        while (!remaining.isEmpty()) {
+            List<String> available = new ArrayList<>();
+            for (Rule rule : originalOrder) {
+                String ruleName = rule.getName();
+                if (remaining.contains(ruleName) && inDegree.get(ruleName) == 0) {
+                    available.add(ruleName);
+                }
+            }
+
+            // If no rules available but rules remain, we have a cycle
+            if (available.isEmpty()) {
+                logger.warn("Circular BiLinear dependencies detected. " +
+                           "Remaining rules will be built in original order: {}", remaining);
+
+                for (Rule rule : originalOrder) {
+                    if (remaining.contains(rule.getName())) {
+                        result.add(rule);
+                    }
+                }
+                break;
+            }
+
+            for (String ruleName : available) {
+                // Always remove from remaining to guarantee loop termination
+                remaining.remove(ruleName);
+
+                RuleImpl rule = ruleMap.get(ruleName);
+                if (rule != null) {
+                    result.add(rule);
+
+                    Set<String> consumers = dependentsMap.get(ruleName);
+                    if (consumers != null) {
+                        for (String consumer : consumers) {
+                            inDegree.put(consumer, inDegree.get(consumer) - 1);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (rulesInGraph.size() == originalOrder.size()) {
+            return result;
+        }
+
+        return mergeWithNonBiLinearRules(originalOrder, result, rulesInGraph);
+    }
+
+    /**
+     * Merges topologically sorted BiLinear rules with non-BiLinear rules.
+     *
+     * Strategy: Use the sorted BiLinear order, but insert non-BiLinear rules
+     * at their original relative positions among the BiLinear rules.
+     */
+    private static List<Rule> mergeWithNonBiLinearRules(
+            List<? extends Rule> originalOrder,
+            List<? extends Rule> sortedBiLinearRules,
+            Set<String> biLinearRuleNames) {
+
+        if (biLinearRuleNames.isEmpty()) {
+            return new ArrayList<>(originalOrder);
+        }
+        if (biLinearRuleNames.size() == originalOrder.size()) {
+            return new ArrayList<>(sortedBiLinearRules);
+        }
+
+        Map<String, Integer> originalPositions = new HashMap<>();
+        for (int i = 0; i < originalOrder.size(); i++) {
+            originalPositions.put(originalOrder.get(i).getName(), i);
+        }
+
+        List<Rule> result = new ArrayList<>();
+        int nextBiLinearIndex = 0;
+
+        for (Rule rule : originalOrder) {
+            if (!biLinearRuleNames.contains(rule.getName())) {
+                // Non-BiLinear rule: add all BiLinear rules that should come before it
+                int currentPos = originalPositions.get(rule.getName());
+                while (nextBiLinearIndex < sortedBiLinearRules.size()) {
+                    Rule biLinearRule = sortedBiLinearRules.get(nextBiLinearIndex);
+                    int originalBiLinearPos = originalPositions.get(biLinearRule.getName());
+                    if (originalBiLinearPos < currentPos) {
+                        result.add(biLinearRule);
+                        nextBiLinearIndex++;
+                    } else {
+                        break;
+                    }
+                }
+                result.add(rule);
+            }
+        }
+
+        while (nextBiLinearIndex < sortedBiLinearRules.size()) {
+            result.add(sortedBiLinearRules.get(nextBiLinearIndex++));
+        }
+
+        return result;
+    }
+}

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockTupleSource.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockTupleSource.java
@@ -28,6 +28,8 @@ public class MockTupleSource extends LeftTupleSource {
     private int               attached;
 
     private int               updated;
+    
+    private int               objectCount = 0;
 
     public MockTupleSource(final int id, BuildContext context) {
         super( id, context );
@@ -68,5 +70,14 @@ public class MockTupleSource extends LeftTupleSource {
     @Override
     public boolean isLeftTupleMemoryEnabled() {
         return true;
+    }
+
+    public void setObjectCount(int objectCount) {
+        this.objectCount = objectCount;
+    }
+    
+    @Override
+    public int getObjectCount() {
+        return this.objectCount;
     }
 }

--- a/drools-core/src/test/java/org/drools/core/reteoo/builder/ReteooRuleBuilderTest.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/builder/ReteooRuleBuilderTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import org.drools.base.base.ClassObjectType;
@@ -34,6 +35,7 @@ import org.drools.base.rule.consequence.Consequence;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.impl.RuleBaseFactory;
 import org.drools.core.reteoo.RuleTerminalNode;
+import org.drools.core.reteoo.builder.BiLinearDetector;
 import org.drools.core.rule.consequence.KnowledgeHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,7 +94,7 @@ public class ReteooRuleBuilderTest {
 
         rule.setConsequence( consequence );
 
-        final List terminals = this.builder.addRule( this.rulebase, Collections.emptyList(), rule );
+        final List terminals = this.builder.addRule( this.rulebase, Collections.emptyList(), rule, new BiLinearDetector.BiLinearContext(new HashMap<>(), new HashMap<>()) );
 
         assertThat(terminals.size()).as("Rule must have a single terminal node").isEqualTo(1);
 

--- a/drools-metric/src/main/java/org/drools/metric/phreak/MetricPhreakNetworkNodeFactoryImpl.java
+++ b/drools-metric/src/main/java/org/drools/metric/phreak/MetricPhreakNetworkNodeFactoryImpl.java
@@ -22,6 +22,7 @@ import org.drools.core.common.ReteEvaluator;
 import org.drools.core.phreak.PhreakAccumulateNode;
 import org.drools.core.phreak.PhreakAsyncReceiveNode;
 import org.drools.core.phreak.PhreakAsyncSendNode;
+import org.drools.core.phreak.PhreakBiLinearJoinNode;
 import org.drools.core.phreak.PhreakBranchNode;
 import org.drools.core.phreak.PhreakEvalNode;
 import org.drools.core.phreak.PhreakExistsNode;
@@ -46,6 +47,11 @@ public class MetricPhreakNetworkNodeFactoryImpl implements PhreakNetworkNodeFact
         } else {
             return new PhreakJoinNode(reteEvaluator);
         }
+    }
+
+    @Override
+    public PhreakBiLinearJoinNode createPhreakBiLinearJoinNode(ReteEvaluator reteEvaluator) {
+        return new PhreakBiLinearJoinNode(reteEvaluator);
     }
 
     @Override

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/LeftTupleIterator.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/iterators/LeftTupleIterator.java
@@ -32,6 +32,7 @@ import org.drools.core.reteoo.ExistsNode;
 import org.drools.core.reteoo.FromNode;
 import org.drools.core.reteoo.FromNode.FromMemory;
 import org.drools.core.reteoo.JoinNode;
+import org.drools.core.reteoo.BiLinearJoinNode;
 import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.LeftTupleSink;
 import org.drools.core.reteoo.LeftTupleSource;
@@ -98,6 +99,7 @@ public class LeftTupleIterator
 
         switch (source.getType()) {
             case NodeTypeEnums.JoinNode:
+            case NodeTypeEnums.BiLinearJoinNode:
             case NodeTypeEnums.NotNode:
             case NodeTypeEnums.FromNode:
             case NodeTypeEnums.AccumulateNode: {
@@ -263,7 +265,7 @@ public class LeftTupleIterator
                 leftTuple = (TupleImpl) localIt.next(leftTuple );
             }
 
-        } else if ( source instanceof JoinNode || source instanceof NotNode|| source instanceof FromNode || source instanceof AccumulateNode ) {
+        } else if ( source instanceof JoinNode || source instanceof BiLinearJoinNode || source instanceof NotNode|| source instanceof FromNode || source instanceof AccumulateNode ) {
             BetaMemory memory;
             FastIterator localIt;
             if ( source instanceof FromNode ) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/ReteooBuilderPerformanceTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/ReteooBuilderPerformanceTest.java
@@ -21,7 +21,7 @@ package org.drools.mvel.compiler.reteoo;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Collections;
-
+import java.util.HashMap;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.impl.RuleBaseFactory;
@@ -29,6 +29,7 @@ import org.drools.drl.parser.DroolsParserException;
 import org.drools.base.definitions.InternalKnowledgePackage;
 import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.core.reteoo.ReteooBuilder;
+import org.drools.core.reteoo.builder.BiLinearDetector;
 import org.drools.mvel.integrationtests.LargeRuleBase;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ public class ReteooBuilderPerformanceTest {
         long    start   = System.currentTimeMillis();
         for (ReteooBuilder reteBuilder : reteBuilders) {
             for (Rule rule : pkg.getRules())
-                reteBuilder.addRule((RuleImpl)rule, Collections.emptyList());
+                reteBuilder.addRule((RuleImpl)rule, Collections.emptyList(), new BiLinearDetector.BiLinearContext(new HashMap<>(), new HashMap<>()));
         }
         System.out.println("Added "+RULE_COUNT+" rules to each ReteBuilder's in "+
                            format(System.currentTimeMillis()-start));

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/BiLinearNodeNotFormedTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/BiLinearNodeNotFormedTest.java
@@ -1,0 +1,517 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.mvel.integrationtests;
+
+import org.drools.core.reteoo.builder.BiLinearDetector;
+import org.drools.mvel.integrationtests.phreak.A;
+import org.drools.mvel.integrationtests.phreak.B;
+import org.drools.mvel.integrationtests.phreak.C;
+import org.drools.mvel.integrationtests.phreak.D;
+import org.junit.jupiter.api.Test;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for scenarios where BiLinearJoinNodes are NOT created.
+ */
+public class BiLinearNodeNotFormedTest extends BiLinearTestBase {
+
+    @Test
+    public void testSameTypePatternChainNoBiLinear() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : A()\n" +
+                        "    $d : A()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : A()\n" +
+                        "    $c : A()\n" +
+                        "    $d : A()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule3\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : A()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(3, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testShortPatternsNoBiLinear() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $b : B()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $c : B()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+        session.insert(new B(10));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(2, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testEqualLengthRulesNoBiLinear() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $c : B()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+        session.insert(new B(10));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(2, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testEvalConditionNoBiLinear() {
+        // Rules with eval conditions don't participate in BiLinear
+        String drl =
+                "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $s1 : String()\n" +
+                        "    $s2 : String()\n" +
+                        "    eval( 1 == 1 )\n" +
+                        "then\n" +
+                        "end\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $s1 : String()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule3\"\n" +
+                        "when\n" +
+                        "    $s1 : String()\n" +
+                        "    $s2 : String()\n" +
+                        "    $s3 : String()\n" +
+                        "    eval( 1 == 1 )\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert("test");
+
+        int firedRules = session.fireAllRules();
+        assertEquals(3, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearDisabled() {
+        BiLinearDetector.setBiLinearEnabled(false);
+
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+    }
+
+    @Test
+    public void testBiLinearNotFormedWithDifferentBetaConstraintOperators() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C($cVal : object)\n" +
+                        "    $d : D(object > $cVal)\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C($cVal : object)\n" +
+                        "    $d : D(object < $cVal)\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        // Verify constraint evaluation still works correctly
+        KieSession session1 = kieBase.newKieSession();
+        session1.insert(new A(1));
+        session1.insert(new B(1));
+        session1.insert(new C(10));
+        session1.insert(new D(20));
+        session1.insert(new D(5));
+
+        int firedRules1 = session1.fireAllRules();
+        assertEquals(2, firedRules1);
+        session1.dispose();
+    }
+
+    @Test
+    public void testBiLinearNotFormedWithDifferentBetaConstraintEqualsVsGreater() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C($cVal : object)\n" +
+                        "    $d : D(object == $cVal)\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C($cVal : object)\n" +
+                        "    $d : D(object > $cVal)\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(1));
+        session.insert(new B(1));
+        session.insert(new C(10));
+        session.insert(new D(10));
+        session.insert(new D(20));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(2, firedRules);
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearNotFormedWithDifferentAlphaConstraints() {
+        String drl =
+                "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $c : C(object == 5)\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C(object == 10)\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new C(5));
+        session.insert(new C(10));
+        session.insert(new D(1));
+
+        int fired = session.fireAllRules();
+        assertEquals(2, fired);
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearNotFormedWithDifferentAlphaOperators() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $c : C(object > 10)\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C(object < 10)\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(1));
+        session.insert(new C(5));
+        session.insert(new C(15));  // Matches C(object > 10
+        session.insert(new D(1));
+
+        int fired = session.fireAllRules();
+        assertEquals(2, fired);
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearNotFormedWithExtraAlphaConstraint() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $c : C(object > 0)\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        // Verify both rules work correctly
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(1));
+        session.insert(new C(5));
+        session.insert(new D(1));
+
+        int fired = session.fireAllRules();
+        assertEquals(2, fired);
+        session.dispose();
+    }
+
+    @Test
+    public void testBetaConstraintCrossPatternReference() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A($aVal : object)\n" +
+                        "    $b : B()\n" +
+                        "    $c : C(object > $aVal)\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        KieSession session1 = kieBase.newKieSession();
+        session1.insert(new A(5));
+        session1.insert(new B(1));
+        session1.insert(new C(10));
+        session1.insert(new D(1));
+
+        int firedRules1 = session1.fireAllRules();
+        assertEquals(2, firedRules1);
+        session1.dispose();
+
+        KieSession session2 = kieBase.newKieSession();
+        session2.insert(new A(5));
+        session2.insert(new B(1));
+        session2.insert(new C(3));
+        session2.insert(new D(1));
+
+        int firedRules2 = session2.fireAllRules();
+        assertEquals(1, firedRules2);
+        session2.dispose();
+    }
+
+    @Test
+    public void testBiLinearNotAppliedWithCrossNetworkConstraint() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A($aVal : object)\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D(object > $aVal)\n" +  // Cross-network: $aVal from first network, D in second
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+
+        // BiLinear should NOT be applied because of cross-network constraint
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        // Rules should still work correctly using standard joins
+        KieSession session1 = kieBase.newKieSession();
+        session1.insert(new A(10));
+        session1.insert(new B(1));
+        session1.insert(new C(1));
+        session1.insert(new D(20));  // 20 > 10, matches
+
+        int firedRules1 = session1.fireAllRules();
+        assertEquals(2, firedRules1, "Both rules should fire with standard joins");
+        session1.dispose();
+
+        KieSession session2 = kieBase.newKieSession();
+        session2.insert(new A(10));
+        session2.insert(new B(1));
+        session2.insert(new C(1));
+        session2.insert(new D(5));   // 5 NOT > 10, doesn't match Rule1
+
+        int firedRules2 = session2.fireAllRules();
+        assertEquals(1, firedRules2, "Only Rule2 should fire");
+        session2.dispose();
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/BiLinearNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/BiLinearNodeTest.java
@@ -1,0 +1,977 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.mvel.integrationtests;
+
+import org.drools.kiesession.rulebase.InternalKnowledgeBase;
+import org.drools.mvel.integrationtests.phreak.A;
+import org.drools.mvel.integrationtests.phreak.B;
+import org.drools.mvel.integrationtests.phreak.C;
+import org.drools.mvel.integrationtests.phreak.D;
+import org.junit.jupiter.api.Test;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for BiLinear optimization where BiLinearJoinNodes ARE created.
+ * All tests have BiLinear enabled and verify that optimization is applied.
+ */
+public class BiLinearNodeTest extends BiLinearTestBase {
+
+    @Test
+    public void testBiLinear() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+        session.insert(new B(10));
+        session.insert(new C(10));
+        session.insert(new D(10));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(2, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearSwapOrder() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+        session.insert(new B(10));
+        session.insert(new C(10));
+        session.insert(new D(10));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(2, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinear3RuleSetup() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule3\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+        session.insert(new B(10));
+        session.insert(new C(10));
+        session.insert(new D(10));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(3, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinear3RuleSetupShort() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule3\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+        session.insert(new B(10));
+        session.insert(new C(10));
+        session.insert(new D(10));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(3, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinear3RuleSetup2BiLinearNodes() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule3\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 2);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+        session.insert(new B(10));
+        session.insert(new C(10));
+        session.insert(new D(10));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(3, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearChain() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "rule \"Rule3\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule4\"\n" +
+                        "when\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 2);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+        session.insert(new B(10));
+        session.insert(new C(10));
+        session.insert(new D(10));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(4, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearWithSameVariableNames() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c1 : C()\n" +
+                        "    $d1 : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c2 : C()\n" +
+                        "    $d2 : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(1));
+        session.insert(new B(2));
+        session.insert(new C(3));
+        session.insert(new D(4));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(2, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearWithSamePropertyBindings() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A($obj : object)\n" +
+                        "    $b : B()\n" +
+                        "    $c : C($cObj : object)\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C($cObj : object)\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(10));
+        session.insert(new B(20));
+        session.insert(new C(30));
+        session.insert(new D(40));
+
+        int firedRules = session.fireAllRules();
+        assertEquals(2, firedRules);
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearWithMatchingAlphaConstraints() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A(object > 10)\n" +
+                        "    $c : C(object == 5)\n" +
+                        "    $d : D(object < 100)\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C(object == 5)\n" +
+                        "    $d : D(object < 100)\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(15));
+        session.insert(new C(5));
+        session.insert(new D(50));
+
+        int fired = session.fireAllRules();
+        assertEquals(2, fired);
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearWithMatchingAlphaConstraintsNoMatch() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A(object > 10)\n" +
+                        "    $c : C(object == 5)\n" +
+                        "    $d : D(object < 100)\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C(object == 5)\n" +
+                        "    $d : D(object < 100)\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(5));
+        session.insert(new C(10));
+        session.insert(new D(150));
+
+        int fired = session.fireAllRules();
+        assertEquals(0, fired);
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearWithIdenticalBetaConstraints() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"Rule1\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C($cVal : object)\n" +
+                        "    $d : D(object > $cVal)\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"Rule2\"\n" +
+                        "when\n" +
+                        "    $c : C($cVal : object)\n" +
+                        "    $d : D(object > $cVal)\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session1 = kieBase.newKieSession();
+        session1.insert(new A(1));
+        session1.insert(new B(1));
+        session1.insert(new C(10));
+        session1.insert(new D(20));
+
+        int firedRules1 = session1.fireAllRules();
+        assertEquals(2, firedRules1);
+        session1.dispose();
+
+        KieSession session2 = kieBase.newKieSession();
+        session2.insert(new A(1));
+        session2.insert(new B(1));
+        session2.insert(new C(10));
+        session2.insert(new D(5));
+
+        int firedRules2 = session2.fireAllRules();
+        assertEquals(0, firedRules2);
+        session2.dispose();
+    }
+
+    @Test
+    public void testRemoveProviderRuleAfterBiLinearFormed() {
+        String drl =
+                "package org.drools.test\n" +
+                        "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"ConsumerRule\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"ProviderRule\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+        InternalKnowledgeBase kbase = (InternalKnowledgeBase) kieBase;
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session1 = kieBase.newKieSession();
+        session1.insert(new A(1));
+        session1.insert(new B(2));
+        session1.insert(new C(3));
+        session1.insert(new D(4));
+        int firedBefore = session1.fireAllRules();
+        assertEquals(2, firedBefore);
+        session1.dispose();
+
+        kbase.removeRule("org.drools.test", "ProviderRule");
+
+        assertEquals(1, kieBase.getKiePackage("org.drools.test").getRules().size());
+
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session2 = kieBase.newKieSession();
+        session2.insert(new A(1));
+        session2.insert(new B(2));
+        session2.insert(new C(3));
+        session2.insert(new D(4));
+
+        session2.fireAllRules();
+        session2.dispose();
+    }
+
+    @Test
+    public void testRemoveConsumerRuleAfterBiLinearFormed() {
+        String drl =
+                "package org.drools.test\n" +
+                        "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"ConsumerRule\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"ProviderRule\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+        InternalKnowledgeBase kbase = (InternalKnowledgeBase) kieBase;
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session1 = kieBase.newKieSession();
+        session1.insert(new A(1));
+        session1.insert(new B(2));
+        session1.insert(new C(3));
+        session1.insert(new D(4));
+        int firedBefore = session1.fireAllRules();
+        assertEquals(2, firedBefore);
+        session1.dispose();
+
+        kbase.removeRule("org.drools.test", "ConsumerRule");
+
+        assertEquals(1, kieBase.getKiePackage("org.drools.test").getRules().size());
+
+        assertNoBiLinearNodes(visitor, kieBase);
+    }
+
+    @Test
+    public void testRemoveBothRulesAfterBiLinearFormed() {
+        String drl =
+                "package org.drools.test\n" +
+                        "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"ConsumerRule\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"ProviderRule\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+        InternalKnowledgeBase kbase = (InternalKnowledgeBase) kieBase;
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        kbase.removeRule("org.drools.test", "ProviderRule");
+
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        kbase.removeRule("org.drools.test", "ConsumerRule");
+
+        assertNoBiLinearNodes(visitor, kieBase);
+
+        // Verify no rules fire after both removed
+        KieSession session = kieBase.newKieSession();
+        session.insert(new A(1));
+        session.insert(new B(2));
+        session.insert(new C(3));
+        session.insert(new D(4));
+        int firedAfter = session.fireAllRules();
+        assertEquals(0, firedAfter);
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearLeftDelete() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"ConsumerRule\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"ProviderRule\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+
+        A a = new A(1);
+        B b = new B(2);
+        C c = new C(3);
+        D d = new D(4);
+
+        session.insert(a);
+        session.insert(b);
+        session.insert(c);
+        session.insert(d);
+
+        int firedFirst = session.fireAllRules();
+        assertEquals(2, firedFirst, "Both rules should fire initially");
+
+        session.delete(session.getFactHandle(a));
+
+        session.insert(new C(30));
+        session.insert(new D(40));
+
+        int firedSecond = session.fireAllRules();
+        assertEquals(3, firedSecond, "ProviderRule should fire for new C+D combinations");
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearRightDelete() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"ConsumerRule\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"ProviderRule\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+
+        A a = new A(1);
+        B b = new B(2);
+        C c = new C(3);
+        D d = new D(4);
+
+        session.insert(a);
+        session.insert(b);
+        session.insert(c);
+        session.insert(d);
+
+        int firedFirst = session.fireAllRules();
+        assertEquals(2, firedFirst, "Both rules should fire initially");
+
+        session.delete(session.getFactHandle(c));
+
+        int firedSecond = session.fireAllRules();
+        assertEquals(0, firedSecond, "No rules should fire after C is deleted");
+
+        session.insert(new A(10));
+
+        int firedThird = session.fireAllRules();
+        assertEquals(0, firedThird, "No rules should fire without C");
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearLeftUpdate() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"ConsumerRule\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"ProviderRule\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+
+        A a = new A(1);
+        B b = new B(2);
+        C c = new C(3);
+        D d = new D(4);
+
+        session.insert(a);
+        session.insert(b);
+        session.insert(c);
+        session.insert(d);
+
+        int firedFirst = session.fireAllRules();
+        assertEquals(2, firedFirst, "Both rules should fire initially");
+
+        a.setObject(10);
+        session.update(session.getFactHandle(a), a);
+
+        int firedSecond = session.fireAllRules();
+        assertEquals(1, firedSecond, "ConsumerRule should re-fire after updating A");
+
+        session.dispose();
+    }
+
+    @Test
+    public void testBiLinearRightUpdate() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"ConsumerRule\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"ProviderRule\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+
+        A a = new A(1);
+        B b = new B(2);
+        C c = new C(3);
+        D d = new D(4);
+
+        session.insert(a);
+        session.insert(b);
+        session.insert(c);
+        session.insert(d);
+
+        int firedFirst = session.fireAllRules();
+        assertEquals(2, firedFirst, "Both rules should fire initially");
+
+        c.setObject(10);
+        session.update(session.getFactHandle(c), c);
+
+        int firedSecond = session.fireAllRules();
+        assertEquals(2, firedSecond, "Both rules should re-fire after updating C");
+
+        session.dispose();
+    }
+
+    /**
+     * Tests that left-side updates still work correctly after right-side updates have occurred.
+     * This is an edge case where the BiLinear right memory already has staged tuples.
+     */
+    @Test
+    public void testBiLinearLeftUpdateAfterRightUpdate() {
+        String drl =
+                "import " + A.class.getCanonicalName() + "\n" +
+                        "import " + B.class.getCanonicalName() + "\n" +
+                        "import " + C.class.getCanonicalName() + "\n" +
+                        "import " + D.class.getCanonicalName() + "\n" +
+                        "\n" +
+                        "rule \"ConsumerRule\"\n" +
+                        "when\n" +
+                        "    $a : A()\n" +
+                        "    $b : B()\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n" +
+                        "\n" +
+                        "rule \"ProviderRule\"\n" +
+                        "when\n" +
+                        "    $c : C()\n" +
+                        "    $d : D()\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieBase kieBase = buildKieBase(drl);
+
+        NetworkVisitor visitor = new NetworkVisitor();
+        visitor.debugNetworkStructure(kieBase);
+        assertBiLinearNodeCount(visitor, kieBase, 1);
+
+        KieSession session = kieBase.newKieSession();
+
+        A a = new A(1);
+        B b = new B(2);
+        C c = new C(3);
+        D d = new D(4);
+
+        session.insert(a);
+        session.insert(b);
+        session.insert(c);
+        session.insert(d);
+
+        int firedFirst = session.fireAllRules();
+        assertEquals(2, firedFirst, "Both rules should fire initially");
+
+        // First update C (right side) to populate BiLinear right memory with updates
+        c.setObject(30);
+        session.update(session.getFactHandle(c), c);
+        int firedAfterC = session.fireAllRules();
+        assertEquals(2, firedAfterC, "Both rules should re-fire after updating C");
+
+        // Now update A (left side) - this should still work after right-side updates
+        a.setObject(10);
+        session.update(session.getFactHandle(a), a);
+
+        int firedAfterA = session.fireAllRules();
+        assertEquals(1, firedAfterA, "ConsumerRule should re-fire after updating A");
+
+        session.dispose();
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/BiLinearTestBase.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/BiLinearTestBase.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.mvel.integrationtests;
+
+import org.drools.base.common.NetworkNode;
+import org.drools.core.reteoo.builder.BiLinearDetector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.api.KieBase;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.utils.KieHelper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base class for BiLinear tests providing common setup, teardown, and assertion methods.
+ */
+public abstract class BiLinearTestBase {
+
+    @BeforeEach
+    public void setUp() {
+        BiLinearDetector.setBiLinearEnabled(true);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        BiLinearDetector.setBiLinearEnabled(false);
+    }
+
+    protected KieBase buildKieBase(String drl) {
+        KieHelper kieHelper = new KieHelper();
+        kieHelper.addContent(drl, ResourceType.DRL);
+        return kieHelper.build();
+    }
+
+    protected void assertBiLinearNodeCount(NetworkVisitor visitor, KieBase kieBase, int bilinearNodeCount) {
+        List<NetworkNode> biLinearNodes = visitor.findBiLinearJoinNodes(kieBase);
+
+        assertThat(biLinearNodes)
+                .as("BiLinear optimization should create BiLinearJoinNode(s)")
+                .isNotEmpty();
+
+        assertThat(biLinearNodes).hasSize(bilinearNodeCount);
+    }
+
+    protected void assertNoBiLinearNodes(NetworkVisitor visitor, KieBase kieBase) {
+        List<NetworkNode> biLinearNodes = visitor.findBiLinearJoinNodes(kieBase);
+
+        assertThat(biLinearNodes)
+                .as("BiLinearJoinNodes should not be created")
+                .isEmpty();
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NetworkVisitor.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NetworkVisitor.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.mvel.integrationtests;
+
+import org.drools.base.common.NetworkNode;
+import org.drools.core.impl.InternalRuleBase;
+import org.drools.core.reteoo.AlphaNode;
+import org.drools.core.reteoo.EntryPointNode;
+import org.drools.core.reteoo.JoinNode;
+import org.drools.core.reteoo.LeftInputAdapterNode;
+import org.drools.core.reteoo.LeftTupleSink;
+import org.drools.core.reteoo.LeftTupleSource;
+import org.drools.core.reteoo.ObjectSource;
+import org.drools.core.reteoo.ObjectTypeNode;
+import org.drools.core.reteoo.Rete;
+import org.drools.core.reteoo.RightInputAdapterNode;
+import org.drools.core.reteoo.RuleTerminalNode;
+import org.kie.api.KieBase;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class NetworkVisitor {
+
+    public void debugNetworkStructure(KieBase kbase) {
+        System.out.println("╔══════════════════════════════════════════════════════════════╗");
+        System.out.println("║                    NETWORK STRUCTURE DEBUG                  ║");
+        System.out.println("╚══════════════════════════════════════════════════════════════╝");
+
+        Rete rete = ((InternalRuleBase) kbase).getRete();
+        List<ObjectTypeNode> objectTypeNodes = rete.getObjectTypeNodes();
+
+        // Collect bugs during traversal
+        List<String> bugs = new ArrayList<>();
+
+        System.out.println("\n📊 ObjectTypeNodes found: " + objectTypeNodes.size());
+        System.out.println("┌─────────────────────────────────────────────────────────────┐");
+
+        for (ObjectTypeNode otn : objectTypeNodes) {
+            String className = otn.getObjectType().toString();
+            if (className.contains("class=")) {
+                className = className.substring(className.lastIndexOf('.') + 1, className.lastIndexOf(']'));
+            }
+            System.out.println("│ 🏭 OTN: " + className + " (id=" + otn.getId() + ")");
+
+            debugSinks(otn.getObjectSinkPropagator().getSinks(), "│   ", new java.util.HashSet<>(), bugs);
+            System.out.println("│");
+        }
+        System.out.println("└─────────────────────────────────────────────────────────────┘");
+
+        // Report bugs summary
+        if (!bugs.isEmpty()) {
+            System.out.println("\n╔══════════════════════════════════════════════════════════════╗");
+            System.out.println("║              ⚠️  NETWORK BUGS DETECTED (" + bugs.size() + ")                    ║");
+            System.out.println("╚══════════════════════════════════════════════════════════════╝");
+            for (int i = 0; i < bugs.size(); i++) {
+                System.out.println("  " + (i + 1) + ". " + bugs.get(i));
+            }
+            System.out.println();
+        }
+    }
+
+    private void debugSinks(Object[] sinks, String indent, java.util.Set<Integer> visited, List<String> bugs) {
+        if (sinks == null) return;
+
+        for (int i = 0; i < sinks.length; i++) {
+            Object sink = sinks[i];
+            int nodeId = ((NetworkNode) sink).getId();
+            boolean isLast = (i == sinks.length - 1);
+            String branch = isLast ? "└─" : "├─";
+            String nextIndent = indent + (isLast ? "  " : "│ ");
+
+            String sinkIcon = getSinkIcon(sink);
+            String nodeInfo = getDetailedNodeInfo(sink, bugs);
+
+            // Check for cycle
+            if (visited.contains(nodeId)) {
+                System.out.println(indent + branch + " ↺ [Already visited: " + sink.getClass().getSimpleName() +
+                        " (id=" + nodeId + ")]");
+                continue;
+            }
+            visited.add(nodeId);
+
+            System.out.println(indent + branch + " " + sinkIcon + " " + sink.getClass().getSimpleName() +
+                    " (id=" + nodeId + ")" + nodeInfo);
+
+            visitSink(nextIndent, sink, visited, bugs);
+        }
+    }
+
+    private String getDetailedNodeInfo(Object sink, List<String> bugs) {
+        if (sink instanceof AlphaNode alphaNode) {
+            return " 🔍 [" + alphaNode.getConstraint() + "]";
+        } else if (sink.getClass().getSimpleName().equals("BiLinearJoinNode")) {
+            // Handle BiLinearJoinNode specifically - show left and right input IDs
+            try {
+                int nodeId = ((NetworkNode) sink).getId();
+                Object leftInput = sink.getClass().getMethod("getLeftTupleSource").invoke(sink);
+                Object secondInput = sink.getClass().getMethod("getSecondLeftInput").invoke(sink);
+                int leftId = leftInput != null ? ((NetworkNode) leftInput).getId() : -1;
+                int rightId = secondInput != null ? ((NetworkNode) secondInput).getId() : -1;
+
+                // Check for self-reference BUG
+                StringBuilder info = new StringBuilder(" 🔗 [left=" + leftId + ", right=" + rightId + "]");
+                if (rightId == nodeId) {
+                    String bugMsg = "BiLinearJoinNode (id=" + nodeId + ") references ITSELF as secondLeftInput (right=" + rightId + ")";
+                    info.append(" ⚠️ BUG: SELF-REFERENCE!");
+                    if (bugs != null) bugs.add(bugMsg);
+                }
+                if (leftId == nodeId) {
+                    String bugMsg = "BiLinearJoinNode (id=" + nodeId + ") references ITSELF as leftInput (left=" + leftId + ")";
+                    info.append(" ⚠️ BUG: SELF-REFERENCE!");
+                    if (bugs != null) bugs.add(bugMsg);
+                }
+                return info.toString();
+            } catch (Exception e) {
+                return " 🔗 [error getting inputs: " + e.getMessage() + "]";
+            }
+        } else if (sink instanceof JoinNode joinNode) {
+            if (joinNode.getConstraints().length == 0) {
+                return " 🔗 [no constraints]";
+            } else {
+                String constraints = String.join(", ",
+                        java.util.Arrays.stream(joinNode.getConstraints())
+                                .map(Object::toString)
+                                .toArray(String[]::new));
+                return " 🔗 [" + constraints + "]";
+            }
+        } else if (sink instanceof RuleTerminalNode rtn) {
+            return " 🏁 [" + rtn.getRule().getName() + "]";
+        }
+        return "";
+    }
+
+    private void visitSink(String indent, Object sink, java.util.Set<Integer> visited, List<String> bugs) {
+        if (sink instanceof AlphaNode) {
+            AlphaNode alphaNode = (AlphaNode) sink;
+            debugSinks(alphaNode.getObjectSinkPropagator().getSinks(), indent, visited, bugs);
+        } else if (sink instanceof LeftTupleSource lts) {
+            // Generic handling for ALL LeftTupleSource types:
+            // JoinNode, EvalConditionNode, NotNode, ExistsNode, FromNode, LeftInputAdapterNode, etc.
+            LeftTupleSink[] sinks = lts.getSinkPropagator().getSinks();
+            if (sinks != null && sinks.length > 0) {
+                for (int j = 0; j < sinks.length; j++) {
+                    LeftTupleSink js = sinks[j];
+                    int nodeId = js.getId();
+                    boolean isLastSink = (j == sinks.length - 1);
+                    String branch = isLastSink ? "└─" : "├─";
+                    String nextIndent = indent + (isLastSink ? "  " : "│ ");
+
+                    // Check for cycle
+                    if (visited.contains(nodeId)) {
+                        System.out.println(indent + branch + " ↺ [Already visited: " + js.getClass().getSimpleName() +
+                                " (id=" + nodeId + ")]");
+                        continue;
+                    }
+                    visited.add(nodeId);
+
+                    String jsIcon = getSinkIcon(js);
+                    String jsInfo = getDetailedNodeInfo(js, bugs);
+
+                    System.out.println(indent + branch + " " + jsIcon + " " + js.getClass().getSimpleName() +
+                            " (id=" + js.getId() + ")" + jsInfo);
+
+                    if (!(js instanceof RuleTerminalNode)) {
+                        visitSink(nextIndent, js, visited, bugs);
+                    }
+                }
+            }
+        } else if (sink instanceof RightInputAdapterNode right) {
+            System.out.println(indent + "├─ ➡️  Adapts to: " + right.getBetaNode().getClass().getSimpleName() +
+                    " (id=" + right.getBetaNode().getId() + ")");
+        }
+    }
+
+    private String getSinkIcon(Object sink) {
+        if (sink instanceof LeftInputAdapterNode) return "⬅️";
+        if (sink.getClass().getSimpleName().equals("BiLinearJoinNode")) return "🔗";
+        if (sink instanceof JoinNode) return "🔗";
+        if (sink instanceof RightInputAdapterNode) return "➡️";
+        if (sink instanceof AlphaNode) return "🔍";
+        if (sink instanceof RuleTerminalNode) return "🏁";
+        if (sink instanceof ObjectTypeNode) return "📦";
+        return "⚪";
+    }
+
+    /**
+     * Finds all BiLinearJoinNodes in the network.
+     * @param kbase The KieBase to search
+     * @return List of BiLinearJoinNode instances (as NetworkNode)
+     */
+    public List<NetworkNode> findBiLinearJoinNodes(KieBase kbase) {
+        List<NetworkNode> biLinearNodes = new ArrayList<>();
+        Rete rete = ((InternalRuleBase) kbase).getRete();
+        collectBiLinearNodes(rete, biLinearNodes, new HashSet<>());
+        return biLinearNodes;
+    }
+
+    private void collectBiLinearNodes(NetworkNode node, List<NetworkNode> biLinearNodes, Set<Integer> visited) {
+        if (visited.contains(node.getId())) {
+            return;
+        }
+        visited.add(node.getId());
+
+        String className = node.getClass().getSimpleName();
+        if (className.equals("BiLinearJoinNode")) {
+            biLinearNodes.add(node);
+        }
+
+        // Traverse children based on node type
+        // Check Rete and EntryPointNode FIRST before ObjectSource since they have specialized handling
+        if (node instanceof Rete) {
+            for (EntryPointNode epn : ((Rete) node).getEntryPointNodes().values()) {
+                collectBiLinearNodes(epn, biLinearNodes, visited);
+            }
+        } else if (node instanceof EntryPointNode) {
+            for (ObjectTypeNode otn : ((EntryPointNode) node).getObjectTypeNodes().values()) {
+                collectBiLinearNodes(otn, biLinearNodes, visited);
+            }
+        } else if (node instanceof ObjectSource) {
+            for (Object sink : ((ObjectSource) node).getObjectSinkPropagator().getSinks()) {
+                collectBiLinearNodes((NetworkNode) sink, biLinearNodes, visited);
+            }
+        }
+
+        // Also check LeftTupleSource sinks (not else-if, since some nodes are both)
+        if (node instanceof LeftTupleSource) {
+            LeftTupleSink[] sinks = ((LeftTupleSource) node).getSinkPropagator().getSinks();
+            if (sinks != null) {
+                for (LeftTupleSink sink : sinks) {
+                    collectBiLinearNodes(sink, biLinearNodes, visited);
+                }
+            }
+        }
+    }
+
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/D.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/D.java
@@ -19,48 +19,36 @@
 package org.drools.mvel.integrationtests.phreak;
 
 import org.kie.api.definition.type.Position;
-import java.util.List;
-import java.util.ArrayList;
 
-public class A {
+public class D {
 
     @Position(0)
-    Integer object;
-    
-    private List<Object> children = new ArrayList<>();
+    Object object;
 
-    public A(Integer object) {
+    public D(Object object) {
         super();
         this.object = object;
     }
-    
-    public static A a(Integer object) {
-        return new A( object );
+
+    public static D d(Object object) {
+        return new D( object );
     }
 
-    public static A[] a(Integer... objects) {
-        A[] as = new A[objects.length];
+    public static D[] d(Object... objects) {
+        D[] ds = new D[objects.length];
         int i = 0;
-        for ( Integer object : objects ) {
-            as[i++] = new A( object );
+        for ( Object object : objects ) {
+            ds[i++] = new D( object );
         }
-        return as;
+        return ds;
     }        
 
     public Object getObject() {
         return object;
     }
 
-    public void setObject(Integer object) {
+    public void setObject(Object object) {
         this.object = object;
-    }
-
-    public List<Object> getChildren() {
-        return children;
-    }
-    
-    public void setChildren(List<Object> children) {
-        this.children = children;
     }
 
     @Override
@@ -76,7 +64,7 @@ public class A {
         if ( this == obj ) return true;
         if ( obj == null ) return false;
         if ( getClass() != obj.getClass() ) return false;
-        A other = (A) obj;
+        D other = (D) obj;
         if ( object == null ) {
             if ( other.object != null ) return false;
         } else if ( !object.equals( other.object ) ) return false;
@@ -85,7 +73,7 @@ public class A {
 
     @Override
     public String toString() {
-        return "A[" + object + "]";
+        return "D [" + object + "]";
     }
 
 }


### PR DESCRIPTION
Fixes: https://github.com/apache/incubator-kie/issues/7045

Explanations that hopefully help understanding the code changes.

First of all. Bilinear is off by default. The default setting can be changed with `drools.bilinear.enabled=true`. I have also built the entire code base with bilinear enabled and it passes.

The goal is to share a part of the network. 
`rule1 has A() B() C() D()` 
and 
`rule2 has C() D() // We can share C() D()`

We can only share if there are no references between from the shared part to the rest of the rule. 
```
rule1 A(x:x) B() C(x == x) D()
rule2 C(x == x) D() // This does not work.
```

# Network structure
## Without bilinear join
```
📊 ObjectTypeNodes found: 5
┌─────────────────────────────────────────────────────────────┐
│ 🏭 OTN: A (id=3)
│   └─ ⬅️ LeftInputAdapterNode (id=4)
│     └─ 🔗 JoinNode (id=7) 🔗 [no constraints]
│       └─ 🔗 JoinNode (id=10) 🔗 [no constraints]
│         └─ 🔗 JoinNode (id=13) 🔗 [no constraints]
│           └─ 🏁 RuleTerminalNode (id=14) 🏁 [Rule1]
│
│ 🏭 OTN: B (id=5)
│   └─ ➡️ JoinRightAdapterNode (id=6)
│     ├─ ➡️  Adapts to: JoinNode (id=7)
│
│ 🏭 OTN: C (id=8)
│   ├─ ➡️ JoinRightAdapterNode (id=9)
│   │ ├─ ➡️  Adapts to: JoinNode (id=10)
│   └─ ⬅️ LeftInputAdapterNode (id=15)
│     └─ 🔗 JoinNode (id=17) 🔗 [no constraints]
│       └─ 🏁 RuleTerminalNode (id=18) 🏁 [Rule2]
│
│ 🏭 OTN: D (id=11)
│   ├─ ➡️ JoinRightAdapterNode (id=12)
│   │ ├─ ➡️  Adapts to: JoinNode (id=13)
│   └─ ➡️ JoinRightAdapterNode (id=16)
│     ├─ ➡️  Adapts to: JoinNode (id=17)
│
│ 🏭 OTN: InitialFactImpl (id=2)
│
└─────────────────────────────────────────────────────────────┘
```
## With bilinear join
```
📊 ObjectTypeNodes found: 5
┌─────────────────────────────────────────────────────────────┐
│ 🏭 OTN: A (id=9)
│   └─ ⬅️ LeftInputAdapterNode (id=10)
│     └─ 🔗 JoinNode (id=13) 🔗 [no constraints]
│       └─ 🔗 BiLinearJoinNode (id=14) 🔗 [left=13, right=7]
│         └─ 🏁 RuleTerminalNode (id=15) 🏁 [Rule1]
│
│ 🏭 OTN: B (id=11)
│   └─ ➡️ JoinRightAdapterNode (id=12)
│     ├─ ➡️  Adapts to: JoinNode (id=13)
│
│ 🏭 OTN: C (id=3)
│   └─ ⬅️ LeftInputAdapterNode (id=4)
│     └─ 🔗 JoinNode (id=7) 🔗 [no constraints]
│       ├─ 🏁 RuleTerminalNode (id=8) 🏁 [Rule2]
│       └─ 🔗 BiLinearJoinNode (id=14) 🔗 [left=13, right=7]
│         └─ 🏁 RuleTerminalNode (id=15) 🏁 [Rule1]
│
│ 🏭 OTN: D (id=5)
│   └─ ➡️ JoinRightAdapterNode (id=6)
│     ├─ ➡️  Adapts to: JoinNode (id=7)
│
│ 🏭 OTN: InitialFactImpl (id=2)
│
└─────────────────────────────────────────────────────────────┘
```

Before building the network we use `BiLinearDetector` to find candidates for bilinear joins. 
Right now the mechanism is limited. We only look for other rules that already create a network that can be shared with the end of another rule. This is one of the improvement points for the future.
It uses hashes for each pattern and generates a tail hash, that is the hash for the chain of patterns starting from the current pattern and including every pattern after it. Once two hashes are same, we can share that part of the network.

Each bilinear opportunity is a `JoinNode` that can be replaced with a `BiLinearJoinNode`.
`BiLinearJoinNode` takes two left inputs, instread of a left and right. To make this work, `BetaRightInput` was added as an interface to serve the right input for other nodes and second left for `BiLinearJoinNode`.
`BiLinearJoinNode` takes the first left input when rule1 is created ( A() B() -> BiLinear join ), this leaves it half done. Then when the second rule2 is created we link the other left bringing in the shared network, ( D() C() -> BiLinear join ). Due to this the order of the rule creation sometimes needs to be reordered.

This PR proves that bilinear joins works. There next step after this is to increase the bilinear reuse.
* Detect network areas that can be shared from any part of the rule. Look for independent isolated sections that appear in other rules.
* Get rid of the rule ordering issue, just build the network parts that are shared last. Not rules.
* The shared network should support bilinear joins inside bilinear joins.

The additional changes will be smaller PRs. I have experimented with a solution for each task, but haven't done a perfectly working solution yet.
One of the use cases that will get the most out of these changes is decision table like structures where certain patterns and constraints tend to repeat.