### PR TITLE
[incubator-kie-issues#2346] B-FEEL relational comparison expressions return false for non-boolean operands

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandler.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandler.java
@@ -203,24 +203,7 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     @Override
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getGteOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
-        // Any non-Boolean coerces to false, so (false,false) --> false
-        map.put(
-                new CheckedPredicate((left, right) -> {
-                    Boolean leftBool = (left instanceof Boolean) ? (Boolean) left : Boolean.FALSE;
-                    Object rightValue = evalRight(right, ctx);
-                    Boolean rightBool = (rightValue instanceof Boolean) ? (Boolean) rightValue : Boolean.FALSE;
-                    return Boolean.FALSE.equals(leftBool) && Boolean.FALSE.equals(rightBool);
-                }, false),
-                (left, right) -> Boolean.FALSE);
 
-        // non-Boolean coercion to false
-        map.put(
-                new CheckedPredicate((left, right) -> (!(left instanceof Boolean) || !(right instanceof Boolean)), false),
-                (left, right) -> {
-                    Boolean leftBool = (left instanceof Boolean) ? (Boolean) left : Boolean.FALSE;
-                    Boolean rightBool = (right instanceof Boolean) ? (Boolean) right : Boolean.FALSE;
-                    return leftBool || rightBool;
-                });
         // numeric/comparable >= logic
         map.put(
                 new CheckedPredicate((left, right) -> true, false),
@@ -249,25 +232,6 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getGtOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
 
-        // Any non-Boolean coerces to false, so (false,false) --> false
-        map.put(
-                new CheckedPredicate((left, right) -> {
-                    Boolean leftBool = (left instanceof Boolean) ? (Boolean) left : Boolean.FALSE;
-                    Object rightValue = evalRight(right, ctx);
-                    Boolean rightBool = (rightValue instanceof Boolean) ? (Boolean) rightValue : Boolean.FALSE;
-                    return Boolean.FALSE.equals(leftBool) && Boolean.FALSE.equals(rightBool);
-                }, false),
-                (left, right) -> Boolean.FALSE);
-
-        // non-Boolean coercion to false
-        map.put(
-                new CheckedPredicate((left, right) -> (!(left instanceof Boolean) || !(right instanceof Boolean)), false),
-                (left, right) -> {
-                    Boolean leftBool = (left instanceof Boolean) ? (Boolean) left : Boolean.FALSE;
-                    Boolean rightBool = (right instanceof Boolean) ? (Boolean) right : Boolean.FALSE;
-                    return leftBool || rightBool;
-                });
-
         // numeric/comparable > logic
         map.put(
                 new CheckedPredicate((left, right) -> true, false),
@@ -284,25 +248,6 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     @Override
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getLteOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
-
-        // Any non-Boolean coerces to false, so (false,false) --> false
-        map.put(
-                new CheckedPredicate((left, right) -> {
-                    Boolean leftBool = (left instanceof Boolean) ? (Boolean) left : Boolean.FALSE;
-                    Object rightValue = evalRight(right, ctx);
-                    Boolean rightBool = (rightValue instanceof Boolean) ? (Boolean) rightValue : Boolean.FALSE;
-                    return Boolean.FALSE.equals(leftBool) && Boolean.FALSE.equals(rightBool);
-                }, false),
-                (left, right) -> Boolean.FALSE);
-
-        // General non-Boolean coercion to false
-        map.put(
-                new CheckedPredicate((left, right) -> (!(left instanceof Boolean) || !(right instanceof Boolean)), false),
-                (left, right) -> {
-                    Boolean leftBool = (left instanceof Boolean) ? (Boolean) left : Boolean.FALSE;
-                    Boolean rightBool = (right instanceof Boolean) ? (Boolean) right : Boolean.FALSE;
-                    return leftBool || rightBool;
-                });
 
         // Numeric/comparable ≤ logic
         map.put(
@@ -330,25 +275,6 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     @Override
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getLtOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
-
-        // Non-Boolean coerces to false, so (false,false) --> false
-        map.put(
-                new CheckedPredicate((left, right) -> {
-                    Boolean leftBool = (left instanceof Boolean) ? (Boolean) left : Boolean.FALSE;
-                    Object rightValue = evalRight(right, ctx);
-                    Boolean rightBool = (rightValue instanceof Boolean) ? (Boolean) rightValue : Boolean.FALSE;
-                    return Boolean.FALSE.equals(leftBool) && Boolean.FALSE.equals(rightBool);
-                }, false),
-                (left, right) -> Boolean.FALSE);
-
-        // General non-Boolean coercion to false
-        map.put(
-                new CheckedPredicate((left, right) -> (!(left instanceof Boolean) || !(right instanceof Boolean)), false),
-                (left, right) -> {
-                    Boolean leftBool = (left instanceof Boolean) ? (Boolean) left : Boolean.FALSE;
-                    Boolean rightBool = (right instanceof Boolean) ? (Boolean) right : Boolean.FALSE;
-                    return leftBool || rightBool;
-                });
 
         // Numeric/comparable < logic
         map.put(

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandler.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandler.java
@@ -25,7 +25,6 @@ import java.time.LocalDate;
 import java.time.chrono.ChronoPeriod;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 
@@ -224,18 +223,13 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
                 new CheckedPredicate((left, right) -> true, false),
                 (left, right) -> {
                     Boolean greater = compare(left, right, (l, r) -> l.compareTo(r) > 0);
-                    //Boolean equal = BooleanEvalHelper.isEqual(left, right, ctx.getFEELDialect());
-                    Boolean equal = (EqExecutor.instance().evaluate(left, right, ctx) instanceof Boolean)
-                            ? (Boolean) EqExecutor.instance().evaluate(left, right, ctx)
-                            : null;
+                    Object eqResult = EqExecutor.instance().evaluate(left, right, ctx);
+                    Boolean equal = (eqResult instanceof Boolean) ? (Boolean) eqResult : null;
 
-                    if (greater == null && equal == null) {
-                        return Boolean.FALSE; // BFEEL default for incompatible types
-                    }
                     if (Boolean.TRUE.equals(greater) || Boolean.TRUE.equals(equal)) {
                         return Boolean.TRUE;
                     }
-                    return Boolean.FALSE;
+                    return Boolean.FALSE; // BFEEL default for incompatible types
                 });
         return map;
     }
@@ -252,11 +246,7 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
         // BFEEL: All other comparisons (numeric, dates, strings, Booleans, etc.)
         map.put(
                 new CheckedPredicate((left, right) -> true, false),
-                (left, right) -> {
-                    Boolean greater = compare(left, right,
-                            (l, r) -> l.compareTo(r) > 0);
-                    return Objects.requireNonNullElse(greater, Boolean.FALSE);
-                });
+                (left, right) -> compare(left, right, (l, r) -> l.compareTo(r) > 0));
         return map;
     }
 
@@ -282,19 +272,14 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
         map.put(
                 new CheckedPredicate((left, right) -> true, false),
                 (left, right) -> {
-                    Boolean less = compare(left, right,
-                            (l, r) -> l.compareTo(r) < 0);
-                    Boolean equal = (EqExecutor.instance().evaluate(left, right, ctx) instanceof Boolean)
-                            ? (Boolean) EqExecutor.instance().evaluate(left, right, ctx)
-                            : null;
+                    Boolean less = compare(left, right, (l, r) -> l.compareTo(r) < 0);
+                    Object eqResult = EqExecutor.instance().evaluate(left, right, ctx);
+                    Boolean equal = (eqResult instanceof Boolean) ? (Boolean) eqResult : null;
 
-                    if (less == null && equal == null) {
-                        return Boolean.FALSE; // BFEEL default for incompatible types
-                    }
                     if (Boolean.TRUE.equals(less) || Boolean.TRUE.equals(equal)) {
                         return Boolean.TRUE;
                     }
-                    return Boolean.FALSE;
+                    return Boolean.FALSE; // BFEEL default for incompatible types
                 });
         return map;
     }
