### PR TITLE
[NO-ISSUE] Fixing jackson after quarkus upgrade

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -470,10 +470,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -470,6 +470,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/pom.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/pom.xml
@@ -86,6 +86,23 @@
                     <artifactId>drools-drlonyaml-schemagen</artifactId>
                     <version>${project.version}</version>
                 </dependency>
+                <!-- Pin Jackson to match project version; victools 4.37.0 brings 2.17.2
+                     which conflicts with jackson-databind 2.19.2 in exec:java classpath -->
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                    <version>${version.com.fasterxml.jackson.annotations}</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                    <version>${version.com.fasterxml.jackson.databind}</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <version>${version.com.fasterxml.jackson}</version>
+                </dependency>
             </dependencies>
         </plugin>
     </plugins>


### PR DESCRIPTION
Pin Jackson 2.19.2 as explicit plugin dependencies in drools-drlonyaml-model's exec-maven-plugin to resolve NoSuchMethodError during build in kie-tools