### PR TITLE
[incubator-kie-issues#2164] Implemented ModelBuildContextUtils to provide utility method for YaML loading. 

### DIFF
--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/AbstractDroolsModelBuildContext.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/AbstractDroolsModelBuildContext.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.TreeMap;
 import java.util.function.Predicate;
 
 import javax.lang.model.SourceVersion;
@@ -41,7 +40,8 @@ import org.drools.codegen.common.di.DependencyInjectionAnnotator;
 import org.drools.codegen.common.rest.RestAnnotator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
+
+import static org.drools.codegen.common.context.ModelBuildContextUtils.loadYmlProperties;
 
 public abstract class AbstractDroolsModelBuildContext implements DroolsModelBuildContext {
 
@@ -89,55 +89,6 @@ public abstract class AbstractDroolsModelBuildContext implements DroolsModelBuil
             loadYmlProperties(ymlFile, applicationProperties);
         }
         return applicationProperties;
-    }
-
-    protected static void loadYmlProperties(File ymlFile, Properties applicationProperties) {
-        Map<String, String> ymlMap  = loadYmlStringMap(ymlFile);
-        if (ymlMap != null) {
-            applicationProperties.putAll(ymlMap);
-        }
-    }
-
-    protected static Map<String, String> loadYmlStringMap(File ymlFile) {
-        TreeMap<String, Object> ymlMap = loadYmlMap(ymlFile);
-        if (ymlMap != null) {
-            return convertYamlObjectToMap(ymlMap);
-        } else {
-            return null;
-        }
-    }
-
-    protected static TreeMap<String, Object> loadYmlMap(File ymlFile) {
-        if (ymlFile.exists() && ymlFile.isFile() && ymlFile.canRead()) {
-            Yaml yaml = new Yaml();
-            try (FileReader yamlFileReader = new FileReader(ymlFile, StandardCharsets.UTF_8)){
-                return yaml.loadAs(yamlFileReader, TreeMap.class);
-            } catch (IOException e) {
-                LOGGER.debug("Unable to load '{}'.", ymlFile.getName(), e);
-            }
-        } else {
-            LOGGER.debug("Unable to load '{}'.", ymlFile.getName());
-        }
-        return null;
-    }
-
-    protected static Map<String, String> convertYamlObjectToMap(TreeMap<String, Object> toConvert) {
-        Map<String, String> toReturn = new HashMap<>();
-        convertYamlObjectToMap(toConvert, new StringBuilder(), toReturn);
-        return toReturn;
-    }
-
-    protected static void convertYamlObjectToMap(Map<String, Object> toRead, StringBuilder builder, Map<String, String> toPopulate) {
-        toRead.forEach((key, value) -> {
-            if (value instanceof Map) {
-                StringBuilder newBuilder = new StringBuilder(builder);
-                convertYamlObjectToMap((Map<String, Object>) value, newBuilder.append(key).append("."), toPopulate);
-            } else {
-                String property = builder.toString() + key;
-                String propertyValue = value != null ? value.toString() : "";
-                toPopulate.put(property, propertyValue);
-            }
-        });
     }
 
     public boolean hasClassAvailable(String fqcn) {

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/ModelBuildContextUtils.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/ModelBuildContextUtils.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.codegen.common.context;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+
+public class ModelBuildContextUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModelBuildContextUtils.class);
+
+    public static void loadYmlProperties(File ymlFile, Properties applicationProperties) {
+        if (ymlFile.exists() && ymlFile.isFile() && ymlFile.canRead()) {
+            try (InputStream ymlResourceStream = new FileInputStream(ymlFile)) {
+                loadYmlProperties(ymlResourceStream, applicationProperties);
+            } catch (IOException e) {
+                LOGGER.debug("Unable to load '{}'.", ymlFile.getName(), e);
+            }
+        } else {
+            LOGGER.debug("Unable to load '{}'.", ymlFile.getName());
+        }
+    }
+
+    public static void loadYmlProperties(InputStream ymlStream, Properties applicationProperties) {
+        Map<String, String> ymlMap  = loadYmlStringMap(ymlStream);
+        if (ymlMap != null) {
+            applicationProperties.putAll(ymlMap);
+        }
+    }
+
+    static Map<String, String> loadYmlStringMap(InputStream ymlStream) {
+        TreeMap<String, Object> ymlMap = loadYmlMap(ymlStream);
+        if (ymlMap != null) {
+            return convertYamlObjectToMap(ymlMap);
+        } else {
+            return null;
+        }
+    }
+
+    /*static TreeMap<String, Object> loadYmlMap(File ymlFile) {
+        if (ymlFile.exists() && ymlFile.isFile() && ymlFile.canRead()) {
+            try (InputStream ymlResourceStream = new FileInputStream(ymlFile)) {
+                return loadYmlMap(ymlResourceStream);
+            } catch (IOException e) {
+                LOGGER.debug("Unable to load '{}'.", ymlFile.getName(), e);
+            }
+        } else {
+            LOGGER.debug("Unable to load '{}'.", ymlFile.getName());
+        }
+        return null;
+    }*/
+
+    static TreeMap<String, Object> loadYmlMap(InputStream ymlStream) {
+        if (ymlStream != null) {
+            Yaml yaml = new Yaml();
+            try (Reader yamlFileReader = new InputStreamReader(ymlStream, StandardCharsets.UTF_8)){
+                return yaml.loadAs(yamlFileReader, TreeMap.class);
+            } catch (IOException e) {
+                LOGGER.debug("Unable to load YaML file.", e);
+            }
+        } else {
+            LOGGER.debug("Unable to load YaML file.");
+        }
+        return null;
+    }
+
+    static Map<String, String> convertYamlObjectToMap(TreeMap<String, Object> toConvert) {
+        Map<String, String> toReturn = new HashMap<>();
+        convertYamlObjectToMap(toConvert, new StringBuilder(), toReturn);
+        return toReturn;
+    }
+
+    static void convertYamlObjectToMap(Map<String, Object> toRead, StringBuilder builder, Map<String, String> toPopulate) {
+        toRead.forEach((key, value) -> {
+            if (value instanceof Map) {
+                StringBuilder newBuilder = new StringBuilder(builder);
+                convertYamlObjectToMap((Map<String, Object>) value, newBuilder.append(key).append("."), toPopulate);
+            } else {
+                String property = builder.toString() + key;
+                String propertyValue = value != null ? value.toString() : "";
+                toPopulate.put(property, propertyValue);
+            }
+        });
+    }
+}   

