### PR TITLE
[DO-NOT-MERGE] [incubator-kie-drools-6765] Fix removeDormantTuple NPE with explicit MatchState

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
@@ -33,6 +33,7 @@ import static org.drools.core.phreak.PhreakNodeOperations.useLeftMemory;
 import org.drools.core.reteoo.LeftTupleSink;
 import org.drools.core.reteoo.RuleTerminalNode;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
+import org.drools.core.reteoo.RuleTerminalNodeLeftTuple.MatchState;
 import org.drools.core.reteoo.TupleFactory;
 import org.drools.core.reteoo.TupleImpl;
 
@@ -142,7 +143,7 @@ public class PhreakBranchNode {
             if (oldRtn != null) {
                 if (newRtn == null) {
                     // old exits, new does not, so delete
-                    if ( branchTuples.rtnLeftTuple.getMemory() != null ) {
+                    if ( branchTuples.rtnLeftTuple.getMatchState() == MatchState.ACTIVE ) {
                         executor.removeActiveTuple(branchTuples.rtnLeftTuple);
                     }
                     PhreakRuleTerminalNode.doLeftDelete(activationsManager, executor, branchTuples.rtnLeftTuple);
@@ -153,7 +154,7 @@ public class PhreakBranchNode {
 
                 } else {
                     // old and new on different branches, delete one and insert the other
-                    if ( branchTuples.rtnLeftTuple.getMemory() != null ) {
+                    if ( branchTuples.rtnLeftTuple.getMatchState() == MatchState.ACTIVE ) {
                         executor.removeActiveTuple(branchTuples.rtnLeftTuple);
                     }
                     PhreakRuleTerminalNode.doLeftDelete(activationsManager, executor, branchTuples.rtnLeftTuple);
@@ -205,7 +206,7 @@ public class PhreakBranchNode {
             BranchTuples branchTuples = getBranchTuples(sink, leftTuple);
 
             if (branchTuples.rtnLeftTuple != null) {
-                if ( branchTuples.rtnLeftTuple.getMemory() != null ) {
+                if ( branchTuples.rtnLeftTuple.getMatchState() == MatchState.ACTIVE ) {
                     executor.removeActiveTuple(branchTuples.rtnLeftTuple);
                 }
                 PhreakRuleTerminalNode.doLeftDelete(activationsManager, executor, branchTuples.rtnLeftTuple);

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
@@ -29,6 +29,7 @@ import org.drools.core.common.TupleSets;
 import org.drools.core.reteoo.ObjectTypeConf;
 import org.drools.core.reteoo.RuleTerminalNode;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
+import org.drools.core.reteoo.RuleTerminalNodeLeftTuple.MatchState;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.reteoo.Tuple;
 import org.drools.core.reteoo.TupleImpl;
@@ -274,11 +275,10 @@ public class PhreakRuleTerminalNode {
 
         leftTuple.cancelActivation( activationsManager );
 
-        if ( leftTuple.getMemory() != null ) {
-            // Expiration propagations should not be removed from the list, as they still need to fire
+        if ( leftTuple.getMatchState() == MatchState.ACTIVE ) {
             executor.removeActiveTuple( leftTuple );
-        } else if ( leftTuple.getStagedType() == Tuple.DELETE && !leftTuple.isQueued() ) {
-            executor.removeDormantTuple( leftTuple );
+        } else {
+            executor.removeTuple( leftTuple );
         }
 
         leftTuple.setContextObject( null );

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -33,6 +33,7 @@ import org.drools.core.event.RuleEventListenerSupport;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.RuleTerminalNode;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
+import org.drools.core.reteoo.RuleTerminalNodeLeftTuple.MatchState;
 import org.drools.core.reteoo.Tuple;
 import org.drools.core.reteoo.TupleImpl;
 import org.drools.core.rule.consequence.InternalMatch;
@@ -48,8 +49,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RuleExecutor {
-
-    private static final boolean DEBUG_DORMANT_TUPLE = false;
 
     protected static final Logger log = LoggerFactory.getLogger(RuleExecutor.class);
 
@@ -294,41 +293,13 @@ public class RuleExecutor {
     }
 
     public void addDormantTuple(RuleTerminalNodeLeftTuple tuple) {
-        if (DEBUG_DORMANT_TUPLE) {
-            if (tuple.isDormant()) {
-                throw new IllegalStateException();
-            }
-        }
+        tuple.setMatchState(MatchState.DORMANT);
         dormantMatches.add(tuple);
-        if (DEBUG_DORMANT_TUPLE) {
-            tuple.setDormant(true);
-        }
     }
-
-    public void removeDormantTuple(RuleTerminalNodeLeftTuple tuple) {
-        if (DEBUG_DORMANT_TUPLE) {
-            if (!tuple.isDormant()) {
-                throw new IllegalStateException();
-            }
-        }
-        if (tuple.getPrevious() != null || dormantMatches.getFirst() == tuple) {
-            dormantMatches.remove(tuple);
-        } else {
-            log.debug("Skipping removeDormantTuple for orphan tuple {} on rule \"{}\" — tuple is not present in dormantMatches",
-                      tuple, ruleAgendaItem.getRule().getName());
-        }
-        if (DEBUG_DORMANT_TUPLE) {
-            tuple.setDormant(false);
-        }
-   }
 
     public void addActiveTuple(RuleTerminalNodeLeftTuple tuple) {
         tuple.setQueued(true);
-        if (DEBUG_DORMANT_TUPLE) {
-            if (tuple.isDormant()) {
-                throw new IllegalStateException();
-            }
-        }
+        tuple.setMatchState(MatchState.ACTIVE);
         this.activeMatches.add(tuple);
         if (queue != null) {
             addQueuedLeftTuple(tuple);
@@ -336,7 +307,9 @@ public class RuleExecutor {
     }
 
     public void modifyActiveTuple(RuleTerminalNodeLeftTuple tuple) {
-        removeDormantTuple(tuple);
+        if (tuple.getMatchState() == MatchState.DORMANT) {
+            dormantMatches.remove(tuple);
+        }
         addActiveTuple(tuple);
     }
 
@@ -345,10 +318,19 @@ public class RuleExecutor {
         activeMatches.remove(tuple);
         if (tuple.getStagedType() != Tuple.DELETE) {
             addDormantTuple(tuple);
+        } else {
+            tuple.setMatchState(MatchState.REMOVED);
         }
         if (queue != null) {
             removeQueuedLeftTuple(tuple);
         }
+    }
+
+    public void removeTuple(RuleTerminalNodeLeftTuple tuple) {
+        if (tuple.getMatchState() == MatchState.DORMANT) {
+            dormantMatches.remove(tuple);
+        }
+        tuple.setMatchState(MatchState.REMOVED);
     }
 
     public void addQueuedLeftTuple(RuleTerminalNodeLeftTuple tuple) {
@@ -379,6 +361,7 @@ public class RuleExecutor {
     public void cancel(ReteEvaluator reteEvaluator, EventSupport es) {
         while (!activeMatches.isEmpty()) {
             RuleTerminalNodeLeftTuple rtnLt = (RuleTerminalNodeLeftTuple) activeMatches.removeFirst();
+            rtnLt.setMatchState(MatchState.REMOVED);
             if (queue != null) {
                 queue.dequeue(rtnLt);
             }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
@@ -133,15 +133,9 @@ public class RuleTerminalNode extends AbstractTerminalNode {
 
     public void cancelMatch(InternalMatch match) {
         if ( match.isQueued() ) {
-            TupleImpl leftTuple = match.getTuple();
-            if ( match.getRuleAgendaItem() != null ) {
-                // phreak must also remove the LT from the rule network evaluator
-                if ( leftTuple.getMemory() != null ) {
-                    leftTuple.getMemory().remove( leftTuple );
-                }
-            }
-            RuleExecutor ruleExecutor = ((RuleTerminalNodeLeftTuple)leftTuple).getRuleAgendaItem().getRuleExecutor();
-            PhreakRuleTerminalNode.doLeftDelete(ruleExecutor.getPathMemory().getActualActivationsManager( ), ruleExecutor, (RuleTerminalNodeLeftTuple) leftTuple);
+            RuleTerminalNodeLeftTuple leftTuple = (RuleTerminalNodeLeftTuple) match.getTuple();
+            RuleExecutor ruleExecutor = leftTuple.getRuleAgendaItem().getRuleExecutor();
+            PhreakRuleTerminalNode.doLeftDelete(ruleExecutor.getPathMemory().getActualActivationsManager( ), ruleExecutor, leftTuple);
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNodeLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNodeLeftTuple.java
@@ -39,6 +39,9 @@ import org.kie.api.runtime.rule.FactHandle;
 
 public class RuleTerminalNodeLeftTuple extends LeftTuple implements InternalMatch {
     private static final long serialVersionUID = 540l;
+
+    public enum MatchState { NONE, ACTIVE, DORMANT, REMOVED }
+
     /**
      * The salience
      */
@@ -65,8 +68,7 @@ public class RuleTerminalNodeLeftTuple extends LeftTuple implements InternalMatc
     private RuleImpl rule;
     private Consequence consequence;
 
-    // left here for debugging purposes: switch RuleExecutor.DEBUG_DORMANT_TUPLE to true to enable this debugging
-    // private boolean dormant;
+    private MatchState matchState = MatchState.NONE;
 
     public RuleTerminalNodeLeftTuple() {
         // constructor needed for serialisation
@@ -352,13 +354,11 @@ public class RuleTerminalNodeLeftTuple extends LeftTuple implements InternalMatc
         return true;
     }
 
-    public boolean isDormant() {
-        throw new IllegalStateException("This method can be called only for debugging purposes. Uncomment dormant boolean to enable debugging.");
-        // return dormant;
+    public MatchState getMatchState() {
+        return matchState;
     }
 
-    public void setDormant(boolean dormant) {
-        throw new IllegalStateException("This method can be called only for debugging purposes. Uncomment dormant boolean to enable debugging.");
-        // this.dormant = dormant;
+    public void setMatchState(MatchState matchState) {
+        this.matchState = matchState;
     }
 }

--- a/drools-core/src/test/java/org/drools/core/phreak/RuleExecutorDormantTupleTest.java
+++ b/drools-core/src/test/java/org/drools/core/phreak/RuleExecutorDormantTupleTest.java
@@ -21,6 +21,7 @@ package org.drools.core.phreak;
 import org.drools.base.base.SalienceInteger;
 import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
+import org.drools.core.reteoo.RuleTerminalNodeLeftTuple.MatchState;
 import org.drools.core.reteoo.Tuple;
 import org.junit.jupiter.api.Test;
 
@@ -29,82 +30,60 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Targeted regression test for the guard in {@link RuleExecutor#removeDormantTuple} added for
- * issue 6422. A tuple passed to {@code removeDormantTuple} may already have been unlinked from
- * {@code dormantMatches} by another path (e.g. {@code modifyActiveTuple}), in which case its
- * {@code previous} pointer is null and the unguarded {@code LinkedList.remove()} dereferences it.
- */
 public class RuleExecutorDormantTupleTest {
 
     @Test
-    public void removeDormantTuple_whenTupleAlreadyUnlinkedFromList_doesNotNPE() {
-        final RuleExecutor executor = newRuleExecutor();
-        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
-        final RuleTerminalNodeLeftTuple t2 = new RuleTerminalNodeLeftTuple();
-
-        executor.addDormantTuple(t1);
-        executor.addDormantTuple(t2);
-
-        // First remove takes t1 out cleanly via the firstNode path. After this,
-        // t1.previous is null and dormantMatches.getFirst() is t2 — the exact state
-        // the bug fix guards against.
-        executor.removeDormantTuple(t1);
-        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
-        assertThat(t1.getPrevious()).isNull();
-        assertThat(executor.getDormantMatches().getFirst()).isNotSameAs(t1);
-
-        // Without the guard, LinkedList.remove() would fall into the middle-node
-        // branch and NPE on t1.getPrevious().setNext(...).
-        assertThatNoException().isThrownBy(() -> executor.removeDormantTuple(t1));
-
-        // The list is unchanged: t2 is still the sole dormant tuple.
-        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
-        assertThat(executor.getDormantMatches().getFirst()).isSameAs(t2);
-    }
-
-    @Test
-    public void removeDormantTuple_whenTupleIsInList_unlinksIt() {
+    public void removeTuple_whenDormant_removesFromListAndSetsRemoved() {
         final RuleExecutor executor = newRuleExecutor();
         final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
 
         executor.addDormantTuple(t1);
         assertThat(executor.getDormantMatches().size()).isEqualTo(1);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.DORMANT);
 
-        executor.removeDormantTuple(t1);
+        executor.removeTuple(t1);
         assertThat(executor.getDormantMatches().size()).isZero();
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.REMOVED);
     }
 
-    /**
-     * {@link RuleExecutor#modifyActiveTuple} routes through {@code removeDormantTuple}, so the
-     * same NPE could surface from this second entry point. Pins the guard from both call sites.
-     */
     @Test
-    public void modifyActiveTuple_whenTupleAlreadyUnlinkedFromDormantList_doesNotNPE() {
+    public void removeTuple_whenNone_setsRemovedWithoutNPE() {
         final RuleExecutor executor = newRuleExecutor();
         final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
-        final RuleTerminalNodeLeftTuple t2 = new RuleTerminalNodeLeftTuple();
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.NONE);
+
+        assertThatNoException().isThrownBy(() -> executor.removeTuple(t1));
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.REMOVED);
+    }
+
+    @Test
+    public void modifyActiveTuple_whenDormant_movesToActive() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
 
         executor.addDormantTuple(t1);
-        executor.addDormantTuple(t2);
-        executor.removeDormantTuple(t1);
+        executor.modifyActiveTuple(t1);
+
+        assertThat(executor.getActiveMatches().size()).isEqualTo(1);
+        assertThat(executor.getDormantMatches().size()).isZero();
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.ACTIVE);
+        assertThat(t1.isQueued()).isTrue();
+    }
+
+    @Test
+    public void modifyActiveTuple_whenNone_movesToActiveWithoutNPE() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
 
         assertThatNoException().isThrownBy(() -> executor.modifyActiveTuple(t1));
 
         assertThat(executor.getActiveMatches().size()).isEqualTo(1);
-        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
-        assertThat(executor.getDormantMatches().getFirst()).isSameAs(t2);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.ACTIVE);
         assertThat(t1.isQueued()).isTrue();
     }
 
-    /**
-     * Pins the upstream half of the bug: {@link RuleExecutor#removeActiveTuple} must skip
-     * {@code addDormantTuple} when the staged type is DELETE. This is the precondition that
-     * leaves a tuple unlinked from {@code dormantMatches} while later paths still try to
-     * remove it.
-     */
     @Test
-    public void removeActiveTuple_whenStagedForDelete_skipsDormantTransition() {
+    public void removeActiveTuple_whenStagedForDelete_setsRemoved() {
         final RuleExecutor executor = newRuleExecutor();
         final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
 
@@ -115,6 +94,7 @@ public class RuleExecutorDormantTupleTest {
 
         assertThat(executor.getActiveMatches().size()).isZero();
         assertThat(executor.getDormantMatches().size()).isZero();
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.REMOVED);
     }
 
     @Test
@@ -123,13 +103,13 @@ public class RuleExecutorDormantTupleTest {
         final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
 
         executor.addActiveTuple(t1);
-        // Default stagedType is NONE (0); leave it as-is.
 
         executor.removeActiveTuple(t1);
 
         assertThat(executor.getActiveMatches().size()).isZero();
         assertThat(executor.getDormantMatches().size()).isEqualTo(1);
         assertThat(executor.getDormantMatches().getFirst()).isSameAs(t1);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.DORMANT);
     }
 
     private static RuleExecutor newRuleExecutor() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RemoveDormantTupleNPETest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RemoveDormantTupleNPETest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.mvel.integrationtests;
+
+import java.util.stream.Stream;
+
+import org.drools.mvel.compiler.Cheese;
+import org.drools.mvel.compiler.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.FactHandle;
+
+/**
+ * Reproducers for NPE in RuleExecutor.removeDormantTuple (issue #6422, PR #6707).
+ *
+ * Root cause: doLeftTupleInsert can return early (no-loop or lock-on-active guard)
+ * without adding the tuple to any RuleExecutor list. The tuple remains linked as
+ * a child at the join node. A subsequent fact modification triggers an UPDATE for
+ * the orphan, and modifyActiveTuple calls removeDormantTuple on a tuple that was
+ * never in dormantMatches — NPE in LinkedList.remove().
+ */
+public class RemoveDormantTupleNPETest {
+
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
+    }
+
+    /**
+     * Orphan via no-loop, triggered by external ksession.update().
+     *
+     * R1 (no-loop) fires → inserts new Cheese → new match blocked by no-loop → orphan.
+     * External update of Person → UPDATE on orphan → NPE.
+     */
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testNoLoopInsertThenExternalUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        final String drl =
+                "package org.drools.reproducer\n" +
+                "import " + Cheese.class.getCanonicalName() + "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule R1\n" +
+                "    no-loop true\n" +
+                "when\n" +
+                "    $c : Cheese(price > 0)\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    insert(new Cheese(\"inserted\", $c.getPrice() + 100));\n" +
+                "end\n";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            Cheese cheese = new Cheese("original", 1);
+            Person person = new Person("john", 1);
+
+            ksession.insert(cheese);
+            FactHandle personHandle = ksession.insert(person);
+
+            // R1 fires → inserts Cheese("inserted",101) → new match blocked by no-loop → orphan
+            ksession.fireAllRules();
+
+            // Modify Person externally → right-side UPDATE at R1's join node hits the orphan
+            person.setAge(2);
+            ksession.update(personHandle, person);
+
+            // doLeftTupleUpdate → modifyActiveTuple → removeDormantTuple → NPE
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+    /**
+     * Orphan via no-loop, triggered by a second rule's modify — single fireAllRules.
+     *
+     * R1 (no-loop, higher salience) fires first → inserts new Cheese → orphan.
+     * R2 fires second → modifies Person → UPDATE on orphan → NPE.
+     * All within one fireAllRules() call.
+     */
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testNoLoopCrossRuleModify(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        final String drl =
+                "package org.drools.reproducer\n" +
+                "import " + Cheese.class.getCanonicalName() + "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule R1\n" +
+                "    no-loop true\n" +
+                "    salience 10\n" +
+                "when\n" +
+                "    $c : Cheese(price > 0)\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    insert(new Cheese(\"inserted\", $c.getPrice() + 100));\n" +
+                "end\n" +
+                "\n" +
+                "rule R2\n" +
+                "    no-loop true\n" +
+                "    salience 5\n" +
+                "when\n" +
+                "    $c : Cheese(type == \"original\")\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    modify($p) { setAge($p.getAge() + 1) };\n" +
+                "end\n";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            ksession.insert(new Cheese("original", 1));
+            ksession.insert(new Person("john", 1));
+
+            // R1 fires (salience 10): inserts Cheese("inserted",101) → orphan at R1's terminal.
+            // R2 fires (salience 5): modifies Person → right-side UPDATE at R1's join node.
+            // R1 re-evaluates: doLeftTupleUpdate on orphan → modifyActiveTuple → NPE.
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+    /**
+     * Orphan via lock-on-active, triggered by external ksession.update().
+     *
+     * R1 (lock-on-active, agenda-group) fires → inserts new Cheese → new match
+     * blocked by lock-on-active → orphan.
+     * After the group deactivates, external update of Person + re-focus → NPE.
+     */
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testLockOnActiveInsertThenExternalUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        final String drl =
+                "package org.drools.reproducer\n" +
+                "import " + Cheese.class.getCanonicalName() + "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule R1\n" +
+                "    agenda-group \"group1\"\n" +
+                "    lock-on-active true\n" +
+                "when\n" +
+                "    $c : Cheese(price > 0)\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    insert(new Cheese(\"inserted\", $c.getPrice() + 100));\n" +
+                "end\n";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            Cheese cheese = new Cheese("original", 1);
+            Person person = new Person("john", 1);
+
+            ksession.insert(cheese);
+            FactHandle personHandle = ksession.insert(person);
+
+            // Activate group and fire. R1 fires → inserts Cheese("inserted",101).
+            // New match blocked by lock-on-active → orphan.
+            ksession.getAgenda().getAgendaGroup("group1").setFocus();
+            ksession.fireAllRules();
+
+            // Modify Person while group is inactive (update recency < activation recency
+            // when group is re-focused, so lock-on-active won't block the update).
+            person.setAge(2);
+            ksession.update(personHandle, person);
+
+            // Re-focus and fire. doLeftTupleUpdate processes the UPDATE on the orphan.
+            // lock-on-active check passes (fact was modified before group re-activation).
+            // modifyActiveTuple → removeDormantTuple → NPE.
+            ksession.getAgenda().getAgendaGroup("group1").setFocus();
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+    /**
+     * Orphan via no-loop, triggered by DELETE (retract) — single fireAllRules,
+     * no external update, no modify.
+     *
+     * R1 (no-loop) fires → inserts a new fact → new match blocked by no-loop → orphan.
+     * R2 retracts the inserted fact → LEFT DELETE propagates to orphan →
+     * doLeftDelete → removeDormantTuple → NPE.
+     *
+     * This is the most realistic scenario: rules only use insert/retract (no modify),
+     * and the NPE occurs within a single fireAllRules() call.
+     */
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testNoLoopInsertRetractNoExternalUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        // R1: inserts a new Cheese("big", price+100) when it finds a cheap Cheese with a Person.
+        //     The new Cheese re-matches R1 with the same Person → blocked by no-loop → orphan.
+        //
+        // R2: retracts any Cheese with price > 50. This covers the inserted Cheese("big", 101).
+        //     Retracting it propagates a LEFT DELETE through R1's join node, hitting the orphan.
+        final String drl =
+                "package org.drools.reproducer\n" +
+                "import " + Cheese.class.getCanonicalName() + "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule R1\n" +
+                "    no-loop true\n" +
+                "    salience 10\n" +
+                "when\n" +
+                "    $c : Cheese(price > 0)\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    insert(new Cheese(\"big\", $c.getPrice() + 100));\n" +
+                "end\n" +
+                "\n" +
+                "rule R2\n" +
+                "    salience 1\n" +
+                "when\n" +
+                "    $c : Cheese(price > 50)\n" +
+                "then\n" +
+                "    retract($c);\n" +
+                "end\n";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            ksession.insert(new Cheese("original", 1));
+            ksession.insert(new Person("john", 1));
+
+            // R1 fires (salience 10): inserts Cheese("big",101) → orphan at R1's terminal.
+            // R2 fires (salience 1): retracts Cheese("big",101) → LEFT DELETE on orphan.
+            // doLeftDelete → removeDormantTuple on orphan → NPE.
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
+    }
+}


### PR DESCRIPTION
Draft fix1

Introduced MatchState to clarify the NONE->ACTIVE->DORMANT->REMOVED state transition. (However, it may be still difficult?)