### PR TITLE
NO-ISSUE Upgrading jackson-databind to 2.22.1 and override jackson-databind to 2.22.1 in optaplanner-build-parent to fix CVE

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -89,7 +89,7 @@
     <version.ch.qos.logback>1.5.35</version.ch.qos.logback>
     <version.com.fasterxml.jackson>2.21.2</version.com.fasterxml.jackson>
     <version.com.fasterxml.jackson.annotations>2.21</version.com.fasterxml.jackson.annotations>
-    <version.com.fasterxml.jackson.databind>2.22.0</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.databind>2.22.1</version.com.fasterxml.jackson.databind>
     <version.com.fasterxml.jackson.datatype>2.21.2</version.com.fasterxml.jackson.datatype>
     <version.com.github.docker-java>3.7.1</version.com.github.docker-java><!-- align with testcontainers ABI; Quarkus BOM pins older docker-java missing ImageHistoryCmd -->
     <version.com.github.eirslett>1.15.1</version.com.github.eirslett>

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -87,10 +87,10 @@
     <version.build.helper.maven.plugin>3.4.0</version.build.helper.maven.plugin>
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
     <version.ch.qos.logback>1.5.35</version.ch.qos.logback>
-    <version.com.fasterxml.jackson>2.21.2</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.annotations>2.21</version.com.fasterxml.jackson.annotations>
+    <version.com.fasterxml.jackson>2.22.1</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.annotations>2.22</version.com.fasterxml.jackson.annotations>
     <version.com.fasterxml.jackson.databind>2.22.1</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson.datatype>2.21.2</version.com.fasterxml.jackson.datatype>
+    <version.com.fasterxml.jackson.datatype>2.22.1</version.com.fasterxml.jackson.datatype>
     <version.com.github.docker-java>3.7.1</version.com.github.docker-java><!-- align with testcontainers ABI; Quarkus BOM pins older docker-java missing ImageHistoryCmd -->
     <version.com.github.eirslett>1.15.1</version.com.github.eirslett>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -59,7 +59,7 @@
     <version.org.slf4j>2.0.17</version.org.slf4j><!-- TODO keep in sync with quarkus-bom -->
     <version.org.springframework>7.0.8</version.org.springframework>
     <version.org.springframework.boot>4.0.7</version.org.springframework.boot>
-    <version.com.fasterxml.jackson.databind>2.22.0</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.databind>2.22.1</version.com.fasterxml.jackson.databind>
     <!-- ************************************************************************ -->
     <!-- Plugins -->
     <!-- ************************************************************************ -->

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -55,6 +55,7 @@
     <version.org.freemarker>2.3.34</version.org.freemarker>
     <version.org.jdom2>2.0.6.1</version.org.jdom2>
     <version.org.jfree.jfreechart>1.5.4</version.org.jfree.jfreechart>
+    <version.io.micrometer>1.16.6</version.io.micrometer>
     <version.org.openrewrite.recipe>1.19.3</version.org.openrewrite.recipe>
     <version.org.slf4j>2.0.17</version.org.slf4j><!-- TODO keep in sync with quarkus-bom -->
     <version.org.springframework>7.0.8</version.org.springframework>
@@ -136,6 +137,22 @@
         <scope>import</scope>
       </dependency>
       <!-- Normal dependencies versions-->
+      <!-- CVE fix: override micrometer version brought in by quarkus-bom 3.27.4 (1.14.7) to 1.16.6 -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${version.io.micrometer}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-commons</artifactId>
+        <version>${version.io.micrometer}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-observation</artifactId>
+        <version>${version.io.micrometer}</version>
+      </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
@@ -201,13 +218,7 @@
         <artifactId>spring-boot-persistence</artifactId>
         <version>${version.org.springframework.boot}</version>
       </dependency>
- <!-- Override quarkus-bom jackson-databind version; transitively imported by
-           optaplanner-persistence-jackson, optaplanner-spring-boot-autoconfigure and optaplanner-quarkus-jackson -->
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${version.com.fasterxml.jackson.databind}</version>
-      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -55,7 +55,6 @@
     <version.org.freemarker>2.3.34</version.org.freemarker>
     <version.org.jdom2>2.0.6.1</version.org.jdom2>
     <version.org.jfree.jfreechart>1.5.4</version.org.jfree.jfreechart>
-    <version.io.micrometer>1.16.6</version.io.micrometer>
     <version.org.openrewrite.recipe>1.19.3</version.org.openrewrite.recipe>
     <version.org.slf4j>2.0.17</version.org.slf4j><!-- TODO keep in sync with quarkus-bom -->
     <version.org.springframework>7.0.8</version.org.springframework>
@@ -137,22 +136,6 @@
         <scope>import</scope>
       </dependency>
       <!-- Normal dependencies versions-->
-      <!-- CVE fix: override micrometer version brought in by quarkus-bom 3.27.4 (1.14.7) to 1.16.6 -->
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-core</artifactId>
-        <version>${version.io.micrometer}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-commons</artifactId>
-        <version>${version.io.micrometer}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-observation</artifactId>
-        <version>${version.io.micrometer}</version>
-      </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
@@ -218,7 +201,13 @@
         <artifactId>spring-boot-persistence</artifactId>
         <version>${version.org.springframework.boot}</version>
       </dependency>
-
+ <!-- Override quarkus-bom jackson-databind version; transitively imported by
+           optaplanner-persistence-jackson, optaplanner-spring-boot-autoconfigure and optaplanner-quarkus-jackson -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.com.fasterxml.jackson.databind}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -59,7 +59,7 @@
     <version.org.slf4j>2.0.17</version.org.slf4j><!-- TODO keep in sync with quarkus-bom -->
     <version.org.springframework>7.0.8</version.org.springframework>
     <version.org.springframework.boot>4.0.7</version.org.springframework.boot>
-
+    <version.com.fasterxml.jackson.databind>2.22.0</version.com.fasterxml.jackson.databind>
     <!-- ************************************************************************ -->
     <!-- Plugins -->
     <!-- ************************************************************************ -->
@@ -201,7 +201,13 @@
         <artifactId>spring-boot-persistence</artifactId>
         <version>${version.org.springframework.boot}</version>
       </dependency>
-
+ <!-- Override quarkus-bom jackson-databind version; transitively imported by
+           optaplanner-persistence-jackson, optaplanner-spring-boot-autoconfigure and optaplanner-quarkus-jackson -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.com.fasterxml.jackson.databind}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION


Upgrading jackson-databind to 2.22.1 and override jackson-databind to 2.22.0 in optaplanner-build-parent to fix CVE
