### PR TITLE
[CVE] Upgrading Quarkus from 3.27.4 to 3.27.4.1 to address security vulnerability

### DIFF
--- a/kie-quarkus-build-parent/pom.xml
+++ b/kie-quarkus-build-parent/pom.xml
@@ -39,8 +39,8 @@
   </description>
 
   <properties>
-    <version.io.quarkus>3.27.4</version.io.quarkus>
-    <version.io.quarkus.camel>3.27.4</version.io.quarkus.camel>
+    <version.io.quarkus>3.27.4.1</version.io.quarkus>
+    <version.io.quarkus.camel>3.27.4.1</version.io.quarkus.camel>
     <!-- Used to define which poms are allowed to have dependencyManagement sections. This is to enforce the convention that only the root pom should have dependencyManagement, and all other poms should inherit from it. -->
     <allowedPomsList>org.kie:kie-quarkus-build-parent</allowedPomsList>
     <!-- To be overridden by poms with dependency management -->


### PR DESCRIPTION
Upgrading Quarkus from 3.27.4 to 3.27.4.1 to address security vulnerability

**Related PR**

incubator-kie-optaplanner: https://github.com/apache/incubator-kie-optaplanner/pull/3236
incubator-kie-kogito-runtimes: https://github.com/apache/incubator-kie-kogito-runtimes/pull/4328
incubator-kie-tools :https://github.com/apache/incubator-kie-tools/pull/3641
incubator-kie-kogito-examples: https://github.com/apache/incubator-kie-kogito-examples/pull/2222