### PR TITLE
[NO-ISSUE] max-parallel for GHA

### DIFF
--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -38,6 +38,7 @@ jobs:
       cancel-in-progress: true
     timeout-minutes: 180
     strategy:
+      max-parallel: 20
       matrix:
         job_name: [ optaplanner, kogito-runtimes, kogito-apps, kogito-quarkus-examples, kogito-springboot-examples, serverless-workflow-examples, kogito-gradle-examples  ]
         os: [ubuntu-latest]


### PR DESCRIPTION
ASF Infrastructure notified us of the following issue:
```
Our analysis has found that the following GitHub Actions workflows need remediation:
        Kogito Downstream: `max-parallel: 20` is required for job matrices. see https://s.apache.org/max-parallel for more details
```
In our case, the number of jobs is currently 7, which is below the limit of 20. However, this appears to be a precautionary requirement, so I’ve applied the fix.