### PR TITLE
[NO-ISSUE]: upgrade log4j-api to 2.26.1 in  to address  cve

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -223,6 +223,11 @@
     <version.org.apache.groovy>4.0.29</version.org.apache.groovy>
     <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.kafka>4.1.2</version.org.apache.kafka>
+    <!-- CVE-2026-49844: poi-ooxml:5.4.1 pulls log4j-api:2.24.3 transitively via log4j-bom:2.24.3.
+         quarkus-bom:3.27.4.1 promotes it to 2.25.1. Both are below the minimum safe version 2.25.5.
+         This managed entry forces 2.26.1 across all modules inheriting kie-parent.
+         https://logging.apache.org/security.html#CVE-2026-49844 -->
+    <version.org.apache.logging.log4j>2.26.1</version.org.apache.logging.log4j>
     <version.org.apache.maven>3.9.11</version.org.apache.maven>
     <version.org.apache.maven.resolver>1.7.3</version.org.apache.maven.resolver>
     <version.org.apache.maven.wagon>3.5.3</version.org.apache.maven.wagon>
@@ -1336,6 +1341,14 @@
             <artifactId>lz4-java</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <!-- CVE-2026-49844: override log4j-api version pulled in transitively by poi-ooxml:5.4.1
+             (via log4j-bom:2.24.3) and promoted by quarkus-bom:3.27.4.1 (to 2.25.1).
+             Both are vulnerable; this pins the version to 2.26.1 for all inheriting modules. -->
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${version.org.apache.logging.log4j}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>

--- a/kogito-springboot/bom/pom.xml
+++ b/kogito-springboot/bom/pom.xml
@@ -48,9 +48,32 @@
          2025.1.1 specifically targets Spring Boot 4.0.1+. -->
     <!-- https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2025.1-Release-Notes -->
     <version.org.springframework.cloud>2025.1.1</version.org.springframework.cloud>
+    <!-- CVE-2026-49844: override log4j2.version used by spring-boot-dependencies BOM (log4j-bom import).
+         Spring Boot 4.0.7 sets log4j2.version=2.25.4 which is vulnerable; upgrade to 2.26.1 (minimum 2.25.5).
+         https://logging.apache.org/security.html#CVE-2026-49844 -->
+    <log4j2.version>2.26.1</log4j2.version>
   </properties>
   <dependencyManagement>
     <dependencies>
+      <!-- CVE-2026-49844: Explicit log4j version overrides BEFORE spring-boot-dependencies and spring-cloud-dependencies
+           imports. Maven's first-declaration-wins rule means these entries take precedence over the hardcoded
+           log4j-api/log4j-to-slf4j/log4j-jul:2.25.4 versions inside spring-boot-dependencies-4.0.7.pom.
+           https://logging.apache.org/security.html#CVE-2026-49844 -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-to-slf4j</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-jul</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>

--- a/kogito-springboot/bom/pom.xml
+++ b/kogito-springboot/bom/pom.xml
@@ -48,32 +48,13 @@
          2025.1.1 specifically targets Spring Boot 4.0.1+. -->
     <!-- https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2025.1-Release-Notes -->
     <version.org.springframework.cloud>2025.1.1</version.org.springframework.cloud>
-    <!-- CVE-2026-49844: override log4j2.version used by spring-boot-dependencies BOM (log4j-bom import).
-         Spring Boot 4.0.7 sets log4j2.version=2.25.4 which is vulnerable; upgrade to 2.26.1 (minimum 2.25.5).
+    <!-- CVE-2026-49844: Spring Boot 4.0.7 sets log4j2.version=2.25.4 which is vulnerable.
+         Override the version property inherited from kie-parent to 2.26.1 (minimum 2.25.5).
          https://logging.apache.org/security.html#CVE-2026-49844 -->
-    <log4j2.version>2.26.1</log4j2.version>
+    <version.org.apache.logging.log4j>2.26.1</version.org.apache.logging.log4j>
   </properties>
   <dependencyManagement>
     <dependencies>
-      <!-- CVE-2026-49844: Explicit log4j version overrides BEFORE spring-boot-dependencies and spring-cloud-dependencies
-           imports. Maven's first-declaration-wins rule means these entries take precedence over the hardcoded
-           log4j-api/log4j-to-slf4j/log4j-jul:2.25.4 versions inside spring-boot-dependencies-4.0.7.pom.
-           https://logging.apache.org/security.html#CVE-2026-49844 -->
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${log4j2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-to-slf4j</artifactId>
-        <version>${log4j2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-jul</artifactId>
-        <version>${log4j2.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -43,7 +43,10 @@
 
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.5.35</version.ch.qos.logback>
-    <version.org.apache.logging.log4j>2.22.1</version.org.apache.logging.log4j>
+    <!-- CVE-2026-49844: log4j-api versions below 2.25.5 are vulnerable. Upgrade log4j to 2.26.1.
+         This covers log4j-to-slf4j (explicitly managed) and log4j-api (promoted by quarkus-bom to 2.25.1).
+         https://logging.apache.org/security.html#CVE-2026-49844 -->
+    <version.org.apache.logging.log4j>2.26.1</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.io.quarkiverse.operatorsdk>6.6.7</version.io.quarkiverse.operatorsdk>
     <version.io.quarkus>3.27.4.1</version.io.quarkus>
@@ -163,6 +166,11 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${version.ch.qos.logback}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${version.org.apache.logging.log4j}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
upgrade log4j-api to 2.26.1 in  to address  cve