### PR TITLE
Fix `spotbug-maven-plugin` usage

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -177,8 +177,7 @@
     <enforcer.failOnBannedDependencies>true</enforcer.failOnBannedDependencies>
     <!-- Set to "true" on every project that has no violations. -->
     <spotbugs.failOnViolation>false</spotbugs.failOnViolation>
-    <!-- replaces findbugs-maven-plugin -->
-    <version.com.github.spotbugs-maven-plugin>3.1.8</version.com.github.spotbugs-maven-plugin>
+    <version.com.github.spotbugs-maven-plugin>4.9.8.3</version.com.github.spotbugs-maven-plugin>
 
     <version.maven.min>3.8.1</version.maven.min>
     <!-- property for productisation to know the last released version -->
@@ -1935,19 +1934,11 @@
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>${version.com.github.spotbugs-maven-plugin}</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.kie</groupId>
-              <artifactId>kie-build-tools</artifactId>
-              <version>${project.version}</version>
-            </dependency>
-          </dependencies>
           <configuration>
             <maxRank>6</maxRank>
             <effort>Max</effort>
             <xmlOutput>true</xmlOutput>
             <failOnError>${spotbugs.failOnViolation}</failOnError>
-            <excludeFilterFile>spotbugs-excludes.xml</excludeFilterFile>
           </configuration>
         </plugin>
         <plugin>

--- a/drools-base/pom.xml
+++ b/drools-base/pom.xml
@@ -214,9 +214,6 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${project.basedir}/src/main/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
-        </configuration>
       </plugin>
 
     </plugins>

--- a/drools-base/src/main/java/org/drools/base/definitions/impl/KnowledgePackageImpl.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/impl/KnowledgePackageImpl.java
@@ -614,7 +614,7 @@ public class KnowledgePackageImpl
             Class<?> typeClass = null;
             try {
                 typeClass = typeDeclaration.getTypeClass();
-                if (typeClass != null || !typeClass.isPrimitive()) {
+                if (typeClass != null && !typeClass.isPrimitive()) {
                     Class<?> cls = getPackageClassLoader().loadClass(typeClass.getName());
                     typeDeclaration.setTypeClass(cls);
                 }

--- a/drools-base/src/main/java/org/drools/base/definitions/impl/KnowledgePackageImpl.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/impl/KnowledgePackageImpl.java
@@ -833,4 +833,3 @@ public class KnowledgePackageImpl
         this.cloningResources.put(key, resource);
     }
 }
-

--- a/drools-base/src/main/java/org/drools/base/definitions/impl/KnowledgePackageImpl.java
+++ b/drools-base/src/main/java/org/drools/base/definitions/impl/KnowledgePackageImpl.java
@@ -833,3 +833,4 @@ public class KnowledgePackageImpl
         this.cloningResources.put(key, resource);
     }
 }
+

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -185,7 +185,6 @@
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <configuration>
-            <excludeFilterFile>${project.basedir}/src/main/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
             <maxHeap>1024</maxHeap> <!-- MB -->
           </configuration>
         </plugin>

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -225,9 +225,6 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${project.basedir}/src/main/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/drools-drl/drools-drl-parser/pom.xml
+++ b/drools-drl/drools-drl-parser/pom.xml
@@ -105,7 +105,6 @@
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
                     <configuration>
-                        <excludeFilterFile>${project.basedir}/src/main/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
                         <maxHeap>1024</maxHeap> <!-- MB -->
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2279

Summary of Changes in This PR

- Removed the kie-build-tools dependency from the SpotBugs configuration. It points to an old external module, and version 999-SNAPSHOT is no longer available, which breaks dependency resolution.
- Removed references to missing SpotBugs exclude filter files. These references pointed to files that no longer exist and to the kie-build-tools JAR.
- Upgraded the spotbugs-maven-plugin.
- Fixed a potential NullPointerException detected by the `spotbugs-maven-plugin`.

As a follow-up, we could agree to enable the `spotbugs-maven-plugin` in this project’s submodules (namely `drools-base`, `drools-compiler`, `drools-core`, and `drools-drl-parser` that already declare it) so that the build fails when SpotBugs detects any issues at compile time.
It appears there was already an intention to enable this behavior in the past, since the following configuration is present in the Drools build-parent POM:
```
    <!-- Set to "true" on every project that has no violations. -->
    <spotbugs.failOnViolation>false</spotbugs.failOnViolation>
```

To enable this in specific submodules, we should:

1. In the target submodule’s pom.xml, set spotbugs.failOnViolation to true under <properties>.
2. Keep the spotbugs-maven-plugin execution bound to the verify phase, with both the spotbugs and check goals enabled:

```
<plugin>
  <groupId>com.github.spotbugs</groupId>
  <artifactId>spotbugs-maven-plugin</artifactId>
  <executions>
    <execution>
      <id>spotbugs</id>
      <phase>verify</phase>
      <goals>
        <goal>spotbugs</goal>
        <goal>check</goal>
      </goals>
    </execution>
  </executions>
</plugin>
```