### PR TITLE
[incubator-kie-drools-6758] Register concrete project classloaders as parallel capable

### DIFF
--- a/drools-wiring/drools-wiring-dynamic/src/main/java/org/drools/wiring/dynamic/DynamicProjectClassLoader.java
+++ b/drools-wiring/drools-wiring-dynamic/src/main/java/org/drools/wiring/dynamic/DynamicProjectClassLoader.java
@@ -33,6 +33,13 @@ import org.drools.wiring.api.util.ClassUtils;
 
 public class DynamicProjectClassLoader extends ProjectClassLoader {
 
+    static {
+        // Parallel capability is per-class, not inherited: without this registration the JVM
+        // ignores the base class' one and getClassLoadingLock falls back to locking `this`,
+        // serializing all class loading through this loader (issue #6758).
+        registerAsParallelCapable();
+    }
+
     private static boolean isIBM_JVM = System.getProperty("java.vendor").toLowerCase().contains("ibm");
 
     protected DynamicProjectClassLoader(ClassLoader parent, ResourceProvider resourceProvider) {
@@ -50,6 +57,10 @@ public class DynamicProjectClassLoader extends ProjectClassLoader {
     }
 
     public static class IBMDynamicClassLoader extends DynamicProjectClassLoader {
+
+        static {
+            registerAsParallelCapable();
+        }
 
         private final boolean parentImplementsFindResources;
 

--- a/drools-wiring/drools-wiring-dynamic/src/test/java/org/drools/wiring/dynamic/ParallelCapableClassLoaderTest.java
+++ b/drools-wiring/drools-wiring-dynamic/src/test/java/org/drools/wiring/dynamic/ParallelCapableClassLoaderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.wiring.dynamic;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Parallel capability is per-class, not inherited: the JVM only enables per-name class loading
+ * locks when the loader's concrete runtime class and its whole superclass chain are registered.
+ * Without the subclass registration, getClassLoadingLock falls back to locking the loader itself
+ * and all class loading serializes on one monitor (issue #6758).
+ *
+ * <p>The probe subclass verifies this deterministically: {@link
+ * ClassLoader#registerAsParallelCapable()} returns {@code false} when any ancestor class is not
+ * itself registered, so these assertions fail if the registration is ever removed from the
+ * loaders under test.
+ */
+class ParallelCapableClassLoaderTest {
+
+    @Test
+    void dynamicProjectClassLoaderChainIsParallelCapable() {
+        assertTrue(DynamicProbe.PARALLEL_CAPABLE,
+                "registerAsParallelCapable() in a subclass only succeeds when the whole "
+                        + "DynamicProjectClassLoader ancestry is registered");
+        DynamicProbe probe = new DynamicProbe(getClass().getClassLoader());
+        Object lockA = probe.lockFor("com.example.A");
+        assertNotSame(probe, lockA, "a parallel-capable loader must not lock on itself");
+        assertNotSame(lockA, probe.lockFor("com.example.B"));
+    }
+
+    private static class DynamicProbe extends DynamicProjectClassLoader {
+        private static final boolean PARALLEL_CAPABLE = registerAsParallelCapable();
+
+        private DynamicProbe(ClassLoader parent) {
+            super(parent, null);
+        }
+
+        private Object lockFor(String className) {
+            return getClassLoadingLock(className);
+        }
+    }
+}

--- a/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticProjectClassLoader.java
+++ b/drools-wiring/drools-wiring-static/src/main/java/org/drools/wiring/statics/StaticProjectClassLoader.java
@@ -30,6 +30,13 @@ import org.drools.wiring.api.classloader.ProjectClassLoader;
 
 public class StaticProjectClassLoader extends ProjectClassLoader {
 
+    static {
+        // Parallel capability is per-class, not inherited: without this registration the JVM
+        // ignores the base class' one and getClassLoadingLock falls back to locking `this`,
+        // serializing all class loading through this loader (issue #6758).
+        registerAsParallelCapable();
+    }
+
     private static boolean isIBM_JVM = System.getProperty("java.vendor").toLowerCase().contains("ibm");
 
     protected StaticProjectClassLoader(ClassLoader parent, ResourceProvider resourceProvider) {
@@ -42,6 +49,11 @@ public class StaticProjectClassLoader extends ProjectClassLoader {
     }
 
     public static class IBMStaticClassLoader extends StaticProjectClassLoader {
+
+        static {
+            registerAsParallelCapable();
+        }
+
         private final boolean parentImplementsFindResources;
 
         private static final Enumeration<URL> EMPTY_RESOURCE_ENUM = new Vector<URL>().elements();
@@ -74,6 +86,10 @@ public class StaticProjectClassLoader extends ProjectClassLoader {
     }
 
     private static class DummyInternalTypesClassLoader extends ClassLoader implements InternalTypesClassLoader {
+
+        static {
+            registerAsParallelCapable();
+        }
 
         private final ProjectClassLoader projectClassLoader;
 

--- a/drools-wiring/drools-wiring-static/src/test/java/org/drools/wiring/statics/StaticParallelCapableClassLoaderTest.java
+++ b/drools-wiring/drools-wiring-static/src/test/java/org/drools/wiring/statics/StaticParallelCapableClassLoaderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.wiring.statics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * See ParallelCapableClassLoaderTest in drools-wiring-dynamic: parallel capability is per-class,
+ * so StaticProjectClassLoader needs its own registration despite the base class' one
+ * (issue #6758). registerAsParallelCapable() in the probe returns {@code false} when any
+ * ancestor class is not itself registered.
+ */
+class StaticParallelCapableClassLoaderTest {
+
+    @Test
+    void staticProjectClassLoaderChainIsParallelCapable() {
+        assertThat(StaticProbe.PARALLEL_CAPABLE)
+                .as("registerAsParallelCapable() in a subclass only succeeds when the whole "
+                        + "StaticProjectClassLoader ancestry is registered")
+                .isTrue();
+        StaticProbe probe = new StaticProbe(getClass().getClassLoader());
+        Object lockA = probe.lockFor("com.example.A");
+        assertThat(lockA).as("a parallel-capable loader must not lock on itself").isNotSameAs(probe);
+        assertThat(probe.lockFor("com.example.B")).isNotSameAs(lockA);
+    }
+
+    private static class StaticProbe extends StaticProjectClassLoader {
+        private static final boolean PARALLEL_CAPABLE = registerAsParallelCapable();
+
+        private StaticProbe(ClassLoader parent) {
+            super(parent, null);
+        }
+
+        private Object lockFor(String className) {
+            return getClassLoadingLock(className);
+        }
+    }
+}


### PR DESCRIPTION
**Issue**:

* Closes https://github.com/apache/incubator-kie-drools/issues/6758

**Summary**

Parallel capability is per-class, not inherited: `ProjectClassLoader` calls `registerAsParallelCapable()`, but the JVM checks the loader's **concrete runtime class** (and its whole superclass chain), so the concrete loaders never benefited - `getClassLoadingLock` fell back to locking the loader instance, serializing every class load through one monitor.

Registered all five concrete classes: `DynamicProjectClassLoader`, `IBMDynamicClassLoader`, `StaticProjectClassLoader`, `IBMStaticClassLoader`, and `DummyInternalTypesClassLoader` (the dynamic `DefaultInternalTypesClassLoader` already had it).

Thread-safety audit of what parallel loading newly exposes: the `defineType`/`defineClass`/`undefineClass` paths are already `synchronized`, and the `loadedClasses`/`nonExistingClasses` caches are `ConcurrentHashMap`s - the base class was designed for this; the subclasses just never opted in.

**Testing**

New tests in both wiring modules use a probe subclass: `registerAsParallelCapable()` returns `false` when any ancestor class is not itself registered, so the assertion is deterministic (no timing games) and goes red if a registration is ever removed - verified red against the unfixed loaders, green with the fix. Full `drools-wiring-dynamic` + `drools-wiring-static` test suites pass on JDK 17.

Developed with AI assistance (Claude Code), reviewed and driven by a human.
