### PR TITLE
Fix getDecisionService method NPE

### DIFF
--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/impl/AbstractTDefinitions.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/impl/AbstractTDefinitions.java
@@ -149,6 +149,6 @@ public abstract class AbstractTDefinitions extends AbstractTNamedElement impleme
      */
     @Override
     public List<DecisionService> getDecisionService() {
-        return drgElement.stream().filter(DecisionService.class::isInstance).map(DecisionService.class::cast).collect(Collectors.toList());
+        return getDrgElement().stream().filter(DecisionService.class::isInstance).map(DecisionService.class::cast).collect(Collectors.toList());
     }
 }

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/impl/AbstractTDefinitionsTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/impl/AbstractTDefinitionsTest.java
@@ -25,15 +25,16 @@ import org.kie.dmn.model.api.Artifact;
 import org.kie.dmn.model.api.BusinessContextElement;
 import org.kie.dmn.model.api.DRGElement;
 import org.kie.dmn.model.api.DecisionService;
+import org.kie.dmn.model.api.Definitions;
 import org.kie.dmn.model.api.ElementCollection;
 import org.kie.dmn.model.api.Import;
 import org.kie.dmn.model.api.ItemDefinition;
-import org.kie.dmn.model.v1_2.TDecision;
-import org.kie.dmn.model.v1_2.TDecisionService;
-import org.kie.dmn.model.v1_2.TDefinitions;
-import org.kie.dmn.model.v1_2.TImport;
-import org.kie.dmn.model.v1_2.TItemDefinition;
-import org.kie.dmn.model.v1_2.TTextAnnotation;
+import org.kie.dmn.model.v1_6.TDecision;
+import org.kie.dmn.model.v1_6.TDecisionService;
+import org.kie.dmn.model.v1_6.TDefinitions;
+import org.kie.dmn.model.v1_6.TImport;
+import org.kie.dmn.model.v1_6.TItemDefinition;
+import org.kie.dmn.model.v1_6.TTextAnnotation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +42,7 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getImportInitializesListWhenNull() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
         List<Import> imports = definitions.getImport();
         
@@ -51,9 +52,9 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getImportAllowsAddingElements() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
-        TImport import1 = new TImport();
+        Import import1 = new TImport();
         import1.setNamespace("http://example.com/ns1");
         definitions.getImport().add(import1);
         
@@ -63,7 +64,7 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getItemDefinitionInitializesListWhenNull() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
         List<ItemDefinition> itemDefinitions = definitions.getItemDefinition();
         
@@ -73,9 +74,9 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getItemDefinitionAllowsAddingElements() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
-        TItemDefinition item = new TItemDefinition();
+        ItemDefinition item = new TItemDefinition();
         item.setName("CustomType");
         definitions.getItemDefinition().add(item);
         
@@ -85,7 +86,7 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getDrgElementInitializesListWhenNull() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
         List<DRGElement> drgElements = definitions.getDrgElement();
         
@@ -95,9 +96,9 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getDrgElementAllowsAddingElements() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
-        TDecision decision = new TDecision();
+        DRGElement decision = new TDecision();
         decision.setName("Decision1");
         definitions.getDrgElement().add(decision);
         
@@ -107,7 +108,7 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getArtifactInitializesListWhenNull() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
         List<Artifact> artifacts = definitions.getArtifact();
         
@@ -117,7 +118,7 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getArtifactAllowsAddingElements() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
         TTextAnnotation annotation = new TTextAnnotation();
         annotation.setText("Test annotation");
@@ -129,7 +130,7 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getElementCollectionInitializesListWhenNull() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
         List<ElementCollection> collections = definitions.getElementCollection();
         
@@ -139,7 +140,7 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getBusinessContextElementInitializesListWhenNull() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
         List<BusinessContextElement> elements = definitions.getBusinessContextElement();
         
@@ -149,7 +150,7 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getDecisionServiceWithNullDrgElement() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
         List<DecisionService> decisionServices = definitions.getDecisionService();
         
@@ -159,14 +160,13 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getDecisionServiceWithDecisionServices() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
-        // Add a DecisionService to drgElement
-        TDecisionService decisionService1 = new TDecisionService();
+        DecisionService decisionService1 = new TDecisionService();
         decisionService1.setName("Service1");
         definitions.getDrgElement().add(decisionService1);
         