@@ -311,11 +296,7 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
         // BFEEL: All other comparisons (numeric, dates, strings, Booleans, etc.)
         map.put(
                 new CheckedPredicate((left, right) -> true, false),
-                (left, right) -> {
-                    Boolean less = compare(left, right,
-                            (l, r) -> l.compareTo(r) < 0);
-                    return Objects.requireNonNullElse(less, Boolean.FALSE);
-                });
+                (left, right) -> compare(left, right, (l, r) -> l.compareTo(r) < 0));
         return map;
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandler.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandler.java
@@ -204,7 +204,22 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getGteOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
 
-        // numeric/comparable >= logic
+        // BFEEL: null returns FALSE (not null like standard FEEL)
+        map.put(
+                new CheckedPredicate((left, right) -> left == null || right == null, false),
+                (left, right) -> Boolean.FALSE);
+
+        // BFEEL: Boolean >= logic (true >= false, true >= true, false >= false)
+        map.put(
+                new CheckedPredicate((left, right) -> left instanceof Boolean && right instanceof Boolean, false),
+                (left, right) -> {
+                    Boolean leftBool = (Boolean) left;
+                    Boolean rightBool = (Boolean) right;
+                    // In BFEEL: true >= anything is true, false >= false is true, false >= true is false
+                    return leftBool || !rightBool;
+                });
+
+        // BFEEL: All other comparisons (numeric, dates, strings, etc.)
         map.put(
                 new CheckedPredicate((left, right) -> true, false),
                 (left, right) -> {
@@ -215,16 +230,13 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
                             : null;
 
                     if (greater == null && equal == null) {
-                        return Boolean.FALSE; // BFEEL default
+                        return Boolean.FALSE; // BFEEL default for incompatible types
                     }
                     if (Boolean.TRUE.equals(greater) || Boolean.TRUE.equals(equal)) {
                         return Boolean.TRUE;
                     }
                     return Boolean.FALSE;
                 });
