### PR TITLE
[NO-ISSUE] Add netty-codec-compression dependency management to fix CVE-2026-42583

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -824,6 +824,12 @@
         <artifactId>netty-codec</artifactId>
         <version>${version.io.netty}</version>
       </dependency>
+      <!-- Netty codec-compression - explicitly managed to fix CVE -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-compression</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-dns</artifactId>


### PR DESCRIPTION

Add netty-codec-compression dependency management to fix CVE-2026-42583