### PR TITLE
[incubator-kie-issues#2265] fix [CWE][High]CWE-22: Path/Directory Traversal in drools

### DIFF
--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/DiskResourceStore.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/DiskResourceStore.java
@@ -18,6 +18,7 @@
  */
 package org.kie.maven.plugin;
 
+import org.drools.util.PathUtils;
 import org.drools.util.PortablePath;
 import org.kie.memorycompiler.resources.ResourceStore;
 
@@ -25,7 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class DiskResourceStore implements ResourceStore {
 
@@ -77,7 +77,7 @@ public class DiskResourceStore implements ResourceStore {
 
     private void commonWrite(String fullPath, byte[] pResourceData, boolean createFolder) {
         try {
-            final Path path = Paths.get(fullPath).normalize();
+            final Path path = PathUtils.getSecuredPath(root.toPath(), fullPath);
             if (createFolder) {
                 final Path parentPath = path.getParent();
                 if (parentPath != null) {
@@ -92,7 +92,8 @@ public class DiskResourceStore implements ResourceStore {
 
     private byte[] commonRead(String fullPath) {
         try {
-            return Files.readAllBytes(Paths.get(fullPath).normalize());
+            final Path path = PathUtils.getSecuredPath(root.toPath(), fullPath);
+            return Files.readAllBytes(path);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -100,7 +101,8 @@ public class DiskResourceStore implements ResourceStore {
 
     private void commonRemove(String fullPath) {
         try {
-            Files.deleteIfExists(Paths.get(fullPath).normalize());
+            final Path path = PathUtils.getSecuredPath(root.toPath(), fullPath);
+            Files.deleteIfExists(path);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Closes : https://github.com/apache/incubator-kie-issues/issues/2265

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
