### PR TITLE
[CVE]Upgrading Quarkus from 3.27.4 to 3.27.4.1

### DIFF
--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -46,7 +46,7 @@
     <version.org.apache.logging.log4j>2.22.1</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.io.quarkiverse.operatorsdk>6.6.7</version.io.quarkiverse.operatorsdk>
-    <version.io.quarkus>3.27.4</version.io.quarkus>
+    <version.io.quarkus>3.27.4.1</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.14.0</version.org.apache.commons.text>
     <version.org.apache.openjpa>4.0.0</version.org.apache.openjpa>


### PR DESCRIPTION
Original PR from Optaplanner: https://github.com/apache/incubator-kie-optaplanner/pull/3236
Wasn't included in the Optaplanner merge PR

Upgrading Quarkus from 3.27.4 to 3.27.4.1 to address security vulnerability

Related PR

incubator-kie-drools: https://github.com/apache/incubator-kie-drools/pull/6793
incubator-kie-kogito-runtimes: https://github.com/apache/incubator-kie-kogito-runtimes/pull/4328
incubator-kie-tools :https://github.com/apache/incubator-kie-tools/pull/3641
incubator-kie-kogito-examples: https://github.com/apache/incubator-kie-kogito-examples/pull/2222