### PR TITLE
[incubator-kie-issues-2382] Migrate StandaloneBPMNProcessTest methods from v7 legacy runtime to code generation

### DIFF
--- a/kogito-jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
+++ b/kogito-jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
@@ -453,36 +453,26 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
     }
 
     @Test
-    public void testEventBasedSplit5() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/intermediate/BPMN2-EventBasedSplit5.bpmn2");
-
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
-        ReceiveTaskHandler receiveTaskHandler = new ReceiveTaskHandler();
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Receive Task", receiveTaskHandler);
+    public void testEventBasedSplit5() {
+        Application app = ProcessTestHelper.newApplication();
+        ProcessTestHelper.registerHandler(app, "Email1", new SystemOutWorkItemHandler());
+        ProcessTestHelper.registerHandler(app, "Email2", new SystemOutWorkItemHandler());
+        ProcessTestHelper.registerHandler(app, "Receive Task", new ReceiveTaskHandler());
+        org.kie.kogito.process.Process<org.jbpm.bpmn2.intermediate.EventBasedSplit5Model> processDefinition =
+                org.jbpm.bpmn2.intermediate.EventBasedSplit5Process.newProcess(app);
         // Yes
-        KogitoProcessInstance processInstance = kruntime.startProcess("EventBasedSplit5");
-        assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Receive Task", receiveTaskHandler);
-
-        receiveTaskHandler.getWorkItemId().stream().findFirst().ifPresent(id -> kruntime.getKogitoWorkItemManager().completeWorkItem(id, Map.of("Message", "YesValue")));
-
-        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
-
-        receiveTaskHandler.getWorkItemId().forEach(id -> kruntime.getKogitoWorkItemManager().completeWorkItem(id, Map.of("Message", "NoValue")));
-
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Receive Task", receiveTaskHandler);
+        ProcessInstance<org.jbpm.bpmn2.intermediate.EventBasedSplit5Model> processInstance =
+                processDefinition.createInstance(processDefinition.createModel());
+        processInstance.start();
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
+        ProcessTestHelper.completeWorkItem(processInstance, Map.of("Message", "YesValue"));
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
         // No
-        processInstance = kruntime.startProcess("EventBasedSplit5");
-        receiveTaskHandler.getWorkItemId().stream().findFirst().ifPresent(id -> kruntime.getKogitoWorkItemManager().completeWorkItem(id, Map.of("Message", "NoValue")));
-
-        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
-
-        receiveTaskHandler.getWorkItemId().stream().findFirst().ifPresent(id -> kruntime.getKogitoWorkItemManager().completeWorkItem(id, Map.of("Message", "YesValue")));
+        processInstance = processDefinition.createInstance(processDefinition.createModel());
+        processInstance.start();
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
+        ProcessTestHelper.completeWorkItem(processInstance, Map.of("Message", "NoValue"));
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
     }
 
     @Test

--- a/kogito-jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
+++ b/kogito-jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
@@ -461,18 +461,29 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         org.kie.kogito.process.Process<org.jbpm.bpmn2.intermediate.EventBasedSplit5Model> processDefinition =
                 org.jbpm.bpmn2.intermediate.EventBasedSplit5Process.newProcess(app);
         // Yes
-        ProcessInstance<org.jbpm.bpmn2.intermediate.EventBasedSplit5Model> processInstance =
+        ProcessInstance<org.jbpm.bpmn2.intermediate.EventBasedSplit5Model> yesInstance =
                 processDefinition.createInstance(processDefinition.createModel());
-        processInstance.start();
-        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
-        ProcessTestHelper.completeWorkItem(processInstance, Map.of("Message", "YesValue"));
-        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
+        yesInstance.start();
+        assertThat(yesInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
+        assertThat(yesInstance.variables().getX()).isNull();
+        yesInstance.workItems().stream()
+                .filter(wi -> "Yes".equals(wi.getName()))
+                .findFirst()
+                .ifPresent(wi -> yesInstance.completeWorkItem(wi.getId(), Map.of("Message", "YesValue")));
+        assertThat(yesInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
+        assertThat(yesInstance.variables().getX()).isEqualTo("YesValue");
         // No
-        processInstance = processDefinition.createInstance(processDefinition.createModel());
-        processInstance.start();
-        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
-        ProcessTestHelper.completeWorkItem(processInstance, Map.of("Message", "NoValue"));
-        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
+        ProcessInstance<org.jbpm.bpmn2.intermediate.EventBasedSplit5Model> noInstance =
+                processDefinition.createInstance(processDefinition.createModel());
+        noInstance.start();
+        assertThat(noInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
+        assertThat(noInstance.variables().getX()).isNull();
+        noInstance.workItems().stream()
+                .filter(wi -> "No".equals(wi.getName()))
+                .findFirst()
+                .ifPresent(wi -> noInstance.completeWorkItem(wi.getId(), Map.of("Message", "NoValue")));
+        assertThat(noInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
+        assertThat(noInstance.variables().getX()).isEqualTo("NoValue");
     }
 
     @Test


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-issues/issues/2383

Migrated testEventBasedSplit5 in StandaloneBPMNProcessTest from the legacy v7 runtime-based API to the v9 code generation approach.

The test can be identified by referring to StandaloneBPMNProcessTest.java:
https://github.com/apache/incubator-kie-kogito-runtimes/blob/main/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java

## Tests Migrated

**testEventBasedSplit5()** - Line 455
- Migrates EventBasedGateway routing behaviour validation
- Converts from v7 createKogitoProcessRuntime() to v9 generated classes
- Uses EventBasedSplit5Process and EventBasedSplit5Model from org.jbpm.bpmn2.intermediate
- Tests two scenarios — "Yes" path and "No" path — through an EventBasedGateway with two competing ReceiveTask nodes
- Validates that the process completes after the first matching receive task is completed with the correct message data

## Migration Changes
- Replaced createKogitoProcessRuntime() with generated process class EventBasedSplit5Process.newProcess(app)
- Used ProcessTestHelper for application and handler registration — handlers registered once instead of being re-registered repeatedly (v7 quirk)
- Replaced receiveTaskHandler.getWorkItemId().stream().findFirst().ifPresent(...) with ProcessTestHelper.completeWorkItem(processInstance, Map.of(...)) — no need to track work item IDs externally
- Replaced assertProcessInstanceCompleted(id, kruntime) with direct processInstance.status() check
- Removed cleanup of cancelled receive task work items — v9 engine automatically cancels the other branch when one completes
- Updated state constants from KogitoProcessInstance.STATE_* to ProcessInstance.STATE_*

## BPMN Files
- `BPMN2-EventBasedSplit5.bpmn2` 