### PR TITLE
[NO-ISSUE] Upgrade logback-core to version 1.5.34 to address CVEs

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -87,7 +87,7 @@
     <version.black.ninia>4.2.0</version.black.ninia>
     <version.build.helper.maven.plugin>3.4.0</version.build.helper.maven.plugin>
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.ch.qos.logback>1.5.32</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.34</version.ch.qos.logback>
     <version.com.fasterxml.jackson>2.21.2</version.com.fasterxml.jackson>
     <version.com.fasterxml.jackson.annotations>2.21</version.com.fasterxml.jackson.annotations>
     <version.com.fasterxml.jackson.databind>2.21.2</version.com.fasterxml.jackson.databind>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double-check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

* N/A

**Issue**: *(please edit the GitHub Issues link if it exists)*

* [NO-ISSUE]

**referenced Pull Requests**: *(please edit the URLs of referenced pullrequests if they exist)*

* N/A

## Description

This PR upgrades Logback from `1.5.32` to `1.5.34` to address reported Logback CVEs.

Updated dependency version property:

```xml
<version.ch.qos.logback>1.5.34</version.ch.qos.logback>
```

This property is used for both:

* `ch.qos.logback:logback-core`
* `ch.qos.logback:logback-classic`

So both dependencies remain aligned to the same version.

## Changes

Updated:

* `kie-parent/pom.xml`

Changed:

* From: `1.5.32`
* To: `1.5.34`

## Validation

Verified locally:

```bash
grep -n "version.ch.qos.logback" kie-parent/pom.xml
grep -R "1.5.32" kie-parent/pom.xml
```

Result:

* `version.ch.qos.logback` is updated to `1.5.34`
* `1.5.32` is no longer present in `kie-parent/pom.xml`
