### PR TITLE
[NO-ISSUE] Update golden files to fix CI check

### DIFF
--- a/script/ci/tests/scenarios-compute-build-scopes/02-hub-module-source/expected-upstream.txt
+++ b/script/ci/tests/scenarios-compute-build-scopes/02-hub-module-source/expected-upstream.txt
@@ -129,8 +129,10 @@ org.optaplanner:optaplanner-persistence-jsonb
 org.optaplanner:optaplanner-quarkus-benchmark-parent
 org.optaplanner:optaplanner-quarkus-integration
 org.optaplanner:optaplanner-quarkus-jackson
+org.optaplanner:optaplanner-quarkus-jackson-deployment
 org.optaplanner:optaplanner-quarkus-jackson-parent
 org.optaplanner:optaplanner-quarkus-jsonb
+org.optaplanner:optaplanner-quarkus-jsonb-deployment
 org.optaplanner:optaplanner-quarkus-jsonb-parent
 org.optaplanner:optaplanner-quarkus-parent
 org.optaplanner:optaplanner-spring-integration

--- a/script/ci/tests/scenarios-compute-build-scopes/05-upstream-downstream-pair/expected-upstream.txt
+++ b/script/ci/tests/scenarios-compute-build-scopes/05-upstream-downstream-pair/expected-upstream.txt
@@ -129,8 +129,10 @@ org.optaplanner:optaplanner-persistence-jsonb
 org.optaplanner:optaplanner-quarkus-benchmark-parent
 org.optaplanner:optaplanner-quarkus-integration
 org.optaplanner:optaplanner-quarkus-jackson
+org.optaplanner:optaplanner-quarkus-jackson-deployment
 org.optaplanner:optaplanner-quarkus-jackson-parent
 org.optaplanner:optaplanner-quarkus-jsonb
+org.optaplanner:optaplanner-quarkus-jsonb-deployment
 org.optaplanner:optaplanner-quarkus-jsonb-parent
 org.optaplanner:optaplanner-quarkus-parent
 org.optaplanner:optaplanner-spring-integration

--- a/script/ci/tests/scenarios-compute-build-scopes/06-aggregator-pom/expected-upstream.txt
+++ b/script/ci/tests/scenarios-compute-build-scopes/06-aggregator-pom/expected-upstream.txt
@@ -139,8 +139,10 @@ org.optaplanner:optaplanner-persistence-jsonb
 org.optaplanner:optaplanner-quarkus-benchmark-parent
 org.optaplanner:optaplanner-quarkus-integration
 org.optaplanner:optaplanner-quarkus-jackson
+org.optaplanner:optaplanner-quarkus-jackson-deployment
 org.optaplanner:optaplanner-quarkus-jackson-parent
 org.optaplanner:optaplanner-quarkus-jsonb
+org.optaplanner:optaplanner-quarkus-jsonb-deployment
 org.optaplanner:optaplanner-quarkus-jsonb-parent
 org.optaplanner:optaplanner-quarkus-parent
 org.optaplanner:optaplanner-spring-integration

--- a/script/ci/tests/scenarios-compute-build-scopes/07-removed-module/expected-upstream.txt
+++ b/script/ci/tests/scenarios-compute-build-scopes/07-removed-module/expected-upstream.txt
@@ -139,8 +139,10 @@ org.optaplanner:optaplanner-persistence-jsonb
 org.optaplanner:optaplanner-quarkus-benchmark-parent
 org.optaplanner:optaplanner-quarkus-integration
 org.optaplanner:optaplanner-quarkus-jackson
+org.optaplanner:optaplanner-quarkus-jackson-deployment
 org.optaplanner:optaplanner-quarkus-jackson-parent
 org.optaplanner:optaplanner-quarkus-jsonb
+org.optaplanner:optaplanner-quarkus-jsonb-deployment
 org.optaplanner:optaplanner-quarkus-jsonb-parent
 org.optaplanner:optaplanner-quarkus-parent
 org.optaplanner:optaplanner-spring-integration

--- a/script/ci/tests/scenarios-compute-build-scopes/08-combined-mixed-changes/expected-upstream.txt
+++ b/script/ci/tests/scenarios-compute-build-scopes/08-combined-mixed-changes/expected-upstream.txt
@@ -127,8 +127,10 @@ org.optaplanner:optaplanner-persistence-jsonb
 org.optaplanner:optaplanner-quarkus-benchmark-parent
 org.optaplanner:optaplanner-quarkus-integration
 org.optaplanner:optaplanner-quarkus-jackson
+org.optaplanner:optaplanner-quarkus-jackson-deployment
 org.optaplanner:optaplanner-quarkus-jackson-parent
 org.optaplanner:optaplanner-quarkus-jsonb
+org.optaplanner:optaplanner-quarkus-jsonb-deployment
 org.optaplanner:optaplanner-quarkus-jsonb-parent
 org.optaplanner:optaplanner-quarkus-parent
 org.optaplanner:optaplanner-spring-integration


### PR DESCRIPTION
The CIComputeBuildScopes update in [this PR](https://github.com/apache/incubator-kie-drools/commit/fa8e05b9bb43558580d41fad29ffa28ac685ba4b#diff-80def67d085c4a147e89006841d4241e214d8643e6d7984e433128a8dd99f19b) now includes a module's -deployment counterpart in the same build set when the extension-descriptor goal resolves it at build time. However, the Optaplanner golden files were not recomputed to reflect this change. This PR regenerates them to match the updated scope computation.

