### PR TITLE
"CI :: Build" job fails in KJarLoadingTest because of missing kjar build

### DIFF
--- a/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
@@ -122,6 +122,27 @@
     </testResources>
 
     <plugins>
+      <!-- The tests load test-kjar at runtime from the local Maven repo via kie-ci.
+           Always ensure it is installed before tests run. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build-test-kjar</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <pom>${basedir}/../test-kjar/pom.xml</pom>
+              <goals>
+                <goal>install</goal>
+              </goals>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
@@ -117,6 +117,40 @@
     </testResources>
 
     <plugins>
+      <!-- The tests load test-kjar (and its test-domain dep) at runtime from the
+           local Maven repo via kie-ci. Always ensure they are installed before tests run. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build-test-domain</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <pom>${basedir}/../test-domain/pom.xml</pom>
+              <goals>
+                <goal>install</goal>
+              </goals>
+            </configuration>
+          </execution>
+          <execution>
+            <id>build-test-kjar</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <pom>${basedir}/../test-kjar/pom.xml</pom>
+              <goals>
+                <goal>install</goal>
+              </goals>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-drools/issues/6819

The fix is to simply build the kjar project using `maven-invoker-plugin`. 