-
-        // Fall back to common >= operations for all other cases
-        map.putAll(getCommonGteOperations(ctx));
         return map;
     }
 
@@ -232,7 +244,12 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getGtOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
 
-        // numeric/comparable > logic
+        // BFEEL: null returns FALSE (not null like standard FEEL)
+        map.put(
+                new CheckedPredicate((left, right) -> left == null || right == null, false),
+                (left, right) -> Boolean.FALSE);
+
+        // BFEEL: All other comparisons (numeric, dates, strings, Booleans, etc.)
         map.put(
                 new CheckedPredicate((left, right) -> true, false),
                 (left, right) -> {
@@ -240,8 +257,6 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
                             (l, r) -> l.compareTo(r) > 0);
                     return Objects.requireNonNullElse(greater, Boolean.FALSE);
                 });
-
-        map.putAll(getCommonGtOperations(ctx));
         return map;
     }
 
@@ -249,7 +264,21 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getLteOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
 
-        // Numeric/comparable ≤ logic
+        // BFEEL: null returns FALSE (not null like standard FEEL)
+        map.put(
+                new CheckedPredicate((left, right) -> left == null || right == null, false),
+                (left, right) -> Boolean.FALSE);
+
+        // BFEEL: Boolean <= logic (false <= anything is true, true <= true is true, true <= false is false)
+        map.put(
+                new CheckedPredicate((left, right) -> left instanceof Boolean && right instanceof Boolean, false),
+                (left, right) -> {
+                    Boolean leftBool = (Boolean) left;
+                    Boolean rightBool = (Boolean) right;
+                    return !leftBool || rightBool;
+                });
+
+        // BFEEL: All other comparisons (numeric, dates, strings, etc.)
         map.put(
                 new CheckedPredicate((left, right) -> true, false),
                 (left, right) -> {
@@ -260,15 +289,13 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
                             : null;
 
                     if (less == null && equal == null) {
-                        return Boolean.FALSE; // BFEEL default
+                        return Boolean.FALSE; // BFEEL default for incompatible types
                     }
                     if (Boolean.TRUE.equals(less) || Boolean.TRUE.equals(equal)) {
                         return Boolean.TRUE;
                     }
                     return Boolean.FALSE;
                 });
-
-        map.putAll(getCommonLteOperations(ctx));
         return map;
     }
 
@@ -276,7 +303,12 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getLtOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
 
