### PR TITLE
[DO-NOT-MERGE] [incubator-kie-drools-6765] Fix removeDormantTuple NPE with explicit MatchState

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/ActivationsManager.java
+++ b/drools-core/src/main/java/org/drools/core/common/ActivationsManager.java
@@ -93,7 +93,7 @@ public interface ActivationsManager {
         if (!ruleAgendaItem.isQueued()) {
             ruleAgendaItem.getRuleExecutor().getPathMemory().queueRuleAgendaItem();
         }
-        ruleAgendaItem.getRuleExecutor().modifyActiveTuple((RuleTerminalNodeLeftTuple) justified.getTuple() );
+        ruleAgendaItem.getRuleExecutor().transitionToActive((RuleTerminalNodeLeftTuple) justified.getTuple() );
     }
 
     default ActivationsManager getPartitionedAgenda(int partitionNr) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakBranchNode.java
@@ -142,9 +142,6 @@ public class PhreakBranchNode {
             if (oldRtn != null) {
                 if (newRtn == null) {
                     // old exits, new does not, so delete
-                    if ( branchTuples.rtnLeftTuple.getMemory() != null ) {
-                        executor.removeActiveTuple(branchTuples.rtnLeftTuple);
-                    }
                     PhreakRuleTerminalNode.doLeftDelete(activationsManager, executor, branchTuples.rtnLeftTuple);
 
                 } else if (newRtn == oldRtn) {
@@ -153,9 +150,6 @@ public class PhreakBranchNode {
 
                 } else {
                     // old and new on different branches, delete one and insert the other
-                    if ( branchTuples.rtnLeftTuple.getMemory() != null ) {
-                        executor.removeActiveTuple(branchTuples.rtnLeftTuple);
-                    }
                     PhreakRuleTerminalNode.doLeftDelete(activationsManager, executor, branchTuples.rtnLeftTuple);
 
                     branchTuples.rtnLeftTuple = (RuleTerminalNodeLeftTuple) TupleFactory.createLeftTuple(leftTuple,
@@ -205,9 +199,6 @@ public class PhreakBranchNode {
             BranchTuples branchTuples = getBranchTuples(sink, leftTuple);
 
             if (branchTuples.rtnLeftTuple != null) {
-                if ( branchTuples.rtnLeftTuple.getMemory() != null ) {
-                    executor.removeActiveTuple(branchTuples.rtnLeftTuple);
-                }
                 PhreakRuleTerminalNode.doLeftDelete(activationsManager, executor, branchTuples.rtnLeftTuple);
             }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakRuleTerminalNode.java
@@ -106,7 +106,7 @@ public class PhreakRuleTerminalNode {
                                          RuleAgendaItem ruleAgendaItem,
                                          RuleTerminalNodeLeftTuple leftTuple) {
         if ( reteEvaluator.getRuleSessionConfiguration().isDirectFiring() ) {
-            executor.addActiveTuple(leftTuple);
+            executor.transitionToActive(leftTuple);
             return;
         }
 
@@ -133,11 +133,11 @@ public class PhreakRuleTerminalNode {
 
         if (activationsManager.getActivationsFilter() != null && !activationsManager.getActivationsFilter().accept( leftTuple )) {
             // only relevant for serialization, to not refire Matches already fired
-            executor.addDormantTuple(leftTuple );
+            executor.transitionToDormant(leftTuple );
             return;
         }
 
-        executor.addActiveTuple(leftTuple );
+        executor.transitionToActive(leftTuple );
 
         activationsManager.addItemToActivationGroup( leftTuple );
         if ( !rtnNode.isFireDirect() && executor.isDeclarativeAgendaEnabled() ) {
@@ -186,7 +186,7 @@ public class PhreakRuleTerminalNode {
 
         if ( reteEvaluator.getRuleSessionConfiguration().isDirectFiring() ) {
             if (!leftTuple.isQueued() ) {
-                executor.modifyActiveTuple(leftTuple );
+                executor.transitionToActive(leftTuple );
                 reteEvaluator.getRuleEventSupport().onUpdateMatch( leftTuple );
             }
             return;
@@ -212,7 +212,7 @@ public class PhreakRuleTerminalNode {
         
         if (activationsManager.getActivationsFilter() != null && !activationsManager.getActivationsFilter().accept( leftTuple)) {
             // only relevant for serialization, to not re-fire Matches already fired
-            executor.addDormantTuple(leftTuple);
+            executor.transitionToDormant(leftTuple);
             return;
         }
         
@@ -231,7 +231,7 @@ public class PhreakRuleTerminalNode {
                     activationsManager.getAgendaEventSupport().fireActivationCreated( leftTuple, reteEvaluator );
 
                     leftTuple.update( salienceInt, pctx );
-                    executor.modifyActiveTuple(leftTuple );
+                    executor.transitionToActive(leftTuple );
                     activationsManager.addItemToActivationGroup( leftTuple );
                     reteEvaluator.getRuleEventSupport().onUpdateMatch( leftTuple );
                 }
@@ -274,12 +274,7 @@ public class PhreakRuleTerminalNode {
 
         leftTuple.cancelActivation( activationsManager );
 
-        if ( leftTuple.getMemory() != null ) {
-            // Expiration propagations should not be removed from the list, as they still need to fire
-            executor.removeActiveTuple( leftTuple );
-        } else if ( leftTuple.getStagedType() == Tuple.DELETE && !leftTuple.isQueued() ) {
-            executor.removeDormantTuple( leftTuple );
-        }
+        executor.deactivateTuple( leftTuple );
 
         leftTuple.setContextObject( null );
     }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -33,6 +33,7 @@ import org.drools.core.event.RuleEventListenerSupport;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.RuleTerminalNode;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
+import org.drools.core.reteoo.RuleTerminalNodeLeftTuple.MatchState;
 import org.drools.core.reteoo.Tuple;
 import org.drools.core.reteoo.TupleImpl;
 import org.drools.core.rule.consequence.InternalMatch;
@@ -48,8 +49,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RuleExecutor {
-
-    private static final boolean DEBUG_DORMANT_TUPLE = false;
 
     protected static final Logger log = LoggerFactory.getLogger(RuleExecutor.class);
 
@@ -101,7 +100,7 @@ public class RuleExecutor {
             } else {
                 fireActivationEvent(reteEvaluator, activationsManager, tuple, tuple.getConsequence());
             }
-            removeActiveTuple(tuple );
+            deactivateTuple(tuple);
         }
         ruleAgendaItem.remove();
         return directFirings;
@@ -186,20 +185,21 @@ public class RuleExecutor {
         return localFireCount;
     }
 
+    // Does not use transitionToDormant() because the fire loop handles salience re-sorting separately and queue.dequeue() must select by priority, not by reference.
     private TupleImpl getNextTuple() {
         if (activeMatches.isEmpty()) {
             return null;
         }
-        TupleImpl leftTuple;
+        RuleTerminalNodeLeftTuple leftTuple;
         if (queue != null) {
-            leftTuple = (TupleImpl) queue.dequeue();
+            leftTuple = (RuleTerminalNodeLeftTuple) queue.dequeue();
             activeMatches.remove(leftTuple);
         } else {
-            leftTuple = activeMatches.removeFirst();
-            ((InternalMatch) leftTuple).setQueued(false);
+            leftTuple = (RuleTerminalNodeLeftTuple) activeMatches.removeFirst();
+            leftTuple.setQueued(false);
         }
-
-        addDormantTuple((RuleTerminalNodeLeftTuple) leftTuple);
+        leftTuple.setMatchState(MatchState.DORMANT);
+        dormantMatches.add(leftTuple);
         return leftTuple;
     }
 
@@ -293,62 +293,59 @@ public class RuleExecutor {
         return dormantMatches;
     }
 
-    public void addDormantTuple(RuleTerminalNodeLeftTuple tuple) {
-        if (DEBUG_DORMANT_TUPLE) {
-            if (tuple.isDormant()) {
-                throw new IllegalStateException();
-            }
+    public void transitionToActive(RuleTerminalNodeLeftTuple tuple) {
+        MatchState current = tuple.getMatchState();
+        if (current == MatchState.ACTIVE) {
+            throw new IllegalStateException("Cannot transition to ACTIVE: already ACTIVE");
         }
-        dormantMatches.add(tuple);
-        if (DEBUG_DORMANT_TUPLE) {
-            tuple.setDormant(true);
-        }
-    }
-
-    public void removeDormantTuple(RuleTerminalNodeLeftTuple tuple) {
-        if (DEBUG_DORMANT_TUPLE) {
-            if (!tuple.isDormant()) {
-                throw new IllegalStateException();
-            }
-        }
-        if (tuple.getPrevious() != null || dormantMatches.getFirst() == tuple) {
+        if (current == MatchState.DORMANT) {
             dormantMatches.remove(tuple);
-        } else {
-            log.debug("Skipping removeDormantTuple for orphan tuple {} on rule \"{}\" — tuple is not present in dormantMatches",
-                      tuple, ruleAgendaItem.getRule().getName());
         }
-        if (DEBUG_DORMANT_TUPLE) {
-            tuple.setDormant(false);
-        }
-   }
-
-    public void addActiveTuple(RuleTerminalNodeLeftTuple tuple) {
         tuple.setQueued(true);
-        if (DEBUG_DORMANT_TUPLE) {
-            if (tuple.isDormant()) {
-                throw new IllegalStateException();
-            }
-        }
-        this.activeMatches.add(tuple);
+        tuple.setMatchState(MatchState.ACTIVE);
+        activeMatches.add(tuple);
         if (queue != null) {
             addQueuedLeftTuple(tuple);
         }
     }
 
-    public void modifyActiveTuple(RuleTerminalNodeLeftTuple tuple) {
-        removeDormantTuple(tuple);
-        addActiveTuple(tuple);
+    public void transitionToDormant(RuleTerminalNodeLeftTuple tuple) {
+        MatchState current = tuple.getMatchState();
+        if (current == MatchState.DORMANT) {
+            throw new IllegalStateException("Cannot transition to DORMANT: already DORMANT");
+        }
+        if (current == MatchState.ACTIVE) {
+            tuple.setQueued(false);
+            activeMatches.remove(tuple);
+            if (queue != null) {
+                removeQueuedLeftTuple(tuple);
+            }
+        }
+        tuple.setMatchState(MatchState.DORMANT);
+        dormantMatches.add(tuple);
     }
 
-    public void removeActiveTuple(RuleTerminalNodeLeftTuple tuple) {
-        tuple.setQueued(false);
-        activeMatches.remove(tuple);
-        if (tuple.getStagedType() != Tuple.DELETE) {
-            addDormantTuple(tuple);
+    public void deactivateTuple(RuleTerminalNodeLeftTuple tuple) {
+        switch (tuple.getMatchState()) {
+            case ACTIVE:
+                tuple.setQueued(false);
+                activeMatches.remove(tuple);
+                if (queue != null) {
+                    removeQueuedLeftTuple(tuple);
+                }
+                if (tuple.getStagedType() != Tuple.DELETE) {
+                    tuple.setMatchState(MatchState.DORMANT);
+                    dormantMatches.add(tuple);
+                    return;
+                }
+                break;
+            case DORMANT:
+                dormantMatches.remove(tuple);
+                break;
+            default:
+                break;
         }
-        if (queue != null) {
-            removeQueuedLeftTuple(tuple);
-        }
+        tuple.setMatchState(MatchState.REMOVED);
     }
 
     public void addQueuedLeftTuple(RuleTerminalNodeLeftTuple tuple) {
@@ -376,13 +373,14 @@ public class RuleExecutor {
         }
     }
 
+    // Does not use deactivateTuple() because cancel requires unconditional REMOVED regardless of stagedType.
     public void cancel(ReteEvaluator reteEvaluator, EventSupport es) {
         while (!activeMatches.isEmpty()) {
             RuleTerminalNodeLeftTuple rtnLt = (RuleTerminalNodeLeftTuple) activeMatches.removeFirst();
+            rtnLt.setMatchState(MatchState.REMOVED);
             if (queue != null) {
                 queue.dequeue(rtnLt);
             }
-
             es.getAgendaEventSupport().fireActivationCancelled(rtnLt, reteEvaluator, MatchCancelledCause.CLEAR);
         }
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
@@ -133,15 +133,9 @@ public class RuleTerminalNode extends AbstractTerminalNode {
 
     public void cancelMatch(InternalMatch match) {
         if ( match.isQueued() ) {
-            TupleImpl leftTuple = match.getTuple();
-            if ( match.getRuleAgendaItem() != null ) {
-                // phreak must also remove the LT from the rule network evaluator
-                if ( leftTuple.getMemory() != null ) {
-                    leftTuple.getMemory().remove( leftTuple );
-                }
-            }
-            RuleExecutor ruleExecutor = ((RuleTerminalNodeLeftTuple)leftTuple).getRuleAgendaItem().getRuleExecutor();
-            PhreakRuleTerminalNode.doLeftDelete(ruleExecutor.getPathMemory().getActualActivationsManager( ), ruleExecutor, (RuleTerminalNodeLeftTuple) leftTuple);
+            RuleTerminalNodeLeftTuple leftTuple = (RuleTerminalNodeLeftTuple) match.getTuple();
+            RuleExecutor ruleExecutor = leftTuple.getRuleAgendaItem().getRuleExecutor();
+            PhreakRuleTerminalNode.doLeftDelete(ruleExecutor.getPathMemory().getActualActivationsManager( ), ruleExecutor, leftTuple);
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNodeLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNodeLeftTuple.java
@@ -39,6 +39,9 @@ import org.kie.api.runtime.rule.FactHandle;
 
 public class RuleTerminalNodeLeftTuple extends LeftTuple implements InternalMatch {
     private static final long serialVersionUID = 540l;
+
+    public enum MatchState { NONE, ACTIVE, DORMANT, REMOVED }
+
     /**
      * The salience
      */
@@ -65,8 +68,7 @@ public class RuleTerminalNodeLeftTuple extends LeftTuple implements InternalMatc
     private RuleImpl rule;
     private Consequence consequence;
 
-    // left here for debugging purposes: switch RuleExecutor.DEBUG_DORMANT_TUPLE to true to enable this debugging
-    // private boolean dormant;
+    private MatchState matchState = MatchState.NONE;
 
     public RuleTerminalNodeLeftTuple() {
         // constructor needed for serialisation
@@ -224,7 +226,7 @@ public class RuleTerminalNodeLeftTuple extends LeftTuple implements InternalMatc
     }
 
     public void dequeue() {
-        ruleAgendaItem.getRuleExecutor().removeActiveTuple(this);
+        ruleAgendaItem.getRuleExecutor().deactivateTuple(this);
     }
 
     public void remove() {
@@ -352,13 +354,11 @@ public class RuleTerminalNodeLeftTuple extends LeftTuple implements InternalMatc
         return true;
     }
 
-    public boolean isDormant() {
-        throw new IllegalStateException("This method can be called only for debugging purposes. Uncomment dormant boolean to enable debugging.");
-        // return dormant;
+    public MatchState getMatchState() {
+        return matchState;
     }
 
-    public void setDormant(boolean dormant) {
-        throw new IllegalStateException("This method can be called only for debugging purposes. Uncomment dormant boolean to enable debugging.");
-        // this.dormant = dormant;
+    public void setMatchState(MatchState matchState) {
+        this.matchState = matchState;
     }
 }

--- a/drools-core/src/test/java/org/drools/core/phreak/RuleExecutorDormantTupleTest.java
+++ b/drools-core/src/test/java/org/drools/core/phreak/RuleExecutorDormantTupleTest.java
@@ -21,115 +21,176 @@ package org.drools.core.phreak;
 import org.drools.base.base.SalienceInteger;
 import org.drools.base.definitions.rule.impl.RuleImpl;
 import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
+import org.drools.core.reteoo.RuleTerminalNodeLeftTuple.MatchState;
 import org.drools.core.reteoo.Tuple;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Targeted regression test for the guard in {@link RuleExecutor#removeDormantTuple} added for
- * issue 6422. A tuple passed to {@code removeDormantTuple} may already have been unlinked from
- * {@code dormantMatches} by another path (e.g. {@code modifyActiveTuple}), in which case its
- * {@code previous} pointer is null and the unguarded {@code LinkedList.remove()} dereferences it.
- */
 public class RuleExecutorDormantTupleTest {
 
     @Test
-    public void removeDormantTuple_whenTupleAlreadyUnlinkedFromList_doesNotNPE() {
-        final RuleExecutor executor = newRuleExecutor();
-        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
-        final RuleTerminalNodeLeftTuple t2 = new RuleTerminalNodeLeftTuple();
-
-        executor.addDormantTuple(t1);
-        executor.addDormantTuple(t2);
-
-        // First remove takes t1 out cleanly via the firstNode path. After this,
-        // t1.previous is null and dormantMatches.getFirst() is t2 — the exact state
-        // the bug fix guards against.
-        executor.removeDormantTuple(t1);
-        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
-        assertThat(t1.getPrevious()).isNull();
-        assertThat(executor.getDormantMatches().getFirst()).isNotSameAs(t1);
-
-        // Without the guard, LinkedList.remove() would fall into the middle-node
-        // branch and NPE on t1.getPrevious().setNext(...).
-        assertThatNoException().isThrownBy(() -> executor.removeDormantTuple(t1));
-
-        // The list is unchanged: t2 is still the sole dormant tuple.
-        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
-        assertThat(executor.getDormantMatches().getFirst()).isSameAs(t2);
-    }
-
-    @Test
-    public void removeDormantTuple_whenTupleIsInList_unlinksIt() {
+    public void transitionToActive_fromNone() {
         final RuleExecutor executor = newRuleExecutor();
         final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
 
-        executor.addDormantTuple(t1);
-        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
-
-        executor.removeDormantTuple(t1);
-        assertThat(executor.getDormantMatches().size()).isZero();
-    }
-
-    /**
-     * {@link RuleExecutor#modifyActiveTuple} routes through {@code removeDormantTuple}, so the
-     * same NPE could surface from this second entry point. Pins the guard from both call sites.
-     */
-    @Test
-    public void modifyActiveTuple_whenTupleAlreadyUnlinkedFromDormantList_doesNotNPE() {
-        final RuleExecutor executor = newRuleExecutor();
-        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
-        final RuleTerminalNodeLeftTuple t2 = new RuleTerminalNodeLeftTuple();
-
-        executor.addDormantTuple(t1);
-        executor.addDormantTuple(t2);
-        executor.removeDormantTuple(t1);
-
-        assertThatNoException().isThrownBy(() -> executor.modifyActiveTuple(t1));
+        executor.transitionToActive(t1);
 
         assertThat(executor.getActiveMatches().size()).isEqualTo(1);
-        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
-        assertThat(executor.getDormantMatches().getFirst()).isSameAs(t2);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.ACTIVE);
         assertThat(t1.isQueued()).isTrue();
     }
 
-    /**
-     * Pins the upstream half of the bug: {@link RuleExecutor#removeActiveTuple} must skip
-     * {@code addDormantTuple} when the staged type is DELETE. This is the precondition that
-     * leaves a tuple unlinked from {@code dormantMatches} while later paths still try to
-     * remove it.
-     */
     @Test
-    public void removeActiveTuple_whenStagedForDelete_skipsDormantTransition() {
+    public void transitionToActive_fromDormant() {
         final RuleExecutor executor = newRuleExecutor();
         final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
 
-        executor.addActiveTuple(t1);
-        t1.setStagedType(Tuple.DELETE);
+        executor.transitionToDormant(t1);
+        executor.transitionToActive(t1);
 
-        executor.removeActiveTuple(t1);
-
-        assertThat(executor.getActiveMatches().size()).isZero();
+        assertThat(executor.getActiveMatches().size()).isEqualTo(1);
         assertThat(executor.getDormantMatches().size()).isZero();
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.ACTIVE);
+        assertThat(t1.isQueued()).isTrue();
     }
 
     @Test
-    public void removeActiveTuple_whenNotStagedForDelete_transitionsToDormant() {
+    public void transitionToActive_fromActive_throws() {
         final RuleExecutor executor = newRuleExecutor();
         final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
 
-        executor.addActiveTuple(t1);
-        // Default stagedType is NONE (0); leave it as-is.
+        executor.transitionToActive(t1);
 
-        executor.removeActiveTuple(t1);
+        assertThatIllegalStateException().isThrownBy(() -> executor.transitionToActive(t1));
+    }
+
+    @Test
+    public void transitionToActive_fromRemoved() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        executor.deactivateTuple(t1);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.REMOVED);
+
+        executor.transitionToActive(t1);
+        assertThat(executor.getActiveMatches().size()).isEqualTo(1);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.ACTIVE);
+    }
+
+    @Test
+    public void transitionToDormant_fromNone() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        executor.transitionToDormant(t1);
+
+        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.DORMANT);
+    }
+
+    @Test
+    public void transitionToDormant_fromActive() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        executor.transitionToActive(t1);
+        executor.transitionToDormant(t1);
+
+        assertThat(executor.getActiveMatches().size()).isZero();
+        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.DORMANT);
+        assertThat(t1.isQueued()).isFalse();
+    }
+
+    @Test
+    public void transitionToDormant_fromDormant_throws() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        executor.transitionToDormant(t1);
+
+        assertThatIllegalStateException().isThrownBy(() -> executor.transitionToDormant(t1));
+    }
+
+    @Test
+    public void transitionToDormant_fromRemoved() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        executor.deactivateTuple(t1);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.REMOVED);
+
+        executor.transitionToDormant(t1);
+        assertThat(executor.getDormantMatches().size()).isEqualTo(1);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.DORMANT);
+    }
+
+    @Test
+    public void deactivateTuple_whenActiveAndStagedForDelete_setsRemoved() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        executor.transitionToActive(t1);
+        t1.setStagedType(Tuple.DELETE);
+
+        executor.deactivateTuple(t1);
+
+        assertThat(executor.getActiveMatches().size()).isZero();
+        assertThat(executor.getDormantMatches().size()).isZero();
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.REMOVED);
+    }
+
+    @Test
+    public void deactivateTuple_whenActiveAndNotStagedForDelete_transitionsToDormant() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        executor.transitionToActive(t1);
+
+        executor.deactivateTuple(t1);
 
         assertThat(executor.getActiveMatches().size()).isZero();
         assertThat(executor.getDormantMatches().size()).isEqualTo(1);
         assertThat(executor.getDormantMatches().getFirst()).isSameAs(t1);
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.DORMANT);
+    }
+
+    @Test
+    public void deactivateTuple_whenDormant_setsRemoved() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        executor.transitionToDormant(t1);
+
+        executor.deactivateTuple(t1);
+
+        assertThat(executor.getDormantMatches().size()).isZero();
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.REMOVED);
+    }
+
+    @Test
+    public void deactivateTuple_whenNone_setsRemovedWithoutNPE() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        assertThatNoException().isThrownBy(() -> executor.deactivateTuple(t1));
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.REMOVED);
+    }
+
+    @Test
+    public void deactivateTuple_whenRemoved_isIdempotent() {
+        final RuleExecutor executor = newRuleExecutor();
+        final RuleTerminalNodeLeftTuple t1 = new RuleTerminalNodeLeftTuple();
+
+        executor.deactivateTuple(t1);
+
+        assertThatNoException().isThrownBy(() -> executor.deactivateTuple(t1));
+        assertThat(t1.getMatchState()).isEqualTo(MatchState.REMOVED);
     }
 
     private static RuleExecutor newRuleExecutor() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RemoveDormantTupleNPETest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RemoveDormantTupleNPETest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.mvel.integrationtests;
+
+import java.util.stream.Stream;
+
+import org.drools.mvel.compiler.Cheese;
+import org.drools.mvel.compiler.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil2;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.FactHandle;
+
+/**
+ * Reproducers for NPE in RuleExecutor.removeDormantTuple (issue #6422, PR #6707).
+ *
+ * Root cause: doLeftTupleInsert can return early (no-loop or lock-on-active guard)
+ * without adding the tuple to any RuleExecutor list. The tuple remains linked as
+ * a child at the join node. A subsequent fact modification triggers an UPDATE for
+ * the orphan, and modifyActiveTuple calls removeDormantTuple on a tuple that was
+ * never in dormantMatches — NPE in LinkedList.remove().
+ */
+public class RemoveDormantTupleNPETest {
+
+    public static Stream<KieBaseTestConfiguration> parameters() {
+        return TestParametersUtil2.getKieBaseCloudConfigurations(true).stream();
+    }
+
+    /**
+     * Orphan via no-loop, triggered by external ksession.update().
+     *
+     * R1 (no-loop) fires → inserts new Cheese → new match blocked by no-loop → orphan.
+     * External update of Person → UPDATE on orphan → NPE.
+     */
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testNoLoopInsertThenExternalUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        final String drl =
+                "package org.drools.reproducer\n" +
+                "import " + Cheese.class.getCanonicalName() + "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule R1\n" +
+                "    no-loop true\n" +
+                "when\n" +
+                "    $c : Cheese(price > 0)\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    insert(new Cheese(\"inserted\", $c.getPrice() + 100));\n" +
+                "end\n";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            Cheese cheese = new Cheese("original", 1);
+            Person person = new Person("john", 1);
+
+            ksession.insert(cheese);
+            FactHandle personHandle = ksession.insert(person);
+
+            // R1 fires → inserts Cheese("inserted",101) → new match blocked by no-loop → orphan
+            ksession.fireAllRules();
+
+            // Modify Person externally → right-side UPDATE at R1's join node hits the orphan
+            person.setAge(2);
+            ksession.update(personHandle, person);
+
+            // doLeftTupleUpdate → modifyActiveTuple → removeDormantTuple → NPE
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+    /**
+     * Orphan via no-loop, triggered by a second rule's modify — single fireAllRules.
+     *
+     * R1 (no-loop, higher salience) fires first → inserts new Cheese → orphan.
+     * R2 fires second → modifies Person → UPDATE on orphan → NPE.
+     * All within one fireAllRules() call.
+     */
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testNoLoopCrossRuleModify(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        final String drl =
+                "package org.drools.reproducer\n" +
+                "import " + Cheese.class.getCanonicalName() + "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule R1\n" +
+                "    no-loop true\n" +
+                "    salience 10\n" +
+                "when\n" +
+                "    $c : Cheese(price > 0)\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    insert(new Cheese(\"inserted\", $c.getPrice() + 100));\n" +
+                "end\n" +
+                "\n" +
+                "rule R2\n" +
+                "    no-loop true\n" +
+                "    salience 5\n" +
+                "when\n" +
+                "    $c : Cheese(type == \"original\")\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    modify($p) { setAge($p.getAge() + 1) };\n" +
+                "end\n";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            ksession.insert(new Cheese("original", 1));
+            ksession.insert(new Person("john", 1));
+
+            // R1 fires (salience 10): inserts Cheese("inserted",101) → orphan at R1's terminal.
+            // R2 fires (salience 5): modifies Person → right-side UPDATE at R1's join node.
+            // R1 re-evaluates: doLeftTupleUpdate on orphan → modifyActiveTuple → NPE.
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+    /**
+     * Orphan via lock-on-active, triggered by external ksession.update().
+     *
+     * R1 (lock-on-active, agenda-group) fires → inserts new Cheese → new match
+     * blocked by lock-on-active → orphan.
+     * After the group deactivates, external update of Person + re-focus → NPE.
+     */
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testLockOnActiveInsertThenExternalUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        final String drl =
+                "package org.drools.reproducer\n" +
+                "import " + Cheese.class.getCanonicalName() + "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule R1\n" +
+                "    agenda-group \"group1\"\n" +
+                "    lock-on-active true\n" +
+                "when\n" +
+                "    $c : Cheese(price > 0)\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    insert(new Cheese(\"inserted\", $c.getPrice() + 100));\n" +
+                "end\n";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            Cheese cheese = new Cheese("original", 1);
+            Person person = new Person("john", 1);
+
+            ksession.insert(cheese);
+            FactHandle personHandle = ksession.insert(person);
+
+            // Activate group and fire. R1 fires → inserts Cheese("inserted",101).
+            // New match blocked by lock-on-active → orphan.
+            ksession.getAgenda().getAgendaGroup("group1").setFocus();
+            ksession.fireAllRules();
+
+            // Modify Person while group is inactive (update recency < activation recency
+            // when group is re-focused, so lock-on-active won't block the update).
+            person.setAge(2);
+            ksession.update(personHandle, person);
+
+            // Re-focus and fire. doLeftTupleUpdate processes the UPDATE on the orphan.
+            // lock-on-active check passes (fact was modified before group re-activation).
+            // modifyActiveTuple → removeDormantTuple → NPE.
+            ksession.getAgenda().getAgendaGroup("group1").setFocus();
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
+    }
+
+    /**
+     * Orphan via no-loop, triggered by DELETE (retract) — single fireAllRules,
+     * no external update, no modify.
+     *
+     * R1 (no-loop) fires → inserts a new fact → new match blocked by no-loop → orphan.
+     * R2 retracts the inserted fact → LEFT DELETE propagates to orphan →
+     * doLeftDelete → removeDormantTuple → NPE.
+     *
+     * This is the most realistic scenario: rules only use insert/retract (no modify),
+     * and the NPE occurs within a single fireAllRules() call.
+     */
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    public void testNoLoopInsertRetractNoExternalUpdate(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        // R1: inserts a new Cheese("big", price+100) when it finds a cheap Cheese with a Person.
+        //     The new Cheese re-matches R1 with the same Person → blocked by no-loop → orphan.
+        //
+        // R2: retracts any Cheese with price > 50. This covers the inserted Cheese("big", 101).
+        //     Retracting it propagates a LEFT DELETE through R1's join node, hitting the orphan.
+        final String drl =
+                "package org.drools.reproducer\n" +
+                "import " + Cheese.class.getCanonicalName() + "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule R1\n" +
+                "    no-loop true\n" +
+                "    salience 10\n" +
+                "when\n" +
+                "    $c : Cheese(price > 0)\n" +
+                "    $p : Person(age > 0)\n" +
+                "then\n" +
+                "    insert(new Cheese(\"big\", $c.getPrice() + 100));\n" +
+                "end\n" +
+                "\n" +
+                "rule R2\n" +
+                "    salience 1\n" +
+                "when\n" +
+                "    $c : Cheese(price > 50)\n" +
+                "then\n" +
+                "    retract($c);\n" +
+                "end\n";
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
+        try {
+            ksession.insert(new Cheese("original", 1));
+            ksession.insert(new Person("john", 1));
+
+            // R1 fires (salience 10): inserts Cheese("big",101) → orphan at R1's terminal.
+            // R2 fires (salience 1): retracts Cheese("big",101) → LEFT DELETE on orphan.
+            // doLeftDelete → removeDormantTuple on orphan → NPE.
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
+    }
+}


### PR DESCRIPTION
Enhanced version of https://github.com/apache/incubator-kie-drools/pull/6767
---

The root cause of the NPE in RuleExecutor.removeDormantTuple is that a
tuple's list membership (active, dormant, or neither) was inferred from
indirect signals (memory, isQueued, previous) rather than tracked
explicitly. DORMANT and orphan (never added to any list) were
indistinguishable, so removeDormantTuple was called on orphan tuples
that were never in dormantMatches.

Add MatchState enum (NONE, ACTIVE, DORMANT, REMOVED) to
RuleTerminalNodeLeftTuple and consolidate all state transitions into
three self-contained methods on RuleExecutor:

- transitionToActive: NONE/DORMANT -> ACTIVE (replaces addActiveTuple
  and modifyActiveTuple). Validates from-state, removes from dormant
  list if needed, adds to active list and salience queue.
- transitionToDormant: NONE/ACTIVE -> DORMANT (replaces addDormantTuple).
  Validates from-state, removes from active list if needed, adds to
  dormant list.
- deactivateTuple: any -> DORMANT or REMOVED (replaces removeActiveTuple
  and removeTuple). Handles all states: ACTIVE uses stagedType to decide
  DORMANT (park for expiration) vs REMOVED; DORMANT/NONE -> REMOVED.
  Fixes the NPE by safely handling orphan tuples (NONE state).

Each method encapsulates state validation, list manipulation, and
MatchState update in one place. Callers no longer need to check
MatchState before calling — eliminating the repeated if/else pattern
in PhreakRuleTerminalNode.doLeftDelete and the redundant pre-checks
in PhreakBranchNode.

Also fix RuleTerminalNode.cancelMatch which bypassed RuleExecutor by
directly removing from activeMatches via getMemory().remove().
