### PR TITLE
Revert Netty version from 4.1.133.Final to 4.1.132.Final and vertx version from 4.5.27 to 4.5.25 address native build compatibility issues

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -146,7 +146,7 @@
     <version.io.fabric8.kubernetes-client>7.3.1</version.io.fabric8.kubernetes-client>
     <version.io.grpc>1.76.0</version.io.grpc>
     <version.io.micrometer>1.16.4</version.io.micrometer>
-    <version.io.netty>4.1.133.Final</version.io.netty>
+    <version.io.netty>4.1.132.Final</version.io.netty>
     <version.io.opentelemetry>1.0.0-alpha</version.io.opentelemetry>
     <version.io.rest-assured>5.5.6</version.io.rest-assured>
     <version.io.smallrye-config>3.13.4</version.io.smallrye-config>
@@ -162,7 +162,7 @@
     <version.io.smallrye.reactive.mutiny-zero>1.1.1</version.io.smallrye.reactive.mutiny-zero>
     <version.io.swagger.core.v3>2.2.38</version.io.swagger.core.v3>
     <version.io.swagger.parser.v3>2.1.34</version.io.swagger.parser.v3>
-    <version.io.vertx>4.5.27</version.io.vertx>
+    <version.io.vertx>4.5.25</version.io.vertx>
     <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
     <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
     <version.jakarta.activation>2.0.3</version.jakarta.activation>


### PR DESCRIPTION
Revert Netty version from 4.1.133.Final to 4.1.132.Final and vertx version from 4.5.27 to 4.5.25 address native build compatibility issues