### PR TITLE
[incubator-kie-issues#2326] Provide correct `Jackson 2` integration for all Spring Boot based KIE modules

### DIFF
--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RestObjectMapperSpringTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RestObjectMapperSpringTemplate.java
@@ -39,7 +39,6 @@ import org.drools.ruleunits.api.SingletonStore;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
-import org.springframework.http.MediaType;
 
 // Jackson 2 Spring configuration — revisit with https://github.com/apache/incubator-kie-drools/issues/6702 (Jackson 3 migration).
 @SpringBootConfiguration

--- a/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RestObjectMapperSpringTemplate.java
+++ b/drools-model/drools-model-codegen/src/main/resources/class-templates/ruleunits/RestObjectMapperSpringTemplate.java
@@ -37,38 +37,21 @@ import org.drools.ruleunits.api.DataStore;
 import org.drools.ruleunits.api.DataStream;
 import org.drools.ruleunits.api.SingletonStore;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
-// Jackson 2 Spring configuration — remove together with https://github.com/apache/incubator-kie-drools/issues/6702 (Jackson 3 migration).
+// Jackson 2 Spring configuration — revisit with https://github.com/apache/incubator-kie-drools/issues/6702 (Jackson 3 migration).
 @SpringBootConfiguration
 public class RestObjectMapper {
 
+    @Autowired
     public RestObjectMapper(ObjectMapper objectMapper) {
         SimpleModule module = new SimpleModule();
         module.addDeserializer(DataStream.class, new DataStreamDeserializer());
         module.addDeserializer(DataStore.class, new DataStoreDeserializer());
         module.addDeserializer(SingletonStore.class, new SingletonStoreDeserializer());
         objectMapper.registerModule(module);
-    }
-
-    // Jackson 2 HTTP message converter — remove together with https://github.com/apache/incubator-kie-drools/issues/6702 (Jackson 3 migration).
-    @Bean
-    @ConditionalOnMissingBean(MappingJackson2HttpMessageConverter.class)
-    public MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter(ObjectMapper objectMapper) {
-        return new MappingJackson2HttpMessageConverter(objectMapper) {
-            @Override
-            public boolean canWrite(Class<?> clazz, MediaType mediaType) {
-                // Refuse String so DMN controllers' pre-serialized JSON passes through StringHttpMessageConverter.
-                if (clazz == String.class) {
-                    return false;
-                }
-                return super.canWrite(clazz, mediaType);
-            }
-        };
     }
 
     public static class DataStreamDeserializer extends JsonDeserializer<DataStream<?>> implements ContextualDeserializer {


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2326

- remove unnecessary Jackson 2 MappingJackson2HttpMessageConverter override

Ensemble:
- https://github.com/apache/incubator-kie-drools/pull/6735
- https://github.com/apache/incubator-kie-kogito-runtimes/pull/4307
- https://github.com/apache/incubator-kie-kogito-apps/pull/2340
- 
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

**Thank you for submitting this pull request**

**NOTE!:** Double-check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

* [link](https://www.example.com)

**Issue**: _(please edit the GitHub Issues link if it exists)_

* [link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
