### PR TITLE
NO-ISSUE: upgrade micrometer-core from 1.14.7 to 1.16.6 in OptaPlanner modules

### DIFF
--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -136,7 +136,8 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- CVE fix: override micrometer version from quarkus-bom (1.14.7) to 1.16.6 -->
+      <!-- Normal dependencies versions-->
+      <!-- CVE fix: override micrometer version brought in by quarkus-bom 3.27.4 (1.14.7) to 1.16.6 -->
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-core</artifactId>
@@ -152,7 +153,6 @@
         <artifactId>micrometer-observation</artifactId>
         <version>${version.io.micrometer}</version>
       </dependency>
-      <!-- Normal dependencies versions-->
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -55,6 +55,7 @@
     <version.org.freemarker>2.3.34</version.org.freemarker>
     <version.org.jdom2>2.0.6.1</version.org.jdom2>
     <version.org.jfree.jfreechart>1.5.4</version.org.jfree.jfreechart>
+    <version.io.micrometer>1.16.6</version.io.micrometer>
     <version.org.openrewrite.recipe>1.19.3</version.org.openrewrite.recipe>
     <version.org.slf4j>2.0.17</version.org.slf4j><!-- TODO keep in sync with quarkus-bom -->
     <version.org.springframework>7.0.8</version.org.springframework>
@@ -134,6 +135,22 @@
         <version>${version.org.drools}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- CVE fix: override micrometer version from quarkus-bom (1.14.7) to 1.16.6 -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${version.io.micrometer}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-commons</artifactId>
+        <version>${version.io.micrometer}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-observation</artifactId>
+        <version>${version.io.micrometer}</version>
       </dependency>
       <!-- Normal dependencies versions-->
       <dependency>


### PR DESCRIPTION

**Summary**
quarkus-bom 3.27.4 pulls in micrometer-core 1.14.7 which has a known CVE. Added explicit dependencyManagement overrides for micrometer-core, micrometer-commons and micrometer-observation in optaplanner-build-parent to enforce version 1.16.6 across all OptaPlanner modules.




