### PR TITLE
Fix CVE-2024-6763, CVE-2025-11143, CVE-2026-2332, CVE-2025-5115: Upgade to Jetty 12.0.33

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -329,7 +329,6 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-      <!-- Import Jetty BOM to ensure consistent Jetty 12.0.33 versions -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
@@ -1599,7 +1598,7 @@
         <artifactId>ecj</artifactId>
         <version>${version.org.eclipse.jdt}</version>
       </dependency>
-      <!-- Explicit Jetty 12.0.33 dependency management to prevent version conflicts -->
+      <!-- Explicit set to Jetty 12.0.33 version, overriding version transitively imported by wiremock-jetty12 3.12.2  -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -1598,7 +1598,22 @@
         <artifactId>ecj</artifactId>
         <version>${version.org.eclipse.jdt}</version>
       </dependency>
-      <!-- Explicit set to Jetty 12.0.33 version, overriding version transitively imported by wiremock-jetty12 3.12.2  -->
+      <!-- Explicit set to Jetty 12.0.33 version, overriding version transitively imported by wiremock-jetty12 3.13.2  -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-alpn-client</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-alpn-server</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-client</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
@@ -1611,7 +1626,22 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-proxy</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-session</artifactId>
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>
@@ -1621,7 +1651,22 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-proxy</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-servlet</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.http2</groupId>
+        <artifactId>jetty-http2-client</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.http2</groupId>
+        <artifactId>jetty-http2-client-transport</artifactId>
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -296,7 +296,6 @@
     <version.org.w3c.dom>2.3.0-jaxb-1.0.6</version.org.w3c.dom>
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>
-    <!-- Addind for jetty CVE fix-->
     <version.org.eclipse.jetty>12.0.33</version.org.eclipse.jetty>
     <version.org.wiremock>3.13.2</version.org.wiremock>
     <version.org.wiremock.webhooks>3.0.4</version.org.wiremock.webhooks>

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -296,6 +296,7 @@
     <version.org.w3c.dom>2.3.0-jaxb-1.0.6</version.org.w3c.dom>
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>
+    <!-- Addind for jetty CVE fix-->
     <version.org.eclipse.jetty>12.0.33</version.org.eclipse.jetty>
     <version.org.wiremock>3.13.2</version.org.wiremock>
     <version.org.wiremock.webhooks>3.0.4</version.org.wiremock.webhooks>

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -1607,12 +1607,12 @@
       <!-- Explicit Jetty 12.0.33 dependency management to prevent version conflicts -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-http</artifactId>
+        <artifactId>jetty-server</artifactId>
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
+        <artifactId>jetty-http</artifactId>
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>
@@ -1626,28 +1626,8 @@
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-client</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-alpn-client</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-security</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-session</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-xml</artifactId>
+        <groupId>org.eclipse.jetty.http2</groupId>
+        <artifactId>jetty-http2-server</artifactId>
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>
@@ -1657,22 +1637,12 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
-        <artifactId>jetty-http2-server</artifactId>
+        <artifactId>jetty-http2-hpack</artifactId>
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-servlet</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-webapp</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-annotations</artifactId>
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -241,6 +241,7 @@
     <version.org.bouncycastle.bc.jdk18on>1.84</version.org.bouncycastle.bc.jdk18on>
     <version.org.codehaus.plexus.plexus-utils>3.6.1</version.org.codehaus.plexus.plexus-utils>
     <version.org.eclipse.jdt>3.44.0</version.org.eclipse.jdt>
+    <version.org.eclipse.jetty>12.0.33</version.org.eclipse.jetty>
     <version.org.eclipse.jetty.jakarta.servlet.api>5.0.2</version.org.eclipse.jetty.jakarta.servlet.api>
     <version.org.eclipse.microprofile.config>3.1</version.org.eclipse.microprofile.config>
     <version.org.eclipse.microprofile.openapi>4.0.2</version.org.eclipse.microprofile.openapi>
@@ -295,7 +296,6 @@
     <version.org.w3c.dom>2.3.0-jaxb-1.0.6</version.org.w3c.dom>
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>
-    <version.org.eclipse.jetty>12.0.33</version.org.eclipse.jetty>
     <version.org.wiremock>3.13.2</version.org.wiremock>
     <version.org.wiremock.webhooks>3.0.4</version.org.wiremock.webhooks>
     <version.org.xmlunit>2.10.4</version.org.xmlunit>
