### PR TITLE
revert: "[CVE][Medium] CVE-2026-45292 opentelemetry-api-1.44.1.jar (#6744)

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -147,7 +147,6 @@
     <version.io.micrometer>1.16.4</version.io.micrometer>
     <version.io.netty>4.1.135.Final</version.io.netty>
     <version.io.opentelemetry>1.0.0-alpha</version.io.opentelemetry>
-    <version.io.opentelemetry-api>1.62.0</version.io.opentelemetry-api>
     <version.io.rest-assured>5.5.6</version.io.rest-assured>
     <version.io.smallrye-config>3.13.4</version.io.smallrye-config>
     <version.io.smallrye-health>4.2.0</version.io.smallrye-health>
@@ -935,15 +934,6 @@
         <artifactId>netty-transport-udt</artifactId>
         <version>${version.io.netty}</version>
       </dependency>
-      <!-- Version overrides to fix vulnerabilities. -->
-      <!-- Quarkus 3.27.3 transitively imports io.opentelemetry:opentelemetry-api:1.44.1 -->
-      <!-- CVE: https://github.com/open-telemetry/opentelemetry-java/security/advisories/GHSA-rcgg-9c38-7xpx -->
-      <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-api</artifactId>
-        <version>${version.io.opentelemetry-api}</version>
-      </dependency>
-      <!-- Version overrides to fix vulnerabilities - end -->
       <dependency>
         <groupId>io.opentelemetry.proto</groupId>
         <artifactId>opentelemetry-proto</artifactId>


### PR DESCRIPTION
This reverts commit 5eb2d69d81ce51a6896047e43d9e0fc6d79a6058.

Quarkus 3.27.x doesn't support the introduced OpenTelemetry version, as a result native build in kogito event driven examples