### PR TITLE
Fix CVE-2026-1002- Update vertx-core to 4.5.24

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -222,12 +222,18 @@
     <version.archunit.maven.plugin>4.0.2</version.archunit.maven.plugin>
     <version.archunit.junit5>1.4.0</version.archunit.junit5>
 
-    <version.io.vertx>4.5.23</version.io.vertx>
+    <version.io.vertx>4.5.24</version.io.vertx>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <!-- Version overrides to fix vulnerabilities. -->
+      <!-- Override vertx-core version from Quarkus 3.27.2 BOM (CVE fix) -->
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-core</artifactId>
+        <version>${version.io.vertx}</version>
+      </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web</artifactId>


### PR DESCRIPTION
Override vertx-core version from Quarkus BOM 3.27.2
related PR-https://github.com/apache/incubator-kie-kogito-runtimes/pull/4242
