### PR TITLE
[NO-ISSUE]: Fix Jackson-databind 3.1.4 → 3.1.5

### DIFF
--- a/kogito-springboot/bom/pom.xml
+++ b/kogito-springboot/bom/pom.xml
@@ -53,20 +53,16 @@
          https://logging.apache.org/security.html#CVE-2026-49844 -->
     <version.org.apache.logging.log4j>2.26.1</version.org.apache.logging.log4j>
     <!-- CVE-2026-59889: force-pin jackson-databind to 3.1.5.
-         spring-boot-dependencies:4.0.7 imports tools.jackson:jackson-bom:3.1.4 which carries
-         the vulnerable jackson-databind:3.1.4. Importing jackson-bom:3.1.5 before
-         spring-boot-dependencies overrides the transitive version for all spring-boot-* carriers.
-         Remove this pin once spring-boot-dependencies imports jackson-bom >= 3.1.5. -->
-    <version.tools.jackson>3.1.5</version.tools.jackson> <!-- CVE-2026-59889: override jackson-bom before spring-boot-dependencies import -->
+         spring-boot-dependencies:4.0.7 carries the vulnerable jackson-databind:3.1.4.
+         Remove this pin once spring-boot-dependencies imports jackson-databind >= 3.1.5. -->
+    <version.tools.jackson.core>3.1.5</version.tools.jackson.core>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>tools.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${version.tools.jackson}</version>
-        <type>pom</type>
-        <scope>import</scope>
+        <groupId>tools.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.tools.jackson.core}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.cloud</groupId>

--- a/kogito-springboot/bom/pom.xml
+++ b/kogito-springboot/bom/pom.xml
@@ -52,9 +52,22 @@
          Override the version property inherited from kie-parent to 2.26.1 (minimum 2.25.5).
          https://logging.apache.org/security.html#CVE-2026-49844 -->
     <version.org.apache.logging.log4j>2.26.1</version.org.apache.logging.log4j>
+    <!-- CVE-2026-59889: force-pin jackson-databind to 3.1.5.
+         spring-boot-dependencies:4.0.7 imports tools.jackson:jackson-bom:3.1.4 which carries
+         the vulnerable jackson-databind:3.1.4. Importing jackson-bom:3.1.5 before
+         spring-boot-dependencies overrides the transitive version for all spring-boot-* carriers.
+         Remove this pin once spring-boot-dependencies imports jackson-bom >= 3.1.5. -->
+    <version.tools.jackson>3.1.5</version.tools.jackson> <!-- CVE-2026-59889: override jackson-bom before spring-boot-dependencies import -->
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.tools.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>


### PR DESCRIPTION
## Summary

Fixes **CVE-2026-59889** (CVSS 6.5, Medium) — `jackson-databind` `@JsonUnwrapped`/`@JsonView` view bypass.

## Root Cause

`spring-boot-dependencies:4.0.7` imports `tools.jackson:jackson-bom:3.1.4` which resolves `jackson-databind:3.1.4` across the Spring Boot transitive tree.

Dependency path (INTRA-TRANSITIVE):
```
spring-boot-dependencies:4.0.7
  └─ tools.jackson:jackson-bom:3.1.4
       └─ [drools|jbpm|kie-addons]-spring-boot-starter
            → spring-boot-starter-web → spring-boot-starter-jackson
              → spring-boot-jackson → jackson-databind:3.1.4  ← CVE-2026-59889
```

## Fix

Pin tools.jackson.core:jackson-databind to 3.1.5 directly in kogito-springboot/bom/pom.xml. This overrides the vulnerable jackson-databind:3.1.4 carried by spring-boot-dependencies:4.0.7. Only jackson-databind is pinned as it is the only artifact affected by CVE-2026-59889.

**File changed:** `springboot/bom/pom.xml`

## Verification

mvn dependency:tree -Dverbose -pl kogito-apps-springboot/integration-tests-jobs-service-springboot -Dincludes="tools.jackson*" confirms jackson-databind resolves to 3.1.5 ✓

## TODO

Remove force-pin once `spring-boot-dependencies` upgrades its `jackson-bom.version` to `>= 3.1.5`.

## References
- https://nvd.nist.gov/vuln/detail/CVE-2026-59889