### PR TITLE
[incubator-kie-drools-6711] Fix NoSuchMethodError in ASM-jitted const…

### DIFF
--- a/drools-mvel/src/main/java/org/drools/mvel/ASMConditionEvaluatorJitter.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/ASMConditionEvaluatorJitter.java
@@ -240,7 +240,7 @@ public class ASMConditionEvaluatorJitter {
             mv.visitVarInsn(ALOAD, 1); // InternalFactHandle
             mv.visitVarInsn(ALOAD, 3); // Tuple
             getFieldFromThis("operators", EvaluatorWrapper[].class);
-            invokeStatic(EvaluatorHelper.class, "initOperators", void.class, FactHandle.class, Tuple.class, EvaluatorWrapper[].class);
+            invokeStatic(EvaluatorHelper.class, "initOperators", void.class, FactHandle.class, BaseTuple.class, EvaluatorWrapper[].class);
         }
 
         private void jitCondition(Condition condition) {

--- a/drools-mvel/src/test/java/org/drools/mvel/ASMConditionEvaluatorJitterTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/ASMConditionEvaluatorJitterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.mvel;
+
+import org.drools.base.rule.Declaration;
+import org.drools.base.rule.accessor.Evaluator;
+import org.drools.compiler.rule.builder.EvaluatorWrapper;
+import org.drools.core.common.DefaultFactHandle;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+
+class ASMConditionEvaluatorJitterTest {
+
+    @Test
+    void jitWithNonEmptyOperators() throws Exception {
+        // incubator-kie-drools#6711
+        // ASMConditionEvaluatorJitter.jitOperators() must generate bytecode calling
+        // EvaluatorHelper.initOperators with BaseTuple.class (not Tuple.class) as
+        // the second parameter, matching the actual method signature.
+        java.lang.reflect.Constructor<ConditionAnalyzer.FixedValueCondition> ctor =
+                ConditionAnalyzer.FixedValueCondition.class.getDeclaredConstructor(boolean.class);
+        ctor.setAccessible(true);
+        ConditionAnalyzer.Condition condition = ctor.newInstance(true);
+
+        Declaration[] declarations = new Declaration[0];
+        Evaluator mockEvaluator = mock(Evaluator.class);
+        EvaluatorWrapper[] operators = new EvaluatorWrapper[]{ new EvaluatorWrapper(mockEvaluator, null, null) };
+
+        ConditionEvaluator evaluator = ASMConditionEvaluatorJitter.jitEvaluator(
+                "true", condition, declarations, operators, getClass().getClassLoader(), null);
+
+        assertThatNoException().isThrownBy(() ->
+                evaluator.evaluate(new DefaultFactHandle(1, new Object()), null, null));
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
@@ -491,4 +491,36 @@ public class JittingTest {
         ksession.insert(person);
         assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
+
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    void jitStrOperatorWithVariable(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        // incubator-kie-drools#6711
+        // The 'str' operator with a variable binding creates an MVELConstraint with
+        // non-empty EvaluatorWrapper[] on a typesafe POJO (isDynamic=false).
+        // With jit threshold 0, the ASM jitter generates bytecode calling
+        // EvaluatorHelper.initOperators with Tuple.class instead of BaseTuple.class.
+
+        String drl =
+                "declare Item\n" +
+                "    name : String\n" +
+                "end\n" +
+                "rule Init when then insert(new Item(\"hello\")); end\n" +
+                "rule R when\n" +
+                "    $prefix : String()\n" +
+                "    Item( name str[startsWith] $prefix )\n" +
+                "then\n" +
+                "end\n";
+
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(
+                kieModule, kieBaseTestConfiguration, ConstraintJittingThresholdOption.get(0));
+        final KieSession ksession = kieBase.newKieSession();
+        try {
+            ksession.insert("hel");
+            assertThat(ksession.fireAllRules()).isEqualTo(2);
+        } finally {
+            ksession.dispose();
+        }
+    }
 }


### PR DESCRIPTION
…raints with EvaluatorWrapper

ASMConditionEvaluatorJitter.jitOperators() generated bytecode calling EvaluatorHelper.initOperators with Tuple.class as the second parameter type, but commit 81dce55001 changed the actual method signature to use BaseTuple.class. This mismatch caused NoSuchMethodError at runtime when an MVELConstraint with non-empty EvaluatorWrapper[] (e.g. str operator with a variable binding on a typesafe type) was ASM-jitted.

Fixes: https://github.com/apache/incubator-kie-drools/issues/6711

- Issue : https://github.com/apache/incubator-kie-drools/issues/6711