@@ -1599,17 +1599,7 @@
         <artifactId>ecj</artifactId>
         <version>${version.org.eclipse.jdt}</version>
       </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty.toolchain</groupId>
-        <artifactId>jetty-jakarta-servlet-api</artifactId>
-        <version>${version.org.eclipse.jetty.jakarta.servlet.api}</version>
-      </dependency>
       <!-- Explicit Jetty 12.0.33 dependency management to prevent version conflicts -->
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
@@ -1622,12 +1612,17 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.http2</groupId>
-        <artifactId>jetty-http2-server</artifactId>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-servlet</artifactId>
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>
@@ -1641,9 +1636,14 @@
         <version>${version.org.eclipse.jetty}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-servlet</artifactId>
+        <groupId>org.eclipse.jetty.http2</groupId>
+        <artifactId>jetty-http2-server</artifactId>
         <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.toolchain</groupId>
+        <artifactId>jetty-jakarta-servlet-api</artifactId>
+        <version>${version.org.eclipse.jetty.jakarta.servlet.api}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.config</groupId>

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -296,6 +296,7 @@
     <version.org.w3c.dom>2.3.0-jaxb-1.0.6</version.org.w3c.dom>
     <version.org.webjars.bootstrap>5.1.3</version.org.webjars.bootstrap>
     <version.org.webjars.jquery>3.6.0</version.org.webjars.jquery>
+    <version.org.eclipse.jetty>12.0.33</version.org.eclipse.jetty>
     <version.org.wiremock>3.13.2</version.org.wiremock>
     <version.org.wiremock.webhooks>3.0.4</version.org.wiremock.webhooks>
     <version.org.xmlunit>2.10.4</version.org.xmlunit>
@@ -329,6 +330,14 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <!-- Import Jetty BOM to ensure consistent Jetty 12.0.33 versions -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!--Both antlr:antlr and org.antlr:antlr-runtime is needed. They are completely different.-->
       <dependency>
         <groupId>antlr</groupId>
@@ -1596,6 +1605,77 @@
         <artifactId>jetty-jakarta-servlet-api</artifactId>
         <version>${version.org.eclipse.jetty.jakarta.servlet.api}</version>
       </dependency>
+      <!-- Explicit Jetty 12.0.33 dependency management to prevent version conflicts -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-http</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-io</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-client</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-alpn-client</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-session</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-xml</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.http2</groupId>
+        <artifactId>jetty-http2-common</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.http2</groupId>
+        <artifactId>jetty-http2-server</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-servlet</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-webapp</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-annotations</artifactId>
+        <version>${version.org.eclipse.jetty}</version>
+      </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.config</groupId>
         <artifactId>microprofile-config-api</artifactId>
@@ -2175,7 +2255,7 @@
       </dependency>
       <dependency>
         <groupId>org.wiremock</groupId>
-        <artifactId>wiremock</artifactId>
+        <artifactId>wiremock-jetty12</artifactId>
         <version>${version.org.wiremock}</version>
         <scope>test</scope>
         <exclusions>

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -68,7 +68,6 @@
     <!-- Set to "true" on every project that has no violations. -->
     <spotbugs.failOnViolation>false</spotbugs.failOnViolation>
     <surefire.forkCount>1</surefire.forkCount>
-
     <!--
      CONVENTIONS:
      - A version property must be specified in the format "version.{groupId}", optionally with a suffix to make it unique.


### PR DESCRIPTION
This PR resolves four critical and high-severity CVEs in Jetty by upgrading from version 11.0.24 to 12.0.33.

WireMock 3.13.2 ships a separate artifact — `wiremock-jetty12` — which pulls Jetty 12.0.33 instead of 11.x. Switching to this artifact resolves all four CVEs.

**Changes Done**
   - Added version.org.eclipse.jetty=12.0.33`
   - wiremock : 3.13.0 -> 3.13.2`
   - Added `jetty-bom:12.0.33` in dependencyManagement
   - Added explicit dependency management other Jetty artifacts:**
           
 This explicit management was necessary because wiremock-jetty12:3.13.2 brings in mixed Jetty versions (12.1.7 for core, 12.0.30 for EE10), causing NoSuchMethodError at runtime.

**Replaced wiremock with wiremock-jetty12:**
   - Changed from `<artifactId>wiremock</artifactId>` to `<artifactId>wiremock-jetty12</artifactId>`
   - Added exclusion for `jetty-jakarta-servlet-api` to avoid conflicts

**Impact**
- All Jetty artifacts now resolve to version 12.0.33
- All four CVEs are resolved