### PR TITLE
[incubator-kie-drools-6781] Resolve kbase-wide globals referenced from another package

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
@@ -224,7 +224,7 @@ public class PackageModel {
         packageModel.addImports( pkg.getImports().keySet());
         packageModel.addStaticImports( pkg.getStaticImports());
         packageModel.addEntryPoints( packageDescr.getEntryPointDeclarations());
-        packageModel.addGlobals( pkg );
+        packageModel.addGlobals( typeDeclarationContext.getGlobals() ); // register globals from all packages in context
         packageModel.setAccumulateFunctions( pkg.getAccumulateFunctions());
         packageModel.setInternalKnowledgePackage( pkg );
         new WindowReferenceGenerator( packageModel, typeResolver ).addWindowReferences( typeDeclarationContext, results, packageDescr.getWindowDeclarations());
@@ -387,6 +387,10 @@ public class PackageModel {
 
     public void addGlobals(InternalKnowledgePackage pkg) {
         globals.putAll( pkg.getGlobals() );
+    }
+
+    public void addGlobals(Map<String, java.lang.reflect.Type> globals) {
+        this.globals.putAll( globals );
     }
 
     public Map<String, java.lang.reflect.Type> getGlobals() {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/PackageModel.java
@@ -140,6 +140,7 @@ public class PackageModel {
     private Map<String, Method> staticMethods;
 
     private final Map<String, java.lang.reflect.Type> globals = new HashMap<>();
+    private final Map<String, Map.Entry<String, java.lang.reflect.Type>> externalGlobals = new ConcurrentHashMap<>();
 
     private final Map<String, RuleUnitMembers> ruleUnitMembers = new ConcurrentHashMap<>();
 
@@ -224,7 +225,7 @@ public class PackageModel {
         packageModel.addImports( pkg.getImports().keySet());
         packageModel.addStaticImports( pkg.getStaticImports());
         packageModel.addEntryPoints( packageDescr.getEntryPointDeclarations());
-        packageModel.addGlobals( typeDeclarationContext.getGlobals() ); // register globals from all packages in context
+        packageModel.addGlobals( pkg );
         packageModel.setAccumulateFunctions( pkg.getAccumulateFunctions());
         packageModel.setInternalKnowledgePackage( pkg );
         new WindowReferenceGenerator( packageModel, typeResolver ).addWindowReferences( typeDeclarationContext, results, packageDescr.getWindowDeclarations());
@@ -389,8 +390,10 @@ public class PackageModel {
         globals.putAll( pkg.getGlobals() );
     }
 
-    public void addGlobals(Map<String, java.lang.reflect.Type> globals) {
-        this.globals.putAll( globals );
+    public void addExternalGlobal(String globalName, String originatingPackage, java.lang.reflect.Type type) {
+        if (!globals.containsKey(globalName)) {
+            externalGlobals.putIfAbsent(globalName, Map.entry(originatingPackage, type));
+        }
     }
 
     public Map<String, java.lang.reflect.Type> getGlobals() {
@@ -620,6 +623,10 @@ public class PackageModel {
 
         for ( Map.Entry<String, java.lang.reflect.Type> g : globals.entrySet() ) {
             addGlobalField(rulesClass, rulesListInitializerBody, getName(), g.getKey(), g.getValue());
+        }
+
+        for ( Map.Entry<String, Map.Entry<String, java.lang.reflect.Type>> ext : externalGlobals.entrySet() ) {
+            addGlobalFieldDeclaration(rulesClass, ext.getValue().getKey(), ext.getKey(), ext.getValue().getValue());
         }
 
         rulesClass.addMember( generateListField("org.drools.model.Global", "globals", globals.isEmpty() && !hasRuleUnit) );
@@ -907,6 +914,11 @@ public class PackageModel {
     }
 
     private static void addGlobalField(ClassOrInterfaceDeclaration classDeclaration, BlockStmt rulesListInitializerBody, String packageName, String globalName, java.lang.reflect.Type globalType) {
+        addGlobalFieldDeclaration(classDeclaration, packageName, globalName, globalType);
+        addInitStatement( rulesListInitializerBody, new NameExpr( toVar(globalName) ), "globals" );
+    }
+
+    private static void addGlobalFieldDeclaration(ClassOrInterfaceDeclaration classDeclaration, String packageName, String globalName, java.lang.reflect.Type globalType) {
         ClassOrInterfaceType varType = toClassOrInterfaceType(Global.class);
         MethodCallExpr declarationOfCall = createDslTopLevelMethod(GLOBAL_OF_CALL);
 
@@ -929,8 +941,6 @@ public class PackageModel {
         FieldDeclaration field = classDeclaration.addField(varType, toVar(globalName), publicModifier().getKeyword(), staticModifier().getKeyword(), finalModifier().getKeyword());
 
         field.getVariables().get(0).setInitializer(declarationOfCall);
-
-        addInitStatement( rulesListInitializerBody, new NameExpr( toVar(globalName) ), "globals" );
     }
 
     public void setAccumulateFunctions(Map<String, AccumulateFunction> accumulateFunctions) {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
@@ -316,15 +316,15 @@ public class RuleContext {
     public void addGlobalDeclarations() {
         Map<String, java.lang.reflect.Type> globals = getGlobals();
 
-        // also takes globals defined in different packages imported with a wildcard
-        packageModel.getImports().stream()
-                .filter( imp -> imp.endsWith(".*") )
-                .map( imp -> imp.substring(0, imp.length()-2) )
-                .map( imp -> typeDeclarationContext.getPackageRegistry(imp) )
+        // Globals are kbase-wide: include globals declared in any package of the kbase, not only
+        // those in the current package or in packages imported with a wildcard. This matches the
+        // classic (non-executable-model) behavior where a global is visible from every package, so
+        // a constraint can reference a global declared in another DRL without a wildcard import.
+        typeDeclarationContext.getPackageRegistry().values().stream()
                 .filter( Objects::nonNull )
-                .map( pkgRegistry -> pkgRegistry.getPackage().getGlobals() )
-                .forEach( globals::putAll );
-        
+                .filter( pkgRegistry -> pkgRegistry.getPackage() != null )
+                .forEach( pkgRegistry -> globals.putAll( pkgRegistry.getPackage().getGlobals() ) );
+
         for (Map.Entry<String, java.lang.reflect.Type> ks : globals.entrySet()) {
             definedVars.put(ks.getKey(), ks.getKey());
             addDeclaration(new TypedDeclarationSpec(ks.getKey(), ks.getValue(), true));

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
@@ -46,6 +46,7 @@ import com.github.javaparser.ast.type.UnknownType;
 import org.drools.compiler.builder.impl.BuildResultCollector;
 import org.drools.compiler.builder.impl.KnowledgeBuilderRulesConfigurationImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationContext;
+import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.compiler.rule.builder.EvaluatorDefinition;
 import org.drools.base.ruleunit.RuleUnitDescriptionLoader;
 import org.drools.core.util.Bag;
@@ -313,11 +314,34 @@ public class RuleContext {
     }
 
     public void addGlobalDeclarations() {
-        // Globals are KieBase-wide (see getGlobals()); register each as a declaration for this rule.
-        for (Map.Entry<String, java.lang.reflect.Type> ks : getGlobals().entrySet()) {
+        Map<String, java.lang.reflect.Type> globals = getGlobals();
+        for (Map.Entry<String, java.lang.reflect.Type> ks : globals.entrySet()) {
             definedVars.put(ks.getKey(), ks.getKey());
             addDeclaration(new TypedDeclarationSpec(ks.getKey(), ks.getValue(), true));
         }
+        registerExternalGlobals(globals);
+    }
+
+    private void registerExternalGlobals(Map<String, java.lang.reflect.Type> globals) {
+        Map<String, java.lang.reflect.Type> pkgGlobals = packageModel.getGlobals();
+        for (Map.Entry<String, java.lang.reflect.Type> entry : globals.entrySet()) {
+            if (!pkgGlobals.containsKey(entry.getKey())) {
+                String originatingPackage = findGlobalPackage(entry.getKey());
+                if (originatingPackage != null) {
+                    packageModel.addExternalGlobal(entry.getKey(), originatingPackage, entry.getValue());
+                }
+            }
+        }
+    }
+
+    private String findGlobalPackage(String globalName) {
+        for (Map.Entry<String, PackageRegistry> entry : typeDeclarationContext.getPackageRegistry().entrySet()) {
+            PackageRegistry reg = entry.getValue();
+            if (reg != null && reg.getPackage() != null && reg.getPackage().getGlobals().containsKey(globalName)) {
+                return entry.getKey();
+            }
+        }
+        return null;
     }
 
     public Map<String, java.lang.reflect.Type> getGlobals() {

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/RuleContext.java
@@ -31,7 +31,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -314,35 +313,19 @@ public class RuleContext {
     }
 
     public void addGlobalDeclarations() {
-        Map<String, java.lang.reflect.Type> globals = getGlobals();
-
-        // Globals are kbase-wide: include globals declared in any package of the kbase, not only
-        // those in the current package or in packages imported with a wildcard. This matches the
-        // classic (non-executable-model) behavior where a global is visible from every package, so
-        // a constraint can reference a global declared in another DRL without a wildcard import.
-        typeDeclarationContext.getPackageRegistry().values().stream()
-                .filter( Objects::nonNull )
-                .filter( pkgRegistry -> pkgRegistry.getPackage() != null )
-                .forEach( pkgRegistry -> globals.putAll( pkgRegistry.getPackage().getGlobals() ) );
-
-        for (Map.Entry<String, java.lang.reflect.Type> ks : globals.entrySet()) {
+        // Globals are KieBase-wide (see getGlobals()); register each as a declaration for this rule.
+        for (Map.Entry<String, java.lang.reflect.Type> ks : getGlobals().entrySet()) {
             definedVars.put(ks.getKey(), ks.getKey());
             addDeclaration(new TypedDeclarationSpec(ks.getKey(), ks.getValue(), true));
         }
     }
 
     public Map<String, java.lang.reflect.Type> getGlobals() {
-        Map<String, java.lang.reflect.Type> pkgGlobals = packageModel.getGlobals();
-        if (ruleUnitDescr == null) {
-            return pkgGlobals;
+        // KieBase-wide globals (declared in any package of the build); the current rule unit's globals, if any, are layered on top
+        Map<String, java.lang.reflect.Type> globals = new HashMap<>(typeDeclarationContext.getGlobals());
+        if (ruleUnitDescr != null) {
+            globals.putAll(packageModel.getGlobalsForUnit(ruleUnitDescr.getSimpleName()));
         }
-        Map<String, java.lang.reflect.Type> ruleUnitGlobals = packageModel.getGlobalsForUnit(ruleUnitDescr.getSimpleName());
-        if (pkgGlobals.isEmpty()) {
-            return ruleUnitGlobals;
-        }
-        Map<String, java.lang.reflect.Type> globals = new HashMap<>();
-        globals.putAll(pkgGlobals);
-        globals.putAll(ruleUnitGlobals);
         return globals;
     }
 

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
@@ -601,6 +601,26 @@ public class DeclaredTypesTest extends BaseModelTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
+    public void testGlobalReferencedInConstraintFromDifferentPackage(RUN_TYPE runType) {
+        // A global declared in one DRL package must be resolvable from a pattern constraint compiled
+        // from a different package in the same KieBase, matching the classic compiler where globals are
+        // KieBase-wide and visible without a wildcard import. Here a BigDecimal global 'threshold' is
+        // declared in com.test.globals and referenced from a Person constraint in com.test.rules.
+        String globalDrl =
+                "package com.test.globals;\n" +
+                "global java.math.BigDecimal threshold;\n";
+        String ruleDrl =
+                "package com.test.rules;\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R when\n" +
+                "  Person( money.compareTo(threshold) < 0 )\n" +
+                "then end";
+        KieSession ksession = getKieSession(runType, globalDrl, ruleDrl);
+        ksession.fireAllRules();
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
     void testNonDefinedCustomAnnotation(RUN_TYPE runType) {
         String str = "package org.example.custom; \n" +
                 "import " + Date.class.getCanonicalName() + ";\n" +

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
@@ -601,26 +601,6 @@ public class DeclaredTypesTest extends BaseModelTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testGlobalReferencedInConstraintFromDifferentPackage(RUN_TYPE runType) {
-        // A global declared in one DRL package must be resolvable from a pattern constraint compiled
-        // from a different package in the same KieBase, matching the classic compiler where globals are
-        // KieBase-wide and visible without a wildcard import. Here a BigDecimal global 'threshold' is
-        // declared in com.test.globals and referenced from a Person constraint in com.test.rules.
-        String globalDrl =
-                "package com.test.globals;\n" +
-                "global java.math.BigDecimal threshold;\n";
-        String ruleDrl =
-                "package com.test.rules;\n" +
-                "import " + Person.class.getCanonicalName() + ";\n" +
-                "rule R when\n" +
-                "  Person( money.compareTo(threshold) < 0 )\n" +
-                "then end";
-        KieSession ksession = getKieSession(runType, globalDrl, ruleDrl);
-        ksession.fireAllRules();
-    }
-
-    @ParameterizedTest
-    @MethodSource("parameters")
     void testNonDefinedCustomAnnotation(RUN_TYPE runType) {
         String str = "package org.example.custom; \n" +
                 "import " + Date.class.getCanonicalName() + ";\n" +

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GlobalTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GlobalTest.java
@@ -19,6 +19,7 @@
 package org.drools.model.codegen.execmodel;
 
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -94,6 +95,32 @@ public class GlobalTest extends BaseModelTest {
         ksession.fireAllRules();
 
         assertThat(result.getValue()).isEqualTo("Mark is 37");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testGlobalReferencedInConstraintFromDifferentPackage(RUN_TYPE runType) {
+        // A global declared in one DRL package must be resolvable from a pattern constraint compiled from
+        // a different package in the same KieBase (globals are KieBase-wide, matching the classic compiler)
+        // and usable at runtime. Here 'threshold' is declared in com.test.globals and referenced from a
+        // Person constraint in com.test.rules, with no wildcard import.
+        String globalDrl =
+                "package com.test.globals;\n" +
+                "global java.math.BigDecimal threshold;\n";
+        String ruleDrl =
+                "package com.test.rules;\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R when\n" +
+                "  Person( money.compareTo(threshold) < 0 )\n" +
+                "then end";
+
+        KieSession ksession = getKieSession(runType, globalDrl, ruleDrl);
+        ksession.setGlobal("threshold", new BigDecimal("100"));
+
+        ksession.insert(new Person("Poor", new BigDecimal("50")));   // 50 < 100 -> matches
+        ksession.insert(new Person("Rich", new BigDecimal("150")));  // 150 < 100 -> no match
+
+        assertThat(ksession.fireAllRules()).isEqualTo(1);
     }
 
     public static class Functions {

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GlobalTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/GlobalTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
 import org.kie.api.builder.Message;
 import org.kie.api.builder.Results;
+import org.kie.api.definition.KiePackage;
+import org.kie.api.definition.rule.Global;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
 
@@ -121,6 +123,40 @@ public class GlobalTest extends BaseModelTest {
         ksession.insert(new Person("Rich", new BigDecimal("150")));  // 150 < 100 -> no match
 
         assertThat(ksession.fireAllRules()).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testRemovingDeclaringPackageCleansUpGlobal(RUN_TYPE runType) {
+        // A global declared in com.test.globals and referenced from com.test.rules must be
+        // removed from the KieBase when com.test.globals is removed, because no remaining
+        // package declares it. If the executable model incorrectly seeds all globals into every
+        // PackageModel, the global survives removal because the non-declaring package still
+        // "owns" it — breaking the package-removal contract.
+        String globalDrl =
+                "package com.test.globals;\n" +
+                "global java.math.BigDecimal threshold;\n";
+        String ruleDrl =
+                "package com.test.rules;\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R when\n" +
+                "  Person( money.compareTo(threshold) < 0 )\n" +
+                "then end";
+
+        KieSession ksession = getKieSession(runType, globalDrl, ruleDrl);
+        KieBase kieBase = ksession.getKieBase();
+
+        assertThat(kieBase.getKiePackage("com.test.globals").getGlobalVariables())
+                .extracting(Global::getName).contains("threshold");
+
+        kieBase.removeKiePackage("com.test.globals");
+
+        assertThat(kieBase.getKiePackage("com.test.globals")).isNull();
+        KiePackage rulesPkg = kieBase.getKiePackage("com.test.rules");
+        assertThat(rulesPkg).isNotNull();
+        assertThat(rulesPkg.getGlobalVariables())
+                .as("Global must be removed after its declaring package is removed")
+                .extracting(Global::getName).doesNotContain("threshold");
     }
 
     public static class Functions {


### PR DESCRIPTION
Fixes: #6781 

GlobalDeclarations only collected globals from the current package and from packages imported with a wildcard. A constraint compiled from a different package in the same KieBase therefore could not resolve a global declared elsewhere, unlike the classic compiler where globals are KieBase-wide. Collect globals from every package registry in the KieBase.