### PR TITLE
 Upgrade Netty to 4.1.133.Final and Vert.x Core to 4.5.27 to address security vulnerabilities

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -72,7 +72,7 @@
     <version.info.picocli>4.7.7</version.info.picocli>
     <version.io.micrometer>1.14.12</version.io.micrometer>
     <version.io.quarkus>3.27.3</version.io.quarkus>
-    <version.io.netty>4.1.132.Final</version.io.netty>
+    <version.io.netty>4.1.133.Final</version.io.netty>
     <version.io.smallrye.openapi.core>4.0.12</version.io.smallrye.openapi.core>
     <version.io.smallrye.config.core>3.13.4</version.io.smallrye.config.core>
     <version.org.apache.kafka>4.1.2</version.org.apache.kafka>
@@ -222,7 +222,7 @@
     <version.archunit.maven.plugin>4.0.2</version.archunit.maven.plugin>
     <version.archunit.junit5>1.4.0</version.archunit.junit5>
 
-    <version.io.vertx>4.5.25</version.io.vertx>
+    <version.io.vertx>4.5.27</version.io.vertx>
     <version.org.codehaus.plexus.plexus-utils>3.6.1</version.org.codehaus.plexus.plexus-utils>
   </properties>
 


### PR DESCRIPTION
 Upgrade Netty to 4.1.133.Final and Vert.x Core to 4.5.27 to address security vulnerabilities