### PR TITLE
[incubator-kie-drools-6784] Log which rule and constraint fail the pattern auto-naming pre-pass

### DIFF
--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/ClassPatternDSL.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/ClassPatternDSL.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
+import org.drools.mvel.parser.ast.expr.DrlxExpression;
 import org.drools.base.util.PropertyReactivityUtil;
 import org.drools.compiler.compiler.DescrBuildError;
 import org.drools.drl.ast.descr.BaseDescr;
@@ -72,6 +73,8 @@ import static org.drools.mvel.parser.printer.PrintUtil.printNode;
 import static org.drools.util.StreamUtils.optionalToStream;
 
 public class ClassPatternDSL extends PatternDSL {
+
+    private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(ClassPatternDSL.class);
 
     private Class<?> patternType;
 
@@ -166,12 +169,36 @@ public class ClassPatternDSL extends PatternDSL {
     }
 
     private Optional<String> findFirstInnerBinding(List<? extends BaseDescr> constraintDescrs, Class<?> patternType) {
-        return constraintDescrs.stream()
-                .map( constraint -> ConstraintExpression.createConstraintExpression( context, patternType, constraint, isPositional(constraint) ).getExpression() )
-                .map( DrlxParseUtil::parseExpression )
-                .filter( drlx -> drlx.getBind() != null )
-                .map( drlx -> drlx.getBind().asString() )
-                .findFirst();
+        for ( BaseDescr constraint : constraintDescrs ) {
+            ConstraintExpression constraintExpression =
+                    ConstraintExpression.createConstraintExpression( context, patternType, constraint, isPositional( constraint ) );
+            if ( constraintExpression == null ) {
+                continue;
+            }
+            String expression = constraintExpression.getExpression();
+            if ( expression == null || expression.trim().isEmpty() ) {
+                continue;
+            }
+            DrlxExpression drlx;
+            try {
+                drlx = DrlxParseUtil.parseExpression( expression );
+            } catch ( RuntimeException e ) {
+                // This method only parses constraints to derive a name for an *unnamed* pattern. A
+                // constraint that doesn't parse here cannot declare an inner binding ($x : field) anyway,
+                // so deriving a name from it is impossible regardless; don't let it abort the whole
+                // KieBase build. Log which rule and pattern carry the offending constraint (to aid
+                // diagnosis), then skip. The actual constraint compilation is handled separately in
+                // findAllConstraint and will report a proper compilation error there if warranted.
+                LOG.warn( "Skipping a constraint that could not be parsed while generating an identifier for an " +
+                          "unnamed pattern of type {} in rule '{}'. Offending constraint expression: [{}] ({}: {})",
+                          patternType, context.getRuleName(), expression, e.getClass().getSimpleName(), e.getMessage() );
+                continue;
+            }
+            if ( drlx.getBind() != null ) {
+                return Optional.of( drlx.getBind().asString() );
+            }
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/ClassPatternDSL.java
+++ b/drools-model/drools-model-codegen/src/main/java/org/drools/model/codegen/execmodel/generator/visitor/pattern/ClassPatternDSL.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
@@ -73,8 +74,6 @@ import static org.drools.mvel.parser.printer.PrintUtil.printNode;
 import static org.drools.util.StreamUtils.optionalToStream;
 
 public class ClassPatternDSL extends PatternDSL {
-
-    private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(ClassPatternDSL.class);
 
     private Class<?> patternType;
 
@@ -182,17 +181,9 @@ public class ClassPatternDSL extends PatternDSL {
             DrlxExpression drlx;
             try {
                 drlx = DrlxParseUtil.parseExpression( expression );
-            } catch ( RuntimeException e ) {
-                // This method only parses constraints to derive a name for an *unnamed* pattern. A
-                // constraint that doesn't parse here cannot declare an inner binding ($x : field) anyway,
-                // so deriving a name from it is impossible regardless; don't let it abort the whole
-                // KieBase build. Log which rule and pattern carry the offending constraint (to aid
-                // diagnosis), then skip. The actual constraint compilation is handled separately in
-                // findAllConstraint and will report a proper compilation error there if warranted.
-                LOG.warn( "Skipping a constraint that could not be parsed while generating an identifier for an " +
-                          "unnamed pattern of type {} in rule '{}'. Offending constraint expression: [{}] ({}: {})",
-                          patternType, context.getRuleName(), expression, e.getClass().getSimpleName(), e.getMessage() );
-                continue;
+            } catch ( ParseProblemException e ) {
+                throw new RuntimeException( "Unable to parse constraint [" + expression + "] while deriving an " +
+                        "identifier for an unnamed pattern of type " + patternType + " in rule '" + context.getRuleName() + "'", e );
             }
             if ( drlx.getBind() != null ) {
                 return Optional.of( drlx.getBind().asString() );

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CompilationFailuresTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/CompilationFailuresTest.java
@@ -20,6 +20,7 @@ package org.drools.model.codegen.execmodel;
 
 import java.math.BigDecimal;
 
+import org.drools.model.codegen.execmodel.domain.Child;
 import org.drools.model.codegen.execmodel.domain.Person;
 import org.drools.model.codegen.execmodel.domain.Result;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +29,7 @@ import org.kie.api.builder.Message;
 import org.kie.api.builder.Results;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class CompilationFailuresTest extends BaseModelTest {
 
@@ -65,6 +67,27 @@ public class CompilationFailuresTest extends BaseModelTest {
         assertThat(results.getMessages(Message.Level.ERROR).isEmpty()).isFalse();
 
         assertThat(results.getMessages().get(0).getLine()).isEqualTo(3);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersPatternOnly")
+    public void testUnparseableConstraintInUnnamedPatternFailsWithContext(RUN_TYPE runType) {
+        // When the pattern auto-naming pre-pass (ClassPatternDSL.findFirstInnerBinding) cannot parse a
+        // constraint of an unnamed pattern, the build must fail with an actionable error naming the rule
+        // and the offending expression - not a bare "unexpected token" and not a silently skipped
+        // constraint. 'class == X.class' is rejected by the executable-model DRLX grammar, so it triggers
+        // that path. Executable-model only: the classic compiler accepts 'class ==' and never reaches it.
+        String drl =
+                "package org.test;\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "import " + Child.class.getCanonicalName() + ";\n" +
+                "rule R when\n" +
+                "    Person( class == Child.class )\n" +
+                "then end";
+
+        assertThatThrownBy(() -> createKieBuilder(runType, drl))
+                .hasStackTraceContaining("rule 'R'")
+                .hasStackTraceContaining("class == Child.class");
     }
 
     private Results getCompilationResults(RUN_TYPE runType, String drl ) {

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
@@ -18,6 +18,11 @@
  */
 package org.drools.model.codegen.execmodel;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -40,8 +45,10 @@ import org.drools.core.reteoo.AlphaNode;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.model.codegen.execmodel.domain.Address;
+import org.drools.model.codegen.execmodel.domain.Child;
 import org.drools.model.codegen.execmodel.domain.Person;
 import org.drools.model.codegen.execmodel.domain.Result;
+import org.drools.model.codegen.execmodel.generator.visitor.pattern.ClassPatternDSL;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
@@ -50,6 +57,7 @@ import org.kie.api.builder.Results;
 import org.kie.api.definition.type.FactField;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -597,6 +605,42 @@ public class DeclaredTypesTest extends BaseModelTest {
 
         ksession.insert(f1);
         assertThat(ksession.fireAllRules()).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersPatternOnly")
+    public void testUnparseableConstraintInUnnamedPatternIsLoggedWithContext(RUN_TYPE runType) {
+        // When the pattern auto-naming pre-pass (ClassPatternDSL.findFirstInnerBinding) hits a
+        // constraint it cannot parse, it must not fail with a bare "unexpected token:" that hides which
+        // rule is at fault. It now logs a WARN naming the rule and the offending expression, then skips
+        // it; the real constraint compilation still rejects it (that abort is unchanged and correct).
+        // 'class == X.class' is rejected by the executable-model DRLX grammar, so it triggers the path.
+        // Executable-model only: the classic compiler accepts 'class ==' and never reaches this pre-pass.
+        Logger logger = (Logger) LoggerFactory.getLogger(ClassPatternDSL.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            String str =
+                    "package org.test;\n" +
+                    "import " + Person.class.getCanonicalName() + ";\n" +
+                    "import " + Child.class.getCanonicalName() + ";\n" +
+                    "rule R when\n" +
+                    "    Person( class == Child.class )\n" +
+                    "then end";
+            try {
+                createKieBuilder(runType, str);
+            } catch (RuntimeException expected) {
+                // The real constraint compilation still rejects 'class == ...'; that abort is unchanged.
+            }
+            assertThat(appender.list)
+                    .as("a WARN naming the rule and the offending constraint expression must be logged")
+                    .anyMatch(e -> e.getLevel() == Level.WARN
+                            && e.getFormattedMessage().contains("rule 'R'")
+                            && e.getFormattedMessage().contains("Child.class"));
+        } finally {
+            logger.detachAppender(appender);
+        }
     }
 
     @ParameterizedTest

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/DeclaredTypesTest.java
@@ -18,11 +18,6 @@
  */
 package org.drools.model.codegen.execmodel;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -45,10 +40,8 @@ import org.drools.core.reteoo.AlphaNode;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.model.codegen.execmodel.domain.Address;
-import org.drools.model.codegen.execmodel.domain.Child;
 import org.drools.model.codegen.execmodel.domain.Person;
 import org.drools.model.codegen.execmodel.domain.Result;
-import org.drools.model.codegen.execmodel.generator.visitor.pattern.ClassPatternDSL;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.KieBase;
@@ -57,7 +50,6 @@ import org.kie.api.builder.Results;
 import org.kie.api.definition.type.FactField;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
-import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -605,42 +597,6 @@ public class DeclaredTypesTest extends BaseModelTest {
 
         ksession.insert(f1);
         assertThat(ksession.fireAllRules()).isEqualTo(1);
-    }
-
-    @ParameterizedTest
-    @MethodSource("parametersPatternOnly")
-    public void testUnparseableConstraintInUnnamedPatternIsLoggedWithContext(RUN_TYPE runType) {
-        // When the pattern auto-naming pre-pass (ClassPatternDSL.findFirstInnerBinding) hits a
-        // constraint it cannot parse, it must not fail with a bare "unexpected token:" that hides which
-        // rule is at fault. It now logs a WARN naming the rule and the offending expression, then skips
-        // it; the real constraint compilation still rejects it (that abort is unchanged and correct).
-        // 'class == X.class' is rejected by the executable-model DRLX grammar, so it triggers the path.
-        // Executable-model only: the classic compiler accepts 'class ==' and never reaches this pre-pass.
-        Logger logger = (Logger) LoggerFactory.getLogger(ClassPatternDSL.class);
-        ListAppender<ILoggingEvent> appender = new ListAppender<>();
-        appender.start();
-        logger.addAppender(appender);
-        try {
-            String str =
-                    "package org.test;\n" +
-                    "import " + Person.class.getCanonicalName() + ";\n" +
-                    "import " + Child.class.getCanonicalName() + ";\n" +
-                    "rule R when\n" +
-                    "    Person( class == Child.class )\n" +
-                    "then end";
-            try {
-                createKieBuilder(runType, str);
-            } catch (RuntimeException expected) {
-                // The real constraint compilation still rejects 'class == ...'; that abort is unchanged.
-            }
-            assertThat(appender.list)
-                    .as("a WARN naming the rule and the offending constraint expression must be logged")
-                    .anyMatch(e -> e.getLevel() == Level.WARN
-                            && e.getFormattedMessage().contains("rule 'R'")
-                            && e.getFormattedMessage().contains("Child.class"));
-        } finally {
-            logger.detachAppender(appender);
-        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Fixes: #6784 

Adds exception details when a constraint isn't parseable and returns empty.