### PR TITLE
[NO-ISSUE] Wiremock upgraded to 3.13.2

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -295,7 +295,7 @@
     <version.org.w3c.dom>2.3.0-jaxb-1.0.6</version.org.w3c.dom>
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>
-    <version.org.wiremock>3.13.0</version.org.wiremock>
+    <version.org.wiremock>3.13.2</version.org.wiremock>
     <version.org.wiremock.webhooks>3.0.4</version.org.wiremock.webhooks>
     <version.org.xmlunit>2.10.4</version.org.xmlunit>
     <version.org.xmlunit-core>2.10.4</version.org.xmlunit-core>


### PR DESCRIPTION
Solving [CVE-2025-48976](https://www.cve.org/CVERecord?id=CVE-2025-48976)