### PR TITLE
NO-ISSUE: override jackson-databind to 2.22.0 in  optaplanner-build-parent to fix cve

### DIFF
--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -40,6 +40,7 @@
     <!-- ************************************************************************ -->
     <!-- SNAPSHOT and KIE dependency versions -->
     <version.org.drools>${project.version}</version.org.drools>
+    <version.com.fasterxml.jackson.databind>2.22.0</version.com.fasterxml.jackson.databind>
 
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.5.34</version.ch.qos.logback>
@@ -200,6 +201,12 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-persistence</artifactId>
         <version>${version.org.springframework.boot}</version>
+      </dependency>
+      <!-- Override quarkus-bom jackson-databind to ensure 2.22.0 is used -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.com.fasterxml.jackson.databind}</version>
       </dependency>
 
     </dependencies>

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -40,7 +40,6 @@
     <!-- ************************************************************************ -->
     <!-- SNAPSHOT and KIE dependency versions -->
     <version.org.drools>${project.version}</version.org.drools>
-    <version.com.fasterxml.jackson.databind>2.22.0</version.com.fasterxml.jackson.databind>
 
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.5.34</version.ch.qos.logback>
@@ -60,6 +59,7 @@
     <version.org.slf4j>2.0.17</version.org.slf4j><!-- TODO keep in sync with quarkus-bom -->
     <version.org.springframework>7.0.8</version.org.springframework>
     <version.org.springframework.boot>4.0.7</version.org.springframework.boot>
+    <version.com.fasterxml.jackson.databind>2.22.0</version.com.fasterxml.jackson.databind>
 
     <!-- ************************************************************************ -->
     <!-- Plugins -->
@@ -202,7 +202,8 @@
         <artifactId>spring-boot-persistence</artifactId>
         <version>${version.org.springframework.boot}</version>
       </dependency>
-      <!-- Override quarkus-bom jackson-databind to ensure 2.22.0 is used -->
+      <!-- Override quarkus-bom jackson-databind version; transitively imported by
+           optaplanner-persistence-jackson, optaplanner-spring-boot-autoconfigure and optaplanner-quarkus-jackson -->
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
**Summary**
override jackson-databind to 2.22.0 in optaplanner-build-parent to override quarkus-bom
