### PR TITLE
[incubator-kie-issues#2336] Fix broken behavior involving ForIterationNode

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ForExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ForExpressionNode.java
@@ -92,7 +92,36 @@ public class ForExpressionNode
         }
     }
 
-    private void populateToReturn(int k, EvaluationContext ctx, List<Object> toPopulate) {
+    static void setValueIntoContext(EvaluationContext ctx, String name, Object value) {
+        ctx.setValue(name, value);
+    }
+
+    @Override
+    public Type getResultType() {
+        return BuiltInType.LIST;
+    }
+
+    @Override
+    public ASTNode[] getChildrenNode() {
+        ASTNode[] children = new ASTNode[iterationContexts.size() + 1];
+        System.arraycopy(iterationContexts.toArray(new ASTNode[]{}), 0, children, 0, iterationContexts.size());
+        children[children.length - 1] = expression;
+        return children;
+    }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+
+    /**
+     * Populate the given <code>List&lt;Object&gt;</code> with the result of evaluating the expressions retrieved from the
+     * <code>IterationContextNode</code> at the <b>k</b> index of <code>iterationContexts</code>.
+     * @param k
+     * @param ctx
+     * @param toPopulate
+     */
+    void populateToReturn(int k, EvaluationContext ctx, List<Object> toPopulate) {
         LOG.trace("populateToReturn at index {}", k);
         if (k > iterationContexts.size() - 1) {
             LOG.trace("Index {} out of range, returning", k);
@@ -118,16 +147,14 @@ public class ForExpressionNode
         }
     }
 
-    static void setValueIntoContext(EvaluationContext ctx, String name, Object value) {
-        ctx.setValue(name, value);
-    }
-
-    @Override
-    public Type getResultType() {
-        return BuiltInType.LIST;
-    }
-
-    private ForIteration createForIteration(EvaluationContext ctx, IterationContextNode iterationContextNode) throws NullContentInsideForIterationException {
+    /**
+     * Instantiate a <code>ForIteration</code> object based on the evaluation of the given <code>IterationContextNode</code>.
+     * @param ctx
+     * @param iterationContextNode
+     * @return
+     * @throws NullContentInsideForIterationException
+     */
+    static ForIteration createForIteration(EvaluationContext ctx, IterationContextNode iterationContextNode) throws NullContentInsideForIterationException {
         LOG.trace("Creating ForIteration for {}", iterationContextNode);
         ForIteration toReturn = null;
         String name = iterationContextNode.evaluateName(ctx);
@@ -147,18 +174,5 @@ public class ForExpressionNode
             toReturn = getForIteration(ctx, name, result, rangeEnd);
         }
         return toReturn;
-    }
-
-    @Override
-    public ASTNode[] getChildrenNode() {
-        ASTNode[] children = new ASTNode[iterationContexts.size() + 1];
-        System.arraycopy(iterationContexts.toArray(new ASTNode[]{}), 0, children, 0, iterationContexts.size());
-        children[children.length - 1] = expression;
-        return children;
-    }
-
-    @Override
-    public <T> T accept(Visitor<T> v) {
-        return v.visit(this);
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ForExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ForExpressionNode.java
@@ -114,8 +114,8 @@ public class ForExpressionNode
             } else if (k < iterationContexts.size() - 1) {
                 populateToReturn(k + 1, ctx, toPopulate);
             }
+            ctx.exitFrame();
         }