-        TDecisionService decisionService2 = new TDecisionService();
+        DecisionService decisionService2 = new TDecisionService();
         decisionService2.setName("Service2");
         definitions.getDrgElement().add(decisionService2);
         
@@ -179,20 +179,18 @@ class AbstractTDefinitionsTest {
 
     @Test
     void getDecisionServiceWithMixedDrgElements() {
-        TDefinitions definitions = new TDefinitions();
+        Definitions definitions = new TDefinitions();
         
-        // Add a DecisionService
-        TDecisionService decisionService = new TDecisionService();
+        DecisionService decisionService = new TDecisionService();
         decisionService.setName("Service1");
         definitions.getDrgElement().add(decisionService);
         
         // Add other DRGElement types (TDecision is not a DecisionService)
-        TDecision decision = new TDecision();
+        DRGElement decision = new TDecision();
         decision.setName("Decision1");
         definitions.getDrgElement().add(decision);
         
-        // Add another DecisionService
-        TDecisionService decisionService2 = new TDecisionService();
+        DecisionService decisionService2 = new TDecisionService();
         decisionService2.setName("Service2");
         definitions.getDrgElement().add(decisionService2);
         

--- a/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/impl/AbstractTDefinitionsTest.java
+++ b/kie-dmn/kie-dmn-model/src/test/java/org/kie/dmn/model/impl/AbstractTDefinitionsTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.dmn.model.impl;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.kie.dmn.model.api.Artifact;
+import org.kie.dmn.model.api.BusinessContextElement;
+import org.kie.dmn.model.api.DRGElement;
+import org.kie.dmn.model.api.DecisionService;
+import org.kie.dmn.model.api.ElementCollection;
+import org.kie.dmn.model.api.Import;
+import org.kie.dmn.model.api.ItemDefinition;
+import org.kie.dmn.model.v1_2.TDecision;
+import org.kie.dmn.model.v1_2.TDecisionService;
+import org.kie.dmn.model.v1_2.TDefinitions;
+import org.kie.dmn.model.v1_2.TImport;
+import org.kie.dmn.model.v1_2.TItemDefinition;
+import org.kie.dmn.model.v1_2.TTextAnnotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractTDefinitionsTest {
+
+    @Test
+    void getImportInitializesListWhenNull() {
+        TDefinitions definitions = new TDefinitions();
+        
+        List<Import> imports = definitions.getImport();
+        
+        assertThat(imports).isNotNull();
+        assertThat(imports).isEmpty();
+    }
+
+    @Test
+    void getImportAllowsAddingElements() {
+        TDefinitions definitions = new TDefinitions();
+        
+        TImport import1 = new TImport();
+        import1.setNamespace("http://example.com/ns1");
+        definitions.getImport().add(import1);
+        
+        assertThat(definitions.getImport()).hasSize(1);
+        assertThat(definitions.getImport()).contains(import1);
+    }
+
+    @Test
+    void getItemDefinitionInitializesListWhenNull() {
+        TDefinitions definitions = new TDefinitions();
+        
+        List<ItemDefinition> itemDefinitions = definitions.getItemDefinition();
+        
+        assertThat(itemDefinitions).isNotNull();
+        assertThat(itemDefinitions).isEmpty();
+    }
+
+    @Test
+    void getItemDefinitionAllowsAddingElements() {
+        TDefinitions definitions = new TDefinitions();
+        
+        TItemDefinition item = new TItemDefinition();
+        item.setName("CustomType");
+        definitions.getItemDefinition().add(item);
+        
+        assertThat(definitions.getItemDefinition()).hasSize(1);
+        assertThat(definitions.getItemDefinition()).contains(item);
+    }
+
+    @Test
+    void getDrgElementInitializesListWhenNull() {
+        TDefinitions definitions = new TDefinitions();
+        
+        List<DRGElement> drgElements = definitions.getDrgElement();
+        
+        assertThat(drgElements).isNotNull();
+        assertThat(drgElements).isEmpty();
+    }
+
+    @Test
+    void getDrgElementAllowsAddingElements() {
+        TDefinitions definitions = new TDefinitions();
+        
+        TDecision decision = new TDecision();
+        decision.setName("Decision1");
+        definitions.getDrgElement().add(decision);
+        
+        assertThat(definitions.getDrgElement()).hasSize(1);
+        assertThat(definitions.getDrgElement()).contains(decision);
+    }
+
+    @Test
+    void getArtifactInitializesListWhenNull() {
+        TDefinitions definitions = new TDefinitions();
+        
+        List<Artifact> artifacts = definitions.getArtifact();
+        
+        assertThat(artifacts).isNotNull();
+        assertThat(artifacts).isEmpty();
+    }
+
+    @Test
+    void getArtifactAllowsAddingElements() {
+        TDefinitions definitions = new TDefinitions();
+        
+        TTextAnnotation annotation = new TTextAnnotation();
+        annotation.setText("Test annotation");
+        definitions.getArtifact().add(annotation);
+        
+        assertThat(definitions.getArtifact()).hasSize(1);
+        assertThat(definitions.getArtifact()).contains(annotation);
+    }
+
+    @Test
+    void getElementCollectionInitializesListWhenNull() {
+        TDefinitions definitions = new TDefinitions();
+        
+        List<ElementCollection> collections = definitions.getElementCollection();
+        
+        assertThat(collections).isNotNull();
+        assertThat(collections).isEmpty();
+    }
+
+    @Test
+    void getBusinessContextElementInitializesListWhenNull() {
+        TDefinitions definitions = new TDefinitions();
+        
+        List<BusinessContextElement> elements = definitions.getBusinessContextElement();
+        
+        assertThat(elements).isNotNull();
+        assertThat(elements).isEmpty();
+    }
+
+    @Test
+    void getDecisionServiceWithNullDrgElement() {
+        TDefinitions definitions = new TDefinitions();
+        
+        List<DecisionService> decisionServices = definitions.getDecisionService();
+        
+        assertThat(decisionServices).isNotNull();
+        assertThat(decisionServices).isEmpty();
+    }
+
+    @Test
+    void getDecisionServiceWithDecisionServices() {
+        TDefinitions definitions = new TDefinitions();
+        
+        // Add a DecisionService to drgElement
+        TDecisionService decisionService1 = new TDecisionService();
+        decisionService1.setName("Service1");
+        definitions.getDrgElement().add(decisionService1);
+        
+        TDecisionService decisionService2 = new TDecisionService();
+        decisionService2.setName("Service2");
+        definitions.getDrgElement().add(decisionService2);
+        
+        List<DecisionService> decisionServices = definitions.getDecisionService();
+        
+        assertThat(decisionServices).isNotNull();
+        assertThat(decisionServices).hasSize(2);
+        assertThat(decisionServices).containsExactly(decisionService1, decisionService2);
+    }
+
+    @Test
+    void getDecisionServiceWithMixedDrgElements() {
+        TDefinitions definitions = new TDefinitions();
+        
+        // Add a DecisionService
+        TDecisionService decisionService = new TDecisionService();
+        decisionService.setName("Service1");
+        definitions.getDrgElement().add(decisionService);
+        
+        // Add other DRGElement types (TDecision is not a DecisionService)
+        TDecision decision = new TDecision();
+        decision.setName("Decision1");
+        definitions.getDrgElement().add(decision);
+        
+        // Add another DecisionService
+        TDecisionService decisionService2 = new TDecisionService();
+        decisionService2.setName("Service2");
+        definitions.getDrgElement().add(decisionService2);
+        
+        List<DecisionService> decisionServices = definitions.getDecisionService();
+        
+        assertThat(decisionServices).isNotNull();
+        assertThat(decisionServices).hasSize(2);
+        assertThat(decisionServices).containsExactly(decisionService, decisionService2);
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/2334

# NPE in AbstractTDefinitions.getDecisionService()

## Summary
`getDecisionService()` throws NPE when `drgElement` is null. A DMN Definitions can legitimately have no DRG elements.

## Location
`kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/impl/AbstractTDefinitions.java:152`

## Problem
```java
return drgElement.stream()... // NPE if drgElement is null
```

## Fix
```java
return getDrgElement().stream()... // Uses null-safe getter
```

Added test for entire AbstractTDefinitions class.