### PR TITLE
[incubator-kie-issues#2262] Fix dmn/efesto LocalUriId generation inside gradle context

### DIFF
--- a/kie-dmn/kie-dmn-efesto-compilation/src/main/java/org/kie/dmn/efesto/compiler/utils/DmnCompilerUtils.java
+++ b/kie-dmn/kie-dmn-efesto-compilation/src/main/java/org/kie/dmn/efesto/compiler/utils/DmnCompilerUtils.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
+
 import org.kie.api.builder.Message;
 import org.kie.api.io.Resource;
 import org.kie.dmn.api.core.DMNMessage;
@@ -42,12 +43,14 @@ import java.util.List;
 public class DmnCompilerUtils {
 
     static final List<String> CLEANABLE_PATTERNS = Arrays.asList("main/resources",
-                                                                 "main/java",
-                                                                 "test/resources",
-                                                                 "test/java",
-                                                                 "target/generated-resources",
-                                                                 "target/classes",
-                                                                 "target/test-classes");
+            "main/java",
+            "test/resources",
+            "test/java",
+            "target/generated-resources",
+            "target/classes",
+            "target/test-classes",
+            "build/resources/main",
+            "build/resources/test");
 
     private DmnCompilerUtils() {
         // avoid instantiation
@@ -120,6 +123,7 @@ public class DmnCompilerUtils {
     /**
      * This method remove unwanted preceding paths from given <code>File</code>, and always returns a <b>/</b>-separated path,
      * without leading <b>/</b>
+     *
      * @param fileToClean
      * @return
      */
@@ -130,6 +134,7 @@ public class DmnCompilerUtils {
     /**
      * This method remove unwanted preceding paths from given <code>String</code>, and always returns a <b>/</b>-separated path,
      * without leading <b>/</b>
+     *
      * @param filenameToClean
      * @return
      */
@@ -149,8 +154,9 @@ public class DmnCompilerUtils {
 
     /**
      * This method remove unwanted preceding paths from given <code>String</code> and always returns a <b>/</b>-separated path,
+     *
      * @param filenameToClean
-     *  @param patternToClean
+     * @param patternToClean
      * @return
      */
     static String getCleanedFileNameForURIByPattern(String filenameToClean, String patternToClean) {


### PR DESCRIPTION
Fixes: https://github.com/apache/incubator-kie-issues/issues/2262

Needed by: https://github.com/apache/incubator-kie-kogito-examples/pull/2183

This PR extend the LocalUriId name generation, inside DMN, to consider the gradle building context

@AthiraHari77 @ChinchuAjith Could you please take a look ? Thanks!

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