-        ctx.exitFrame();
     }
 
     static void setValueIntoContext(EvaluationContext ctx, String name, Object value) {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/ForExpressionNodeTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/ForExpressionNodeTest.java
@@ -20,6 +20,7 @@ package org.kie.dmn.feel.lang.ast;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -27,6 +28,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.ast.forexpressioniterators.ForIteration;
+import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.ExecutionFrame;
 import org.kie.dmn.feel.util.EvaluationContextTestUtil;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 
@@ -80,5 +85,70 @@ class ForExpressionNodeTest {
         Object retrieved = forExpressionNode.evaluate(EvaluationContextTestUtil.newEmptyEvaluationContext());
         assertThat(retrieved).isInstanceOf(List.class).asList().containsExactly(LocalDate.of(1980, 1, 1),
                 LocalDate.of(1980, 1, 2), LocalDate.of(1980, 1, 3));
+    }
+
+    @Test
+    void populateToReturnFromRange() {
+        String iterationName = "x";
+        IterationContextNode iterationContextNode = getIterationContextNode(iterationName, getLocalDateRangeNode("[1980-01-01 .. 1980-01-03]", LocalDate.of(1980, 1, 1), LocalDate.of(1980, 1, 3), RangeNode.IntervalBoundary.CLOSED, RangeNode.IntervalBoundary.CLOSED ), iterationName + " in [1980-01-01 .. 1980-01-03]");
+        ForExpressionNode forExpressionNode = new ForExpressionNode(Collections.singletonList(iterationContextNode), getNameRefNode(BuiltInType.DATE, iterationName), "for " + iterationName + " in [1980-01-01 .. 1980-01-03] return " + iterationName);
+        List<Object> toPopulate = new ArrayList<>();
+        EvaluationContextImpl ctx = (EvaluationContextImpl) EvaluationContextTestUtil.newEmptyEvaluationContext();
+        ExecutionFrame peeked = ctx.peek();
+        forExpressionNode.populateToReturn(0, ctx, toPopulate);
+        assertThat(toPopulate).containsExactly(LocalDate.of(1980, 1, 1),
+                                               LocalDate.of(1980, 1, 2),
+                                               LocalDate.of(1980, 1, 3));
+        assertThat(ctx.getAllValues()).doesNotContainKeys(iterationName);
+        assertThat(ctx.peek()).isEqualTo(peeked);
+    }
+
+    @Test
+    void populateToReturnFromArray() {
+        String iterationName = "x";
+        IterationContextNode iterationContextNode = getIterationContextNode("x", getListNode("[ 1, 2, 3, 4 ]", Arrays.asList("1", "2", "3", "4")), "x in [ 1, 2, 3, 4 ]");
+        ForExpressionNode forExpressionNode = new ForExpressionNode(Collections.singletonList(iterationContextNode), getNameRefNode(BuiltInType.UNKNOWN, iterationName), "for " + iterationName + " in [ 1, 2, 3, 4 ] return " + iterationName);
+        List<Object> toPopulate = new ArrayList<>();
+        EvaluationContextImpl ctx = (EvaluationContextImpl) EvaluationContextTestUtil.newEmptyEvaluationContext();
+        ExecutionFrame peeked = ctx.peek();
+        forExpressionNode.populateToReturn(0, ctx, toPopulate);
+        assertThat(toPopulate).containsExactly(BigDecimal.ONE,
+                                               BigDecimal.valueOf(2),
+                                               BigDecimal.valueOf(3),
+                                               BigDecimal.valueOf(4));
+        assertThat(ctx.getAllValues()).doesNotContainKeys(iterationName);
+        assertThat(ctx.peek()).isEqualTo(peeked);
+    }
+
+    @Test
+    void populateToReturnOutsideBoundaries() {
+        IterationContextNode x = getIterationContextNode("x", getLocalDateRangeNode("[1980-01-01 .. 1980-01-03]", LocalDate.of(1980, 1, 1), LocalDate.of(1980, 1, 3), RangeNode.IntervalBoundary.CLOSED, RangeNode.IntervalBoundary.CLOSED ), "x in [1980-01-01 .. 1980-01-03]");
+        ForExpressionNode forExpressionNode = new ForExpressionNode(Collections.singletonList(x), getNameRefNode(BuiltInType.DATE, "x"), "for x in [1980-01-01 .. 1980-01-03] return x");
+        List<Object> toPopulate = new ArrayList<>();
+        EvaluationContext ctx = EvaluationContextTestUtil.newEmptyEvaluationContext();
+        forExpressionNode.populateToReturn(1, ctx, toPopulate);
+        assertThat(toPopulate).isEmpty();
+    }
+
+    @Test
+    void createForIterationFromRange() {
+        String iterationName = "x";
+        IterationContextNode iterationContextNode = getIterationContextNode(iterationName, getLocalDateRangeNode("[1980-01-01 .. 1980-01-03]", LocalDate.of(1980, 1, 1), LocalDate.of(1980, 1, 3), RangeNode.IntervalBoundary.CLOSED, RangeNode.IntervalBoundary.CLOSED ), "x in [1980-01-01 .. 1980-01-03]");
+        ForIteration retrieved = ForExpressionNode.createForIteration(EvaluationContextTestUtil.newEmptyEvaluationContext(), iterationContextNode);
+        assertThat(retrieved).isNotNull();
+        assertThat(retrieved.getName()).isEqualTo(iterationName);
+        assertThat(retrieved.hasNextValue()).isTrue();
+        assertThat(retrieved.getNextValue()).isEqualTo(LocalDate.of(1980, 1, 1));
+    }
+
+    @Test
+    void createForIterationFromArray() {
+        String iterationName = "x";
+        IterationContextNode iterationContextNode = getIterationContextNode("x", getListNode("[ 1, 2, 3, 4 ]", Arrays.asList("1", "2", "3", "4")), "x in [ 1, 2, 3, 4 ]");
+        ForIteration retrieved = ForExpressionNode.createForIteration(EvaluationContextTestUtil.newEmptyEvaluationContext(), iterationContextNode);
+        assertThat(retrieved).isNotNull();
+        assertThat(retrieved.getName()).isEqualTo(iterationName);
+        assertThat(retrieved.hasNextValue()).isTrue();
+        assertThat(retrieved.getNextValue()).isEqualTo(BigDecimal.ONE);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2336

The issue is related to the enter/exit context frame inside a while loop in ForIterationNode.
This PR fixes that, keeping in sync enter/exit frame.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
