### PR TITLE
[kie_pmml_dependencies_packaging] Changing packaging/type of kie-pmml-dependencies to pom

### DIFF
--- a/bom/kie-pmml-bom/pom.xml
+++ b/bom/kie-pmml-bom/pom.xml
@@ -583,6 +583,7 @@
       <dependency>
         <groupId>org.kie</groupId>
         <artifactId>kie-pmml-dependencies</artifactId>
+        <type>pom</type>
         <version>${project.version}</version>
       </dependency>
       <!-- EXTERNAL -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -180,6 +180,7 @@
       <dependency>
         <groupId>org.kie</groupId>
         <artifactId>kie-pmml-dependencies</artifactId>
+        <type>pom</type>
         <version>${project.version}</version>
       </dependency>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-integrationtest/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-integrationtest/pom.xml
@@ -55,6 +55,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-dependencies</artifactId>
+      <type>pom</type>
       <exclusions>
         <!-- Tree -->
         <exclusion>

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
@@ -57,6 +57,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-dependencies</artifactId>
+      <type>pom</type>
       <scope>test</scope>
       <exclusions>
         <!-- Tree -->

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -319,6 +319,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-dependencies</artifactId>
+      <type>pom</type>
       <scope>test</scope>
     </dependency>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-dependencies</artifactId>
+      <type>pom</type>
       <version>@org.kie.version@</version>
       <scope>provided</scope>
     </dependency>

--- a/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
@@ -22,15 +22,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
     <version>999-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>kie-pmml-dependencies</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
 
   <name>KIE :: PMML :: Dependencies</name>
   <description>


### PR DESCRIPTION
[DRAFT]
Currently, the packaging/type of org.kie:kie-pmml-dependencies is "jar" while it seems to be more a "bom", so it should be "pom".


Relates to:
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4305

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