--- a/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/ModelBuildContextUtils.java
+++ b/drools-model/drools-codegen-common/src/main/java/org/drools/codegen/common/context/ModelBuildContextUtils.java
@@ -66,19 +66,6 @@ public class ModelBuildContextUtils {
         }
     }
 
-    /*static TreeMap<String, Object> loadYmlMap(File ymlFile) {
-        if (ymlFile.exists() && ymlFile.isFile() && ymlFile.canRead()) {
-            try (InputStream ymlResourceStream = new FileInputStream(ymlFile)) {
-                return loadYmlMap(ymlResourceStream);
-            } catch (IOException e) {
-                LOGGER.debug("Unable to load '{}'.", ymlFile.getName(), e);
-            }
-        } else {
-            LOGGER.debug("Unable to load '{}'.", ymlFile.getName());
-        }
-        return null;
-    }*/
-
     static TreeMap<String, Object> loadYmlMap(InputStream ymlStream) {
         if (ymlStream != null) {
             Yaml yaml = new Yaml();

--- a/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/context/ModelBuildContextUtilsTest.java
+++ b/drools-model/drools-codegen-common/src/test/java/org/drools/codegen/common/context/ModelBuildContextUtilsTest.java
@@ -19,11 +19,12 @@
 package org.drools.codegen.common.context;
 
 import org.drools.util.FileUtils;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
@@ -31,17 +32,20 @@ import java.util.TreeMap;
 
 import static org.drools.codegen.common.DroolsModelBuildContext.APPLICATION_PROPERTIES_YAML_FILE_NAME;
 import static org.drools.codegen.common.DroolsModelBuildContext.APPLICATION_PROPERTIES_YML_FILE_NAME;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-class AbstractDroolsModelBuildContextTest {
+class ModelBuildContextUtilsTest {
 
     @MethodSource("testData")
     @ParameterizedTest
-    void loadYmlProperties(String fileName) {
+    void loadYmlPropertiesByFile(String fileName) {
         File ymlFile = FileUtils.getFile(fileName);
         assertTrue(ymlFile.exists());
         Properties properties = new Properties();
-        AbstractDroolsModelBuildContext.loadYmlProperties(ymlFile, properties);
+        ModelBuildContextUtils.loadYmlProperties(ymlFile, properties);
         assertEquals("test", properties.getProperty("this.is.a"));
         assertEquals("notNull", properties.getProperty("this.is.b"));
         assertEquals("test", properties.getProperty("this.was.a"));
@@ -54,12 +58,38 @@ class AbstractDroolsModelBuildContextTest {
 
     @MethodSource("testData")
     @ParameterizedTest
+    void loadYmlPropertiesByInputStream(String fileName) {
+        File ymlFile = FileUtils.getFile(fileName);
+        assertTrue(ymlFile.exists());
+        Properties properties = new Properties();
+        try (InputStream ymlResourceStream = new FileInputStream(ymlFile)) {
+            ModelBuildContextUtils.loadYmlProperties(ymlResourceStream, properties);
+            assertEquals("test", properties.getProperty("this.is.a"));
+            assertEquals("notNull", properties.getProperty("this.is.b"));
+            assertEquals("test", properties.getProperty("this.was.a"));
+            assertEquals("notNull", properties.getProperty("this.was.b"));
+            assertEquals("test", properties.getProperty("that.is.a"));
+            assertEquals("notNull", properties.getProperty("that.is.b"));
+            assertEquals("test", properties.getProperty("that.was.a"));
+            assertEquals("notNull", properties.getProperty("that.was.b"));
+        } catch (Exception e) {
+            fail("Unexpected exception while loading yml string map from file: " + fileName, e);
+        }
+
+    }
+
+    @MethodSource("testData")
+    @ParameterizedTest
     void loadYmlStringMap(String fileName) {
         File ymlFile = FileUtils.getFile(fileName);
         assertTrue(ymlFile.exists());
-        Map<String, String> retrieved = AbstractDroolsModelBuildContext.loadYmlStringMap(ymlFile);
-        assertNotNull(retrieved);
-        commonCheck(retrieved);
+        try (InputStream ymlResourceStream = new FileInputStream(ymlFile)) {
+            Map<String, String> retrieved = ModelBuildContextUtils.loadYmlStringMap(ymlResourceStream);
+            assertNotNull(retrieved);
+            commonCheck(retrieved);
+        } catch (Exception e) {
+            fail("Unexpected exception while loading yml string map from file: " + fileName, e);
+        }
     }
 
     @MethodSource("testData")
@@ -67,9 +97,13 @@ class AbstractDroolsModelBuildContextTest {
     void loadYmlMap(String fileName) {
         File ymlFile = FileUtils.getFile(fileName);
         assertTrue(ymlFile.exists());
-        TreeMap<String, Object> retrieved = AbstractDroolsModelBuildContext.loadYmlMap(ymlFile);
-        assertNotNull(retrieved);
-        assertTrue(retrieved.containsKey("this"));
+        try (InputStream ymlResourceStream = new FileInputStream(ymlFile)) {
+            TreeMap<String, Object> retrieved = ModelBuildContextUtils.loadYmlMap(ymlResourceStream);
+            assertNotNull(retrieved);
+            assertTrue(retrieved.containsKey("this"));
+        } catch (Exception e) {
+            fail("Unexpected exception while loading yml string map from file: " + fileName, e);
+        }
     }
 
 
@@ -78,11 +112,14 @@ class AbstractDroolsModelBuildContextTest {
     void convertYamlObjectToMap(String fileName) {
         File ymlFile = FileUtils.getFile(fileName);
         assertTrue(ymlFile.exists());
-        TreeMap<String, Object> ymlMap = AbstractDroolsModelBuildContext.loadYmlMap(ymlFile);
-        assertNotNull(ymlMap);
-
-        Map<String, String> retrieved = AbstractDroolsModelBuildContext.convertYamlObjectToMap(ymlMap);
-        commonCheck(retrieved);
+        try (InputStream ymlResourceStream = new FileInputStream(ymlFile)) {
+            TreeMap<String, Object> ymlMap = ModelBuildContextUtils.loadYmlMap(ymlResourceStream);
+            assertNotNull(ymlMap);
+            Map<String, String> retrieved = ModelBuildContextUtils.convertYamlObjectToMap(ymlMap);
+            commonCheck(retrieved);
+        } catch (Exception e) {
+            fail("Unexpected exception while loading yml string map from file: " + fileName, e);
+        }
     }
 
     private static Collection<String> testData() {


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2164

This PR provide a couple of common utility methods to load propertis from YaML files

Needed by:
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4260
https://github.com/apache/incubator-kie-kogito-examples/pull/2206

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
