### PR TITLE
exclude brotli4j from netty-codec-http to fix native build issue

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -354,6 +354,12 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
         <version>${version.io.netty}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
Add exclusion for com.aayushatharva.brotli4j artifacts in the netty-codec-http dependency to fix native build issue