### PR TITLE
[incubator-kie-drools#6666] Integration Tests for kie-maven-plugin fail on a fresh clone due to drools-ruleunits-engine not being found

### DIFF
--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -237,11 +237,7 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-ruleunits-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-ruleunits-impl</artifactId>
+      <artifactId>drools-ruleunits-engine</artifactId>
     </dependency>
     <!-- Include all dependencies needed to support all resource types out-of-the-box -->
     <dependency>

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml
@@ -33,13 +33,13 @@
   <properties>
     <org.kie.version>${project.version}</org.kie.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.release>11</maven.compiler.release>
-    <junit.version>4.13.1</junit.version>
-    <junit.jupiter.version>5.10.2</junit.jupiter.version>
+    <maven.compiler.release>17</maven.compiler.release>
+    <junit.version>4.13.2</junit.version>
+    <junit.jupiter.version>5.13.4</junit.jupiter.version>
     <assertj.version>3.27.7</assertj.version>
-    <compiler.plugin.version>3.11.0</compiler.plugin.version>
-    <surefire.plugin.version>3.1.0</surefire.plugin.version>
-    <failsafe.plugin.version>3.1.0</failsafe.plugin.version>
+    <compiler.plugin.version>3.13.0</compiler.plugin.version>
+    <surefire.plugin.version>3.2.5</surefire.plugin.version>
+    <failsafe.plugin.version>3.2.5</failsafe.plugin.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-drools/issues/6666

### Summary
Synchronized ruleunits dependency configuration between kie-maven-plugin and its integration test module by consolidating to use the unified `drools-ruleunits-engine` artifact.

### Changes
- **Modified**: [`kie-maven-plugin/pom.xml`](kie-maven-plugin/pom.xml)
  - Removed `drools-ruleunits-api` dependency
  - Removed `drools-ruleunits-impl` dependency  
  - Added `drools-ruleunits-engine` dependency
- Updated versions in the root pom 

### Motivation
The integration test module [`kie-maven-plugin-test-kjar-14-ruleunits`](kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/pom.xml) was already using `drools-ruleunits-engine` (line 39). This change aligns the main plugin's dependencies with the test configuration, ensuring consistency across the module.