### PR TITLE
[incubator-kie#7062] Migrate ActivityTests methods from v7 legacy runtime to code generation

### DIFF
--- a/kogito-jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/kogito-jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -39,6 +39,8 @@ import org.jbpm.bpmn2.activity.ScriptTaskWithIOModel;
 import org.jbpm.bpmn2.activity.ScriptTaskWithIOProcess;
 import org.jbpm.bpmn2.activity.UserTaskWithBooleanOutputModel;
 import org.jbpm.bpmn2.activity.UserTaskWithBooleanOutputProcess;
+import org.jbpm.bpmn2.activity.UserTaskWithDataStoreModel;
+import org.jbpm.bpmn2.activity.UserTaskWithDataStoreProcess;
 import org.jbpm.bpmn2.activity.UserTaskWithIOexpressionModel;
 import org.jbpm.bpmn2.activity.UserTaskWithIOexpressionProcess;
 import org.jbpm.bpmn2.activity.UserTaskWithParametrizedInputModel;
@@ -503,11 +505,13 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     }
 
     @Test
-    public void testUserTaskWithDataStoreScenario() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/activity/BPMN2-UserTaskWithDataStore.bpmn2");
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Human Task",
-                new DoNothingWorkItemHandler());
-        kruntime.startProcess("UserTaskWithDataStore");
+    public void testUserTaskWithDataStoreScenario() {
+        Application app = ProcessTestHelper.newApplication();
+        ProcessTestHelper.registerHandler(app, "Human Task", new DoNothingWorkItemHandler());
+        org.kie.kogito.process.Process<UserTaskWithDataStoreModel> processDefinition = UserTaskWithDataStoreProcess.newProcess(app);
+        UserTaskWithDataStoreModel model = processDefinition.createModel();
+        org.kie.kogito.process.ProcessInstance<UserTaskWithDataStoreModel> instance = processDefinition.createInstance(model);
+        instance.start();
         // we can't test further as user tasks are asynchronous.
     }
 


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie/issues/7062

Migrated testUserTaskWithDataStoreScenario in ActivityTest from the legacy v7 runtime-based API to the v9 generated process class approach.

The test file can be identified by referring to ActivityTest.java:
https://github.com/apache/incubator-kie/blob/main/kogito-jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java

## Tests Migrated
**testUserTaskWithDataStoreScenario()** — Line 508

- Validates that a process containing two sequential Human Tasks connected via a BPMN Data Store element can be instantiated and started without errors
- Converts from v7 createKogitoProcessRuntime() with runtime XML parsing to v9
- UserTaskWithDataStoreProcess.newProcess(app) using the code-generated process class backed by the pre-existing BPMN2-UserTaskWithDataStore.bpmn2
- Replaces kruntime.getKogitoWorkItemManager().registerWorkItemHandler() with ProcessTestHelper.registerHandler(app, "Human Task", new DoNothingWorkItemHandler())
- No assertions existed in the original test beyond process start; none were added — the test confirms the engine correctly ignores the informational <bpmn2:dataStore> association elements and starts the process without throwing error.