### PR TITLE
[incubator-kie-drools#6773] Improve CronExpression wildcard validation

### DIFF
--- a/drools-core/src/main/java/org/drools/core/time/impl/KieCronExpression.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/KieCronExpression.java
@@ -510,7 +510,7 @@ public class KieCronExpression implements Serializable {
                     throw new ParseException("Increment > 12 : " + incr, i);
                 }
             } else {
-                incr = 1;
+                throw new ParseException("Unexpected character after '*': " + c, i);
             }
 
             addToSet(ALL_SPEC_INT, -1, incr, type);
@@ -542,6 +542,9 @@ public class KieCronExpression implements Serializable {
                     ValueSet vs = getValue(val, s, i);
                     val = vs.value;
                     i = vs.pos;
+                }
+                if (val == ALL_SPEC_INT || val == NO_SPEC_INT) {
+                    throw new ParseException("'" + val + "' is not valid as a numeric value", i);
                 }
                 i = checkNext(i, s, val, type);
                 return i;

--- a/drools-core/src/test/java/org/drools/core/time/impl/CronExpressionTest.java
+++ b/drools-core/src/test/java/org/drools/core/time/impl/CronExpressionTest.java
@@ -26,11 +26,14 @@ import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 public class CronExpressionTest extends SerializationTestSupport {
@@ -183,10 +186,52 @@ public class CronExpressionTest extends SerializationTestSupport {
         }
     }
     
-    @Test 
+    @Test
     @Disabled
     public void testSerialization() {
         // TODO as we don't want to worry about this for now
     }
 
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    public void testLargeRangeValueInMinuteField() {
+        assertThatThrownBy(() -> new CronExpression("0 99-99909990 * * * ?"))
+                .isInstanceOf(ParseException.class);
+    }
+
+    @Test
+    public void testOutOfRangeMinuteValueMatchingSentinel() {
+        assertThatThrownBy(() -> new CronExpression("0 99 * * * ?"))
+                .isInstanceOf(ParseException.class);
+    }
+
+    @Test
+    public void testOutOfRangeRangeStartMatchingSentinel() {
+        assertThatThrownBy(() -> new CronExpression("0 99-5 * * * ?"))
+                .isInstanceOf(ParseException.class);
+    }
+
+    @Test
+    public void testOutOfRangeStepBaseMatchingSentinel() {
+        assertThatThrownBy(() -> new CronExpression("0 99/5 * * * ?"))
+                .isInstanceOf(ParseException.class);
+    }
+
+    @Test
+    public void testWildcardInRange() {
+        assertThatThrownBy(() -> new CronExpression("0 *-5 * * * ?"))
+                .isInstanceOf(ParseException.class);
+    }
+
+    @Test
+    public void testValidWildcard() throws ParseException {
+        CronExpression expr = new CronExpression("0 * * * * ?");
+        assertThat(expr.getCronExpression()).isEqualTo("0 * * * * ?");
+    }
+
+    @Test
+    public void testValidWildcardWithStep() throws ParseException {
+        CronExpression expr = new CronExpression("0 */5 * * * ?");
+        assertThat(expr.getCronExpression()).isEqualTo("0 */5 * * * ?");
+    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarWithPseudoTimeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarWithPseudoTimeTest.java
@@ -298,6 +298,13 @@ public class TimerAndCalendarWithPseudoTimeTest {
         wrongTimerExpression(kieBaseTestConfiguration, "cron: 0/30 * * * * *");
     }
 
+    @ParameterizedTest(name = "KieBase type={0}")
+    @MethodSource("parameters")
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void testLargeRangeValueInCronExpression(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        wrongTimerExpression(kieBaseTestConfiguration, "cron: 0 99-99909990 * * * ?");
+    }
+
     private void wrongTimerExpression(KieBaseTestConfiguration kieBaseTestConfiguration, final String timer) {
         final String drl =
                 "package org.simple \n" +


### PR DESCRIPTION
- Fix https://github.com/apache/incubator-kie-drools/issues/6773

Reject expression like `0 99-99909990 * * * ?`. Actually reject `99` because it's not acceptable number in cron (`99` is a special `int` to express `*` internally)