### PR TITLE
[NO-ISSUE] Fix flaky PersistenceTest by disabling parallel test execution

### DIFF
--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -37,6 +37,7 @@
 
   <properties>
     <java.module.name>org.drools.traits</java.module.name>
+
     <!-- These are properties used in the database profiles. Some of them must be initialized
      to be empty so that Maven applies their values via filtering to the resources. -->
     <maven.datasource.classname>org.h2.jdbcx.JdbcDataSource</maven.datasource.classname>

--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -37,8 +37,6 @@
 
   <properties>
     <java.module.name>org.drools.traits</java.module.name>
-    <surefire.forkCount>2</surefire.forkCount>
-
     <!-- These are properties used in the database profiles. Some of them must be initialized
      to be empty so that Maven applies their values via filtering to the resources. -->
     <maven.datasource.classname>org.h2.jdbcx.JdbcDataSource</maven.datasource.classname>

--- a/drools-traits/src/test/java/org/drools/traits/UseOfRuleFlowGroupPlusLockOnTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/UseOfRuleFlowGroupPlusLockOnTest.java
@@ -63,8 +63,8 @@ public class UseOfRuleFlowGroupPlusLockOnTest {
         KieSession ksession = kbase.newKieSession();
         if (LOGGER.isDebugEnabled()) {
             ReteDumper.dumpRete(ksession);
+            ksession.addEventListener( new DebugAgendaEventListener() );
         }
-        ksession.addEventListener( new DebugAgendaEventListener() );
         try {
             ksession.insert(new Person());
             ksession.insert(new Cheese("eidam"));

--- a/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
+++ b/drools-traits/src/test/java/org/drools/traits/compiler/factmodel/traits/TraitTest.java
@@ -2911,7 +2911,6 @@ public class TraitTest extends CommonTraitTest {
             String C = "" + c;
             source += "rule Rule" + C +
                       " when \n" + C + "() \nthen\n" +
-                      " System.out.println(\"Rule " + C + "\");\n" +
                       " list.add('"+ C + "'); \n" +
                       "end \n";
         }
@@ -2925,7 +2924,6 @@ public class TraitTest extends CommonTraitTest {
                         "";
 
 
-        System.out.println(source);
         KieSession ks = getSessionFromString(source);
         TraitFactoryImpl.setMode(mode, ks.getKieBase());
 


### PR DESCRIPTION
### Fix flaky PersistenceTest by disabling parallel test execution

**Problem:**
`PersistenceTest.testTraitsSerialization` fails intermittently with:
```
org.apache.openjpa.persistence.ArgumentException: This configuration disallows runtime optimization, 
but the following listed types were not enhanced at build time or at class load time with a javaagent:
org.drools.persistence.info.WorkItemInfo
org.drools.persistence.info.SessionInfo
```

**Root Cause:**
The test uses OpenJPA with `-javaagent` for runtime entity enhancement. With `surefire.forkCount=2`, two test instances run in parallel, creating a race condition:
- The javaagent enhancement is asynchronous
- When tests run concurrently, EntityManagerFactory creation sometimes happens before enhancement completes
- This triggers the "unenhanced classes" error

**Solution:**
Removed `surefire.forkCount=2` property to use Maven's default sequential execution (`forkCount=1`). This ensures the javaagent completes enhancement before any EntityManagerFactory is created.

**Testing:**
The fix can be verified by running the test multiple times:
```bash
mvn clean test -pl drools-traits -Dtest=PersistenceTest -Dsurefire.rerunFailingTestsCount=10
```