### PR TITLE
NO-ISSUE: upgrade parsson from 1.1.7 to 1.1.8 to remediate CVE

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -169,7 +169,7 @@
     <version.jakarta.annotation-api>3.0.0</version.jakarta.annotation-api>
     <version.jakarta.enterprise.cdi-api>4.1.0</version.jakarta.enterprise.cdi-api>
     <version.jakarta.inject-api>2.0.1</version.jakarta.inject-api>
-    <version.jakarta.json>1.1.7</version.jakarta.json>
+    <version.jakarta.json>1.1.8</version.jakarta.json>
     <version.jakarta.json-api>2.1.3</version.jakarta.json-api>
     <version.jakarta.json.bind-api>3.0.1</version.jakarta.json.bind-api>
     <version.jakarta.persistence-api>3.2.0</version.jakarta.persistence-api>


### PR DESCRIPTION
**Summary**
upgrade parsson from 1.1.7 to 1.1.8 to remediate CVE

Bump version.jakarta.json from 1.1.7 to 1.1.8 in kie-parent/pom.xml.

parsson 1.1.7 is pulled in transitively via:
  quarkus-core → jboss-logmanager-3.2.1.Final → parsson-1.1.7

The inherited dependencyManagement entry in kie-parent takes precedence
over the parsson 1.1.7 pin in quarkus-bom-3.27.4.1, so this single
version bump is sufficient to enforce 1.1.8 across all modules including
Quarkus extension modules.

**CVE Remediated:**
[High] CVE-2026-9563