### PR TITLE
[CVE] Upgrade Quarkus to 3.27.4, Netty to 4.1.133.Final, and Vert.x to 4.5.27 

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -146,7 +146,7 @@
     <version.io.fabric8.kubernetes-client>7.3.1</version.io.fabric8.kubernetes-client>
     <version.io.grpc>1.76.0</version.io.grpc>
     <version.io.micrometer>1.16.4</version.io.micrometer>
-    <version.io.netty>4.1.132.Final</version.io.netty>
+    <version.io.netty>4.1.133.Final</version.io.netty>
     <version.io.opentelemetry>1.0.0-alpha</version.io.opentelemetry>
     <version.io.opentelemetry-api>1.62.0</version.io.opentelemetry-api>
     <version.io.rest-assured>5.5.6</version.io.rest-assured>
@@ -163,7 +163,7 @@
     <version.io.smallrye.reactive.mutiny-zero>1.1.1</version.io.smallrye.reactive.mutiny-zero>
     <version.io.swagger.core.v3>2.2.38</version.io.swagger.core.v3>
     <version.io.swagger.parser.v3>2.1.34</version.io.swagger.parser.v3>
-    <version.io.vertx>4.5.25</version.io.vertx>
+    <version.io.vertx>4.5.27</version.io.vertx>
     <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
     <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
     <version.jakarta.activation>2.0.3</version.jakarta.activation>

--- a/kie-quarkus-build-parent/pom.xml
+++ b/kie-quarkus-build-parent/pom.xml
@@ -39,8 +39,8 @@
   </description>
 
   <properties>
-    <version.io.quarkus>3.27.3</version.io.quarkus>
-    <version.io.quarkus.camel>3.27.3</version.io.quarkus.camel>
+    <version.io.quarkus>3.27.4</version.io.quarkus>
+    <version.io.quarkus.camel>3.27.4</version.io.quarkus.camel>
     <!-- Used to define which poms are allowed to have dependencyManagement sections. This is to enforce the convention that only the root pom should have dependencyManagement, and all other poms should inherit from it. -->
     <allowedPomsList>org.kie:kie-quarkus-build-parent</allowedPomsList>
     <!-- To be overridden by poms with dependency management -->


### PR DESCRIPTION
**Upgraded:**

Quarkus: 3.27.3 → 3.27.4
Netty: 4.1.132.Final → 4.1.133.Final
Vert.x: 4.5.25 → 4.5.27

**CVEs Remediated:**

[Critical] CVE-2026-42580, CVE-2026-42581, CVE-2026-42584, CVE-2026-42585, CVE-2026-42587 (netty-codec-http, netty-codec-http2)
[High] CVE-2026-42579 (netty-codec-dns)
[High] CVE-2026-42583, CVE-2026-33870, CVE-2026-33871 (netty-codec-http)
[Medium] CVE-2026-1002, CVE-2026-6860 (vertx-core)
[Low] CVE-2026-42578 (netty-handler-proxy)

**Related PRs:**
incubator-kie-optaplanner: https://github.com/apache/incubator-kie-optaplanner/pull/3233
incubator-kie-kogito-runtimes: https://github.com/apache/incubator-kie-kogito-runtimes/pull/4311
incubator-kie-tools: https://github.com/apache/incubator-kie-tools/pull/3619
incubator-kie-kogito-examples: https://github.com/apache/incubator-kie-kogito-examples/pull/2216
