### PR TITLE
[incubator-kie-drools-6620] Warning: Bad option value in "-JDK_VERSIO…

### DIFF
--- a/drools-model/drools-mvel-parser/pom.xml
+++ b/drools-model/drools-mvel-parser/pom.xml
@@ -73,7 +73,6 @@
             </goals>
             <configuration>
               <grammarEncoding>${project.build.sourceEncoding}</grammarEncoding>
-              <jdkVersion>${java.version}</jdkVersion>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
…N=17.0.9" will be ignored.

- https://github.com/apache/incubator-kie-drools/issues/6620

`17.0.9` comes from `<jdkVersion>${java.version}</jdkVersion>` which is an actual JDK version running maven. https://github.com/apache/incubator-kie-drools/blob/10.1.0/drools-model/drools-mvel-parser/pom.xml#L76

It's not accepted by parser-generator-cc , then falls back to `JDK_VERSION = "1.8";` configured in mvel.jj : https://github.com/apache/incubator-kie-drools/blob/10.1.0/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj#L40

The warning is harmless and it should be fine with the default `1.8` . So I'll remove the `<jdkVersion>${java.version}</jdkVersion>`  line to avoid the confusion.