### PR TITLE
[NO-ISSUE] Fix for -Dquickly build

### DIFF
--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -969,6 +969,7 @@
         <skipITs>true</skipITs>
         <formatter.skip>true</formatter.skip>
         <animal.sniffer.skip>true</animal.sniffer.skip>
+        <exec.skip>true</exec.skip>
       </properties>
     </profile>
 


### PR DESCRIPTION
Currently `mvn clean install -Dquickly` fails with
```
[INFO] --- exec:3.1.0:java (default) @ optaplanner-benchmark ---
[WARNING] 
java.lang.IllegalArgumentException: The file (/home/tkobayas/usr/work/readme-review/drools/optaplanner-benchmark/target/classes/solver.xsd) does not exist.
    at org.optaplanner.benchmark.impl.xsd.XsdAggregator.checkFileExists (XsdAggregator.java:86)
    at org.optaplanner.benchmark.impl.xsd.XsdAggregator.main (XsdAggregator.java:72)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run (ExecJavaMojo.java:279)
    at java.lang.Thread.run (Thread.java:840)
```

With the fix, I confirmed that `mvn clean install -Dquickly` builds all modules.