-        // Numeric/comparable < logic
+        // BFEEL: null returns FALSE (not null like standard FEEL)
+        map.put(
+                new CheckedPredicate((left, right) -> left == null || right == null, false),
+                (left, right) -> Boolean.FALSE);
+
+        // BFEEL: All other comparisons (numeric, dates, strings, Booleans, etc.)
         map.put(
                 new CheckedPredicate((left, right) -> true, false),
                 (left, right) -> {
@@ -284,7 +316,6 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
                             (l, r) -> l.compareTo(r) < 0);
                     return Objects.requireNonNullElse(less, Boolean.FALSE);
                 });
-        map.putAll(getCommonLtOperations(ctx));
         return map;
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandler.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandler.java
@@ -202,8 +202,7 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     @Override
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getGteOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
-
-        // BFEEL: null returns FALSE (not null like standard FEEL)
+        // BFEEL: null returns FALSE
         map.put(
                 new CheckedPredicate((left, right) -> left == null || right == null, false),
                 (left, right) -> Boolean.FALSE);
@@ -237,8 +236,7 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     @Override
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getGtOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
-
-        // BFEEL: null returns FALSE (not null like standard FEEL)
+        // BFEEL: null returns FALSE 
         map.put(
                 new CheckedPredicate((left, right) -> left == null || right == null, false),
                 (left, right) -> Boolean.FALSE);
@@ -253,8 +251,7 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     @Override
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getLteOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
-
-        // BFEEL: null returns FALSE (not null like standard FEEL)
+        // BFEEL: null returns FALSE
         map.put(
                 new CheckedPredicate((left, right) -> left == null || right == null, false),
                 (left, right) -> Boolean.FALSE);
@@ -287,8 +284,7 @@ public class BFEELDialectHandler extends DefaultDialectHandler implements Dialec
     @Override
     public Map<CheckedPredicate, BiFunction<Object, Object, Object>> getLtOperations(EvaluationContext ctx) {
         Map<CheckedPredicate, BiFunction<Object, Object, Object>> map = new LinkedHashMap<>();
-
-        // BFEEL: null returns FALSE (not null like standard FEEL)
+        // BFEEL: null returns FALSE
         map.put(
                 new CheckedPredicate((left, right) -> left == null || right == null, false),
                 (left, right) -> Boolean.FALSE);

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/DefaultDialectHandler.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/DefaultDialectHandler.java
@@ -212,10 +212,8 @@ public abstract class DefaultDialectHandler implements DialectHandler {
                 (left, right) -> {
                     Boolean greater = compare(left, right,
                             (leftNum, rightNum) -> leftNum.compareTo(rightNum) > 0);
-                    //Boolean equal = BooleanEvalHelper.isEqual(left, right, dialect);
-                    Boolean equal = (EqExecutor.instance().evaluate(left, right, ctx) instanceof Boolean)
-                            ? (Boolean) EqExecutor.instance().evaluate(left, right, ctx)
-                            : null;
+                    Object eqResult = EqExecutor.instance().evaluate(left, right, ctx);
+                    Boolean equal = (eqResult instanceof Boolean) ? (Boolean) eqResult : null;
                     if (greater == null && equal == null)
                         return null;
                     if (Boolean.TRUE.equals(greater) || Boolean.TRUE.equals(equal))
@@ -275,10 +273,8 @@ public abstract class DefaultDialectHandler implements DialectHandler {
                 (left, right) -> {
                     Boolean less = compare(left, right,
                             (l, r) -> l.compareTo(r) < 0);
-                    // Boolean equal = BooleanEvalHelper.isEqual(left, right, dialect);
-                    Boolean equal = (EqExecutor.instance().evaluate(left, right, ctx) instanceof Boolean)
-                            ? (Boolean) EqExecutor.instance().evaluate(left, right, ctx)
-                            : null;
+                    Object eqResult = EqExecutor.instance().evaluate(left, right, ctx);
+                    Boolean equal = (eqResult instanceof Boolean) ? (Boolean) eqResult : null;
 
                     if (less == null && equal == null) {
                         return null;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/DefaultDialectHandler.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/dialectHandlers/DefaultDialectHandler.java
@@ -694,18 +694,17 @@ public abstract class DefaultDialectHandler implements DialectHandler {
             Object right,
             EvaluationContext ctx,
             Map<CheckedPredicate, BiFunction<Object, Object, Object>> operationMap) {
-        Optional<Map.Entry<CheckedPredicate, BiFunction<Object, Object, Object>>> match =
-                operationMap.entrySet().stream()
-                        .filter(entry -> entry.getKey().predicate.test(left, right))
-                        .findFirst();
-
-        if (match.isPresent()) {
-            Object result = match.get().getValue().apply(left, right);
-            if (result == null && match.get().getKey().toNotify) {
-                commonManageInvalidParameters(ctx);
+        for (Map.Entry<CheckedPredicate, BiFunction<Object, Object, Object>> entry : operationMap.entrySet()) {
+            if (entry.getKey().predicate.test(left, right)) {
+                Object result = entry.getValue().apply(left, right);
+                if (result == null && entry.getKey().toNotify) {
+                    commonManageInvalidParameters(ctx);
+                }
+                return result;
             }
-            return result;
         }
+        
+        // No matching predicate found
         commonManageInvalidParameters(ctx);
         return null;
     }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandlerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandlerTest.java
@@ -273,15 +273,10 @@ class BFEELDialectHandlerTest {
         
         assertThat(handler.executeNotEqual(null, null, ctx)).isEqualTo(Boolean.FALSE);
         assertThat(handler.executeNotEqual(10, 20, ctx)).isEqualTo(Boolean.TRUE);
-    
-        // Comparison_Relational - Fixed to expect correct behavior after bug fix
-        // For booleans: false >= false is true (equal via equality check)
         assertThat(handler.executeGte(Boolean.FALSE, Boolean.FALSE, ctx)).isEqualTo(Boolean.TRUE);
-        // Boolean TRUE >= FALSE: falls through to common operations which does OR → true
         assertThat(handler.executeGte(Boolean.TRUE, Boolean.FALSE, ctx)).isEqualTo(Boolean.TRUE);
         // String vs Boolean: incompatible types → false
         assertThat(handler.executeGte("test", Boolean.TRUE, ctx)).isEqualTo(Boolean.FALSE);
-        // FIXED: Numeric comparisons now work correctly
         assertThat(handler.executeGte(20, 10, ctx)).isEqualTo(Boolean.TRUE);  // 20 >= 10 is TRUE
         assertThat(handler.executeGte(10, 10, ctx)).isEqualTo(Boolean.TRUE);  // 10 >= 10 is TRUE
         assertThat(handler.executeGte("test", 10, ctx)).isEqualTo(Boolean.FALSE);

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandlerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/ast/dialectHandlers/BFEELDialectHandlerTest.java
@@ -53,12 +53,14 @@ class BFEELDialectHandlerTest {
         // Case 1 : STRING - If either operand is a string, convert non-string to string
         // Left: string + other
         assertThat(handler.executeAdd("Hello", 123, ctx)).isEqualTo("Hello123");
+        assertThat(handler.executeAdd("The result is: ", 1, ctx)).isEqualTo("The result is: 1");
         assertThat(handler.executeAdd("Date:", LocalDate.of(2024, 1, 1), ctx)).isEqualTo("Date:2024-01-01");
         assertThat(handler.executeAdd("Duration:", Duration.ofDays(5), ctx)).isEqualTo("Duration:PT120H");
         assertThat(handler.executeAdd("Period:", Period.ofMonths(3), ctx)).isEqualTo("Period:P3M");
         
         // Right: other + string
         assertThat(handler.executeAdd(123, "World", ctx)).isEqualTo("123World");
+        assertThat(handler.executeAdd(5, " minutes", ctx)).isEqualTo("5 minutes");
         assertThat(handler.executeAdd(LocalDate.of(2024, 1, 1), " is the date", ctx)).isEqualTo("2024-01-01 is the date");
         assertThat(handler.executeAdd(Duration.ofDays(5), " duration", ctx)).isEqualTo("PT120H duration");
         assertThat(handler.executeAdd(Period.ofMonths(3), " period", ctx)).isEqualTo("P3M period");
@@ -272,22 +274,137 @@ class BFEELDialectHandlerTest {
         assertThat(handler.executeNotEqual(null, null, ctx)).isEqualTo(Boolean.FALSE);
         assertThat(handler.executeNotEqual(10, 20, ctx)).isEqualTo(Boolean.TRUE);
     
-        // Comparison_Relational
-        assertThat(handler.executeGte(Boolean.FALSE, Boolean.FALSE, ctx)).isEqualTo(Boolean.FALSE);
-        assertThat(handler.executeGte("test", Boolean.TRUE, ctx)).isEqualTo(Boolean.TRUE);
-        assertThat(handler.executeGte(20, 10, ctx)).isEqualTo(Boolean.FALSE);
+        // Comparison_Relational - Fixed to expect correct behavior after bug fix
+        // For booleans: false >= false is true (equal via equality check)
+        assertThat(handler.executeGte(Boolean.FALSE, Boolean.FALSE, ctx)).isEqualTo(Boolean.TRUE);
+        // Boolean TRUE >= FALSE: falls through to common operations which does OR → true
+        assertThat(handler.executeGte(Boolean.TRUE, Boolean.FALSE, ctx)).isEqualTo(Boolean.TRUE);
+        // String vs Boolean: incompatible types → false
+        assertThat(handler.executeGte("test", Boolean.TRUE, ctx)).isEqualTo(Boolean.FALSE);
+        // FIXED: Numeric comparisons now work correctly
+        assertThat(handler.executeGte(20, 10, ctx)).isEqualTo(Boolean.TRUE);  // 20 >= 10 is TRUE
+        assertThat(handler.executeGte(10, 10, ctx)).isEqualTo(Boolean.TRUE);  // 10 >= 10 is TRUE
         assertThat(handler.executeGte("test", 10, ctx)).isEqualTo(Boolean.FALSE);
         
-        assertThat(handler.executeGt(20, 10, ctx)).isEqualTo(Boolean.FALSE);
+        assertThat(handler.executeGt(20, 10, ctx)).isEqualTo(Boolean.TRUE);   // 20 > 10 is TRUE
+        assertThat(handler.executeGt(10, 20, ctx)).isEqualTo(Boolean.FALSE);  // 10 > 20 is FALSE
         assertThat(handler.executeGt(new Object(), new Object(), ctx)).isEqualTo(Boolean.FALSE);
-        assertThat(handler.executeLte(5, 10, ctx)).isEqualTo(Boolean.FALSE);
-        assertThat(handler.executeLt(5, 10, ctx)).isEqualTo(Boolean.FALSE);
+        assertThat(handler.executeLte(5, 10, ctx)).isEqualTo(Boolean.TRUE);   // 5 <= 10 is TRUE
+        assertThat(handler.executeLte(10, 10, ctx)).isEqualTo(Boolean.TRUE);  // 10 <= 10 is TRUE
+        assertThat(handler.executeLt(5, 10, ctx)).isEqualTo(Boolean.TRUE);    // 5 < 10 is TRUE
+        assertThat(handler.executeLt(10, 5, ctx)).isEqualTo(Boolean.FALSE);   // 10 < 5 is FALSE
     
         // Comparison_CompareMethod
         assertThat(handler.compare(null, null, (l, r) -> l.compareTo(r) > 0)).isEqualTo(Boolean.FALSE);
         assertThat(handler.compare(20, 10, (l, r) -> l.compareTo(r) > 0)).isTrue();
         assertThat(handler.compare("test", "test", (l, r) -> l.compareTo(r) == 0)).isTrue();
         assertThat(handler.compare("test", 10, (l, r) -> l.compareTo(r) > 0)).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    void testRelationalOperatorsComprehensive() {
+        // Test GT (>) operator - comprehensive scenarios
+        assertThat(handler.executeGt(5, 2, ctx)).isEqualTo(Boolean.TRUE);     // 5 > 2
+        assertThat(handler.executeGt(2, 5, ctx)).isEqualTo(Boolean.FALSE);    // 2 > 5
+        assertThat(handler.executeGt(5, 5, ctx)).isEqualTo(Boolean.FALSE);    // 5 > 5 (equal)
+        assertThat(handler.executeGt(new BigDecimal("10.5"), new BigDecimal("10.4"), ctx)).isEqualTo(Boolean.TRUE);
+        assertThat(handler.executeGt(null, 5, ctx)).isEqualTo(Boolean.FALSE); // null > 5
+        assertThat(handler.executeGt(5, null, ctx)).isEqualTo(Boolean.FALSE); // 5 > null
+        
+        // Test GTE (>=) operator - comprehensive scenarios
+        assertThat(handler.executeGte(5, 2, ctx)).isEqualTo(Boolean.TRUE);    // 5 >= 2
+        assertThat(handler.executeGte(5, 5, ctx)).isEqualTo(Boolean.TRUE);    // 5 >= 5 (equal)
+        assertThat(handler.executeGte(2, 5, ctx)).isEqualTo(Boolean.FALSE);   // 2 >= 5
+        assertThat(handler.executeGte(new BigDecimal("10.5"), new BigDecimal("10.5"), ctx)).isEqualTo(Boolean.TRUE);
+        assertThat(handler.executeGte(null, 5, ctx)).isEqualTo(Boolean.FALSE); // null >= 5
+        
+        // Test LT (<) operator - comprehensive scenarios
+        assertThat(handler.executeLt(2, 5, ctx)).isEqualTo(Boolean.TRUE);     // 2 < 5
+        assertThat(handler.executeLt(5, 2, ctx)).isEqualTo(Boolean.FALSE);    // 5 < 2
+        assertThat(handler.executeLt(5, 5, ctx)).isEqualTo(Boolean.FALSE);    // 5 < 5 (equal)
+        assertThat(handler.executeLt(new BigDecimal("10.4"), new BigDecimal("10.5"), ctx)).isEqualTo(Boolean.TRUE);
+        assertThat(handler.executeLt(null, 5, ctx)).isEqualTo(Boolean.FALSE); // null < 5
+        assertThat(handler.executeLt(5, null, ctx)).isEqualTo(Boolean.FALSE); // 5 < null
+        
+        // Test LTE (<=) operator - comprehensive scenarios
+        assertThat(handler.executeLte(2, 5, ctx)).isEqualTo(Boolean.TRUE);    // 2 <= 5
+        assertThat(handler.executeLte(5, 5, ctx)).isEqualTo(Boolean.TRUE);    // 5 <= 5 (equal)
+        assertThat(handler.executeLte(5, 2, ctx)).isEqualTo(Boolean.FALSE);   // 5 <= 2
+        assertThat(handler.executeLte(new BigDecimal("10.5"), new BigDecimal("10.5"), ctx)).isEqualTo(Boolean.TRUE);
+        assertThat(handler.executeLte(null, 5, ctx)).isEqualTo(Boolean.FALSE); // null <= 5
+        
+        // Test with BigDecimal edge cases
+        assertThat(handler.executeGt(new BigDecimal("0.1"), new BigDecimal("0.09"), ctx)).isEqualTo(Boolean.TRUE);
+        assertThat(handler.executeLt(new BigDecimal("-5"), new BigDecimal("5"), ctx)).isEqualTo(Boolean.TRUE);
+        assertThat(handler.executeGte(new BigDecimal("0"), new BigDecimal("0"), ctx)).isEqualTo(Boolean.TRUE);
+        
+        // Test with negative numbers
+        assertThat(handler.executeGt(-2, -5, ctx)).isEqualTo(Boolean.TRUE);   // -2 > -5
+        assertThat(handler.executeLt(-5, -2, ctx)).isEqualTo(Boolean.TRUE);   // -5 < -2
+        assertThat(handler.executeGte(-5, -5, ctx)).isEqualTo(Boolean.TRUE);  // -5 >= -5
+        assertThat(handler.executeLte(-2, -2, ctx)).isEqualTo(Boolean.TRUE);  // -2 <= -2
+    }
+
+    @Test
+    void testRelationalOperatorsWithDatesAndDurations() {
+        // Test with LocalDate
+        LocalDate date1 = LocalDate.of(2024, 1, 1);
+        LocalDate date2 = LocalDate.of(2024, 1, 10);
+        LocalDate date3 = LocalDate.of(2024, 1, 1);
+        
+        assertThat(handler.executeGt(date2, date1, ctx)).isEqualTo(Boolean.TRUE);   // later > earlier
+        assertThat(handler.executeLt(date1, date2, ctx)).isEqualTo(Boolean.TRUE);   // earlier < later
+        assertThat(handler.executeGte(date1, date3, ctx)).isEqualTo(Boolean.TRUE);  // same >= same
+        assertThat(handler.executeLte(date1, date3, ctx)).isEqualTo(Boolean.TRUE);  // same <= same
+        assertThat(handler.executeGt(date1, date2, ctx)).isEqualTo(Boolean.FALSE);  // earlier > later
+        
+        // Test with Duration
+        Duration dur1 = Duration.ofHours(1);
+        Duration dur2 = Duration.ofHours(2);
+        Duration dur3 = Duration.ofHours(1);
+        
+        assertThat(handler.executeGt(dur2, dur1, ctx)).isEqualTo(Boolean.TRUE);     // 2h > 1h
+        assertThat(handler.executeLt(dur1, dur2, ctx)).isEqualTo(Boolean.TRUE);     // 1h < 2h
+        assertThat(handler.executeGte(dur1, dur3, ctx)).isEqualTo(Boolean.TRUE);    // 1h >= 1h
+        assertThat(handler.executeLte(dur1, dur3, ctx)).isEqualTo(Boolean.TRUE);    // 1h <= 1h
+        assertThat(handler.executeGt(dur1, dur2, ctx)).isEqualTo(Boolean.FALSE);    // 1h > 2h
+        
+        // Test with Period
+        Period period1 = Period.ofMonths(6);
+        Period period2 = Period.ofYears(1);  // 12 months
+        Period period3 = Period.ofMonths(6);
+        
+        assertThat(handler.executeGt(period2, period1, ctx)).isEqualTo(Boolean.TRUE);  // 12m > 6m
+        assertThat(handler.executeLt(period1, period2, ctx)).isEqualTo(Boolean.TRUE);  // 6m < 12m
+        assertThat(handler.executeGte(period1, period3, ctx)).isEqualTo(Boolean.TRUE); // 6m >= 6m
+        assertThat(handler.executeLte(period1, period3, ctx)).isEqualTo(Boolean.TRUE); // 6m <= 6m
+    }
+
+    @Test
+    void testRelationalOperatorsWithIncompatibleTypes() {
+        // String vs Number - should return false
+        assertThat(handler.executeGt("test", 10, ctx)).isEqualTo(Boolean.FALSE);
+        assertThat(handler.executeLt("test", 10, ctx)).isEqualTo(Boolean.FALSE);
+        assertThat(handler.executeGte("test", 10, ctx)).isEqualTo(Boolean.FALSE);
+        assertThat(handler.executeLte("test", 10, ctx)).isEqualTo(Boolean.FALSE);
+        
+        // Number vs String - should return false
+        assertThat(handler.executeGt(10, "test", ctx)).isEqualTo(Boolean.FALSE);
+        assertThat(handler.executeLt(10, "test", ctx)).isEqualTo(Boolean.FALSE);
+        
+        // Date vs Number - should return false
+        assertThat(handler.executeGt(LocalDate.of(2024, 1, 1), 10, ctx)).isEqualTo(Boolean.FALSE);
+        assertThat(handler.executeLt(LocalDate.of(2024, 1, 1), 10, ctx)).isEqualTo(Boolean.FALSE);
+        
+        // Duration vs String - should return false
+        assertThat(handler.executeGt(Duration.ofDays(5), "test", ctx)).isEqualTo(Boolean.FALSE);
+        assertThat(handler.executeLt(Duration.ofDays(5), "test", ctx)).isEqualTo(Boolean.FALSE);
+        
+        // Object vs Object (non-comparable) - should return false
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        assertThat(handler.executeGt(obj1, obj2, ctx)).isEqualTo(Boolean.FALSE);
+        assertThat(handler.executeLt(obj1, obj2, ctx)).isEqualTo(Boolean.FALSE);
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2346

Fix overly aggressive false coercion in BFEEL relational evaluation

Remove false-coercion guards from relational evaluation paths in BFEEL.
These guards were likely introduced to provide a default false result
for invalid or non-comparable operands, but they also intercepted valid
comparison flows and caused legitimate expressions such as 5 > 2,
2 < 5, 5 >= 5, count([1,2,3]) > 0, and between checks to
evaluate to false.

The change restores proper relational behavior while keeping the intended fallback intact — invalid or incompatible comparisons still evaluate to false, ensuring test coverage remains preserved for the affected scenarios.