### PR TITLE
NO-ISSUE:Upgrade Quarkus from 3.27.4.1 to  3.27.5.1 , Netty 4.2.15.Final to 4.2.16.final, Vertx 4.5.27 to 4.5.31

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -156,12 +156,12 @@
     <version.io.smallrye.mutiny>2.9.5</version.io.smallrye.mutiny>
     <version.io.smallrye.openapi.core>4.0.12</version.io.smallrye.openapi.core>
     <version.io.smallrye.reactive.messaging.in.memory>4.28.0</version.io.smallrye.reactive.messaging.in.memory>
-    <version.io.smallrye.reactive.mutiny-vertx-web-client>3.21.3</version.io.smallrye.reactive.mutiny-vertx-web-client>
+    <version.io.smallrye.reactive.mutiny-vertx-web-client>3.21.6</version.io.smallrye.reactive.mutiny-vertx-web-client>
     <!-- Mutiny Zero Flow Adapters -->
     <version.io.smallrye.reactive.mutiny-zero>1.1.1</version.io.smallrye.reactive.mutiny-zero>
     <version.io.swagger.core.v3>2.2.38</version.io.swagger.core.v3>
     <version.io.swagger.parser.v3>2.1.34</version.io.swagger.parser.v3>
-    <version.io.vertx>4.5.27</version.io.vertx>
+    <version.io.vertx>4.5.31</version.io.vertx>
     <version.it.unimi.dsi.fastutil>8.5.11</version.it.unimi.dsi.fastutil>
     <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
     <version.jakarta.activation>2.0.3</version.jakarta.activation>

--- a/kie-quarkus-build-parent/pom.xml
+++ b/kie-quarkus-build-parent/pom.xml
@@ -39,8 +39,8 @@
   </description>
 
   <properties>
-    <version.io.quarkus>3.27.4.1</version.io.quarkus>
-    <version.io.quarkus.camel>3.27.4.1</version.io.quarkus.camel>
+    <version.io.quarkus>3.27.5.1</version.io.quarkus>
+    <version.io.quarkus.camel>3.27.5.1</version.io.quarkus.camel>
     <!-- Used to define which poms are allowed to have dependencyManagement sections. This is to enforce the convention that only the root pom should have dependencyManagement, and all other poms should inherit from it. -->
     <allowedPomsList>org.kie:kie-quarkus-build-parent</allowedPomsList>
     <!-- To be overridden by poms with dependency management -->

--- a/kogito-quarkus/bom/pom.xml
+++ b/kogito-quarkus/bom/pom.xml
@@ -31,14 +31,14 @@
     <!-- Used to define which poms are allowed to have dependencyManagement sections. This is to enforce the convention that only the root pom should have dependencyManagement, and all other poms should inherit from it. -->
     <allowedPomsList>org.kie.kogito:kogito-quarkus-bom</allowedPomsList>
     <quarkus.logging.manager>org.jboss.logmanager.LogManager</quarkus.logging.manager>
-    <version.io.quarkus>3.27.4.1</version.io.quarkus>
+    <version.io.quarkus>3.27.5.1</version.io.quarkus>
     <version.io.quarkus.quarkus-test>${version.io.quarkus}</version.io.quarkus.quarkus-test>
     <version.io.quarkiverse.jackson-jq>2.4.0</version.io.quarkiverse.jackson-jq>
     <version.io.quarkiverse.openapi.generator>2.16.0-lts</version.io.quarkiverse.openapi.generator>
     <version.io.quarkiverse.asyncapi>1.0.5</version.io.quarkiverse.asyncapi>
     <version.io.quarkiverse.reactivemessaging.http>2.5.0-lts</version.io.quarkiverse.reactivemessaging.http>
     <version.io.quarkiverse.embedded.postgresql>0.8.0</version.io.quarkiverse.embedded.postgresql>
-    <version.io.quarkus.camel>3.27.4.1</version.io.quarkus.camel>
+    <version.io.quarkus.camel>3.27.5.1</version.io.quarkus.camel>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kogito-springboot/bom/pom.xml
+++ b/kogito-springboot/bom/pom.xml
@@ -36,7 +36,7 @@
     <allowedPomsList>org.kie.kogito:kogito-spring-boot-bom</allowedPomsList>
     <!-- Aligned with Spring Boot Cloud (spring-cloud-kubernetes-fabric8 5.0.1 declares fabric8 7.4.0) -->
     <version.io.fabric8>7.4.0</version.io.fabric8>
-    <version.io.netty>4.2.15.Final</version.io.netty>
+    <version.io.netty>4.2.16.Final</version.io.netty>
     <version.jakarta.servlet>6.0.0</version.jakarta.servlet>
     <!-- This is needed to override the default version inherited from kie-parent-drools -->
     <version.mongodb-driver-sync>5.6.4</version.mongodb-driver-sync>

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -46,7 +46,7 @@
     <version.org.apache.logging.log4j>2.22.1</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.io.quarkiverse.operatorsdk>6.6.7</version.io.quarkiverse.operatorsdk>
-    <version.io.quarkus>3.27.4.1</version.io.quarkus>
+    <version.io.quarkus>3.27.5.1</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.14.0</version.org.apache.commons.text>
     <version.org.apache.openjpa>4.0.0</version.org.apache.openjpa>


### PR DESCRIPTION
## Summary

Upgrades Quarkus from `3.27.4.1` → `3.27.5.1` across all affected modules to remediate two CVEs.

## Fix Strategy

- **CVE-2026-55831 (netty 4.1.x):** Quarkus 3.27.5.1 BOM pins `io.netty:netty-codec-http:4.1.136.Final` — resolves automatically via upgrade.
- **CVE-2026-55831 (netty 4.2.x):** Direct property `version.io.netty` bumped `4.2.15.Final` → `4.2.16.Final` in `springboot/bom/pom.xml` (Spring Boot path, independent of Quarkus BOM).
- **CVE-2026-55831 (vertx):** Quarkus 3.27.5.1 upgrades `vertx-core` from `4.5.27` → `4.5.31`.
- **CVE-2026-8484 (jansi):** Quarkus 3.27.5 upgraded `readline` from `2.6` → `2.6.3`, which replaces the unmaintained `org.fusesource.jansi:jansi:2.4.0` with the maintained `org.jline:jansi:4.2.1`. No separate exclusion needed.

## Verification

Confirmed via `quarkus-bom 3.27.5.1` dependency management on Maven Central:
- `io.netty:netty-codec-http` = `4.1.136.Final`
- `io.vertx:vertx-core` = `4.5.31`
- `org.aesh:readline` = `2.6.3` → `org.jline:jansi` = `4.2.1`

## Related PRs
-https://github.com/apache/incubator-kie-tools/pull/3700
https://github.com/apache/incubator-kie-examples/pull/2223