### PR TITLE
NO-ISSUE: upgrade Netty to 4.1.136.Final to fix 11 Dependabot CVEs

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -146,7 +146,6 @@
     <version.io.grpc>1.76.0</version.io.grpc>
     <version.io.micrometer>1.16.6</version.io.micrometer>
     <version.io.netty>4.1.136.Final</version.io.netty>
-    <version.io.netty.codec-compression>4.2.13.Final</version.io.netty.codec-compression>
     <version.io.opentelemetry>1.0.0-alpha</version.io.opentelemetry>
     <version.io.rest-assured>5.5.6</version.io.rest-assured>
     <version.io.smallrye-config>3.13.4</version.io.smallrye-config>
@@ -825,11 +824,11 @@
         <artifactId>netty-codec</artifactId>
         <version>${version.io.netty}</version>
       </dependency>
-      <!-- Netty codec-compression - explicitly managed to fix CVE (CVE-2026-42583) -->
+      <!-- Netty codec-compression - explicitly managed to fix CVE -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-compression</artifactId>
-        <version>${version.io.netty.codec-compression}</version>
+        <version>${version.io.netty}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -145,7 +145,8 @@
     <version.io.fabric8.kubernetes-client>7.3.1</version.io.fabric8.kubernetes-client>
     <version.io.grpc>1.76.0</version.io.grpc>
     <version.io.micrometer>1.16.6</version.io.micrometer>
-    <version.io.netty>4.1.135.Final</version.io.netty>
+    <version.io.netty>4.1.136.Final</version.io.netty>
+    <version.io.netty.codec-compression>4.2.13.Final</version.io.netty.codec-compression>
     <version.io.opentelemetry>1.0.0-alpha</version.io.opentelemetry>
     <version.io.rest-assured>5.5.6</version.io.rest-assured>
     <version.io.smallrye-config>3.13.4</version.io.smallrye-config>
@@ -824,11 +825,11 @@
         <artifactId>netty-codec</artifactId>
         <version>${version.io.netty}</version>
       </dependency>
-      <!-- Netty codec-compression - explicitly managed to fix CVE -->
+      <!-- Netty codec-compression - explicitly managed to fix CVE (CVE-2026-42583) -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-compression</artifactId>
-        <version>${version.io.netty}</version>
+        <version>${version.io.netty.codec-compression}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
## Security Fix — Netty Dependency Upgrades

### Summary
Upgrades `version.io.netty` in `kie-parent/pom.xml` from `4.1.135.Final` to `4.1.136.Final` to resolve **11 open Dependabot security alerts**.

> 📋 **Draft PR** — pending full CI test suite run before marking ready.

---

### Changes Made

| File | Property | Old Version | New Version |
|---|---|---|---|
| `kie-parent/pom.xml` | `version.io.netty` | `4.1.135.Final` | `4.1.136.Final` |

All Netty modules including `netty-codec-compression` use the single shared `${version.io.netty}` property.

---

### Alerts Fixed (11 Dependabot alerts)

#### High Severity (5)
| Alert | Package | CVE | Description |
|---|---|---|---|
| #7 | netty-handler-ssl-ocsp | CVE-2026-56820 | Missing CertificateID Validation — Replay Attacks |
| #8 | netty-handler-ssl-ocsp | CVE-2026-56821 | Out-of-date OCSP Responses Accepted |
| #9 | netty-handler-ssl-ocsp | CVE-2026-56822 | TOCTOU in OcspServerCertificateValidator |
| #13 | netty-codec | CVE-2026-59901 | Infinite Loop in Bzip2Decoder — Thread Hang |
| #2 | netty-codec-compression | CVE-2026-42583 | Lz4FrameDecoder Resource Exhaustion |

#### Medium Severity (6)
| Alert | Package | CVE | Description |
|---|---|---|---|
| #6 | netty-codec-http | CVE-2026-56746 | CORS Short-Circuit Security Bypass |
| #10 | netty-codec-http | CVE-2026-59898 | WebSockets V07/V08 Handshaker Validation |
| #11 | netty-codec-http | CVE-2026-59899 | Unbounded Queue Growth — DoS via Pipelining |
| #16 | netty-codec-http | CVE-2026-59921 | CRLF Injection via Multipart Filename |
| #12 | netty-codec-http2 | CVE-2026-59900 | Host Header Deduplication — Routing Bypass |
| #14 | netty-codec-haproxy | CVE-2026-59919 | HAProxy V1 CRLF Injection via AF_UNIX |
| #15 | netty-codec-stomp | CVE-2026-59920 | STOMP CONNECT Frame Header Injection |

---

### Local Verification
- `mvn validate -pl kie-parent` → **BUILD SUCCESS**
- Maven enforcer rules passed:
  - `NoExternalManagedDependencyRule` ✅
  - `RequireMavenVersion` ✅
  - `RequireJavaVersion` ✅

---

### Remaining Alerts (not in this PR)
- Jetty alerts (#17, #18, #19, #20) — separate PR
- Keycloak (#1, CVE-2024-4028) — no patch available yet

---
*Draft PR created by dependabot-autofix skill from fork `AnnJoy23/incubator-kie-drools`*