### PR TITLE
[NO-ISSUE] Revert Fix flaky PersistenceTest by disabling parallel test execution

### DIFF
--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -37,6 +37,7 @@
 
   <properties>
     <java.module.name>org.drools.traits</java.module.name>
+    <surefire.forkCount>2</surefire.forkCount>
 
     <!-- These are properties used in the database profiles. Some of them must be initialized
      to be empty so that Maven applies their values via filtering to the resources. -->


### PR DESCRIPTION
Revert previous fix  because now raising more critical failures:

```
2026-04-23T20:42:58.2424972Z [ERROR] Errors: 
2026-04-23T20:42:58.2426719Z [ERROR]   TraitTypeGenerationTest.testIsAWith2KContainers:209 » Consequence Exception executing consequence for rule "create student" in defaultpkg: java.lang.NullPointerException: Cannot invoke "java.lang.reflect.Constructor.newInstance(Object[])" because "konst" is null
2026-04-23T20:42:58.2429579Z [ERROR]   TraitTypeGenerationTest.testMvelJittingWithTraitProxies:254 » Consequence Exception executing consequence for rule "In1" in org.drools.test: java.lang.NullPointerException: Cannot invoke "java.lang.reflect.Constructor.newInstance(Object[])" because "konst" is null
2026-04-23T20:42:58.2431589Z [ERROR]   TraitTypeGenerationTest.testNeeds:331 » Consequence Exception executing consequence for rule "Main" in org.drools.abductive.test: java.lang.NullPointerException: Cannot invoke "java.lang.reflect.Constructor.newInstance(Object[])" because "konst" is null
2026-04-23T20:42:58.2433610Z [ERROR]   TraitTypeGenerationTest.testWithBeanAndTraitInDifferentPackages:157 » Consequence Exception executing consequence for rule "R" in org.drools.test: java.lang.NullPointerException: Cannot invoke "java.lang.reflect.Constructor.newInstance(Object[])" because "konst" is null
2026-04-23T20:42:58.2436791Z [ERROR]   TraitTypeGenerationTest.testWithDeclaredTypeAndTraitInDifferentPackages:124 » Consequence Exception executing consequence for rule "R" in org.pkg3: java.lang.NullPointerException: Cannot invoke "java.lang.reflect.Constructor.newInstance(Object[])" because "konst" is null
```