### PR TITLE
[CVE]Updating  micrometer-core-1.16.4 to 1.16.6 to address security vulnerability

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -144,7 +144,7 @@
     <version.io.fabric8>7.3.1</version.io.fabric8>
     <version.io.fabric8.kubernetes-client>7.3.1</version.io.fabric8.kubernetes-client>
     <version.io.grpc>1.76.0</version.io.grpc>
-    <version.io.micrometer>1.16.4</version.io.micrometer>
+    <version.io.micrometer>1.16.6</version.io.micrometer>
     <version.io.netty>4.1.135.Final</version.io.netty>
     <version.io.opentelemetry>1.0.0-alpha</version.io.opentelemetry>
     <version.io.rest-assured>5.5.6</version.io.rest-assured>


### PR DESCRIPTION

**Upgraded:**
micrometer-core :1.16.4 to 1.16.6 

**CVEs Remediated:**

CVE-2026-40983[HIGH],CVE-2026-40984[HIGH]
