### PR TITLE
[incubator-kie#7060] Process stays STATE_ACTIVE after interrupting escalation boundary event cancels a work item node

### DIFF
--- a/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcessFactory.java
+++ b/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcessFactory.java
@@ -65,6 +65,7 @@ import static org.jbpm.ruleflow.core.Metadata.ATTACHED_TO;
 import static org.jbpm.ruleflow.core.Metadata.CANCEL_ACTIVITY;
 import static org.jbpm.ruleflow.core.Metadata.ERROR_EVENT;
 import static org.jbpm.ruleflow.core.Metadata.ERROR_STRUCTURE_REF;
+import static org.jbpm.ruleflow.core.Metadata.EVENT_TYPE_ESCALATION;
 import static org.jbpm.ruleflow.core.Metadata.HAS_ERROR_EVENT;
 import static org.jbpm.ruleflow.core.Metadata.SIGNAL_NAME;
 import static org.jbpm.ruleflow.core.Metadata.TIME_CYCLE;
@@ -308,6 +309,8 @@ public class RuleFlowProcessFactory extends RuleFlowNodeContainerFactory<RuleFlo
                             linkBoundarySignalEvent(node, attachedTo);
                         } else if (type.startsWith(ERROR_TYPE_PREFIX)) {
                             linkBoundaryErrorEvent(node, attachedTo, attachedNode);
+                        } else if (type.startsWith(EVENT_TYPE_ESCALATION)) {
+                            linkBoundaryEscalationEvent(node, attachedTo);
                         }
                     }
                 }
@@ -367,6 +370,20 @@ public class RuleFlowProcessFactory extends RuleFlowNodeContainerFactory<RuleFlo
     }
 
     protected void linkBoundarySignalEvent(Node node, String attachedTo) {
+        boolean cancelActivity = (Boolean) node.getMetaData().get(CANCEL_ACTIVITY);
+        if (cancelActivity) {
+            List<DroolsAction> actions = ((EventNode) node).getActions(EVENT_NODE_EXIT);
+            if (actions == null) {
+                actions = new ArrayList<>();
+            }
+            DroolsConsequenceAction action = new DroolsConsequenceAction("java", null);
+            action.setMetaData(ACTION, new CancelNodeInstanceAction(attachedTo));
+            actions.add(action);
+            ((EventNode) node).setActions(EVENT_NODE_EXIT, actions);
+        }
+    }
+
+    protected void linkBoundaryEscalationEvent(Node node, String attachedTo) {
         boolean cancelActivity = (Boolean) node.getMetaData().get(CANCEL_ACTIVITY);
         if (cancelActivity) {
             List<DroolsAction> actions = ((EventNode) node).getActions(EVENT_NODE_EXIT);

--- a/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/NodeInstanceContainer.java
+++ b/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/NodeInstanceContainer.java
@@ -51,6 +51,9 @@ public interface NodeInstanceContainer extends KogitoNodeInstanceContainer {
 
     void nodeInstanceCompleted(NodeInstance nodeInstance, String outType);
 
+    default void nodeInstanceCancelled(NodeInstance nodeInstance) {
+    }
+
     int getState();
 
     void setState(int state);

--- a/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
+++ b/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
@@ -209,6 +209,7 @@ public abstract class NodeInstanceImpl implements org.jbpm.workflow.instance.Nod
                     .getProcessEventSupport().fireBeforeNodeLeft(this, kruntime);
         }
         nodeInstanceContainer.removeNodeInstance(this);
+        nodeInstanceContainer.nodeInstanceCancelled(this);
         if (!hidden) {
             InternalKnowledgeRuntime kruntime = getProcessInstance().getKnowledgeRuntime();
             ((InternalProcessRuntime) kruntime.getProcessRuntime())

--- a/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -1112,6 +1112,13 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl im
     }
 
     @Override
+    public void nodeInstanceCancelled(NodeInstance nodeInstance) {
+        if (((org.jbpm.workflow.core.WorkflowProcess) getProcess()).isAutoComplete() && canComplete()) {
+            setState(KogitoProcessInstance.STATE_COMPLETED);
+        }
+    }
+
+    @Override
     public void nodeInstanceCompleted(NodeInstance nodeInstance, String outType) {
         org.kie.api.definition.process.Node nodeInstanceNode = nodeInstance.getNode();
         if (nodeInstanceNode != null) {
@@ -1124,7 +1131,8 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl im
         if (nodeInstance instanceof FaultNodeInstance || nodeInstance instanceof EndNodeInstance ||
                 ((org.jbpm.workflow.core.WorkflowProcess) getWorkflowProcess()).isDynamic()
                 || nodeInstance instanceof CompositeNodeInstance) {
-            if (((org.jbpm.workflow.core.WorkflowProcess) getProcess()).isAutoComplete() && canComplete()) {
+            if (canComplete() && (nodeInstance instanceof FaultNodeInstance || nodeInstance instanceof EndNodeInstance
+                    || ((org.jbpm.workflow.core.WorkflowProcess) getProcess()).isAutoComplete())) {
                 setState(KogitoProcessInstance.STATE_COMPLETED);
             }
         } else {

--- a/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
+++ b/kogito-jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
@@ -419,6 +419,13 @@ public class CompositeNodeInstance extends StateBasedNodeInstance implements Nod
     }
 
     @Override
+    public void nodeInstanceCancelled(NodeInstance nodeInstance) {
+        if (getCompositeNode().isAutoComplete() && nodeInstances.isEmpty()) {
+            triggerCompleted(Node.CONNECTION_DEFAULT_TYPE);
+        }
+    }
+
+    @Override
     public void nodeInstanceCompleted(NodeInstance nodeInstance, String outType) {
         org.kie.api.definition.process.Node nodeInstanceNode = nodeInstance.getNode();
         if (nodeInstanceNode != null) {


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie/issues/7060 

## Root Cause

RuleFlowProcessFactory.linkBoundaryEvents() handled Timer, Signal, and Error boundary events but did not handle Escalation boundary events. As a result, the CancelNodeInstanceAction was never registered, so the subprocess was not cancelled when the escalation event was triggered.
nodeInstanceCompleted() depended on isAutoComplete() to complete the process. Since standard BPMN processes have autoComplete=false by default, reaching the end node after the escalation path did not complete the process.

## Fix

Added linkBoundaryEscalationEvent() in RuleFlowProcessFactory to register the cancellation action for interrupting Escalation Boundary Events.
Updated nodeInstanceCompleted() to complete the process when an EndNodeInstance or FaultNodeInstance finishes and canComplete() returns true, without requiring isAutoComplete().
Added a nodeInstanceCancelled() callback in NodeInstanceContainer to re-evaluate process completion when a child node is cancelled.