### PR TITLE
[incubator-kie-issues#2361] Add missing build-ordering dependencies for Data Index integration tests in partial builds

### DIFF
--- a/kogito-apps-bom/pom.xml
+++ b/kogito-apps-bom/pom.xml
@@ -148,7 +148,25 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
+        <artifactId>data-index-service-inmemory</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
         <artifactId>data-index-service-mongodb</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>data-index-service-mongodb</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>data-index-service-postgresql</artifactId>
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
@@ -156,7 +174,7 @@
         <groupId>org.kie.kogito</groupId>
         <artifactId>data-index-service-postgresql</artifactId>
         <version>${project.version}</version>
-        <classifier>sources</classifier>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
@@ -84,6 +84,22 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Ensure data-index-service-mongodb binary is built before running integration tests.
+         Build-ordering sentinel only: type=pom + full exclusions adds nothing to classpath.
+         Without this edge the partial CI build skips the service module and the
+         DataIndexMongoDBContainer image is missing at runtime. -->
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>data-index-service-mongodb</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
@@ -91,6 +91,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-mongodb</artifactId>
+      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
@@ -91,7 +91,6 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-mongodb</artifactId>
-      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>

--- a/kogito-apps-quarkus/integration-tests-data-index-service-quarkus-parent/integration-tests-data-index-service-quarkus/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-data-index-service-quarkus-parent/integration-tests-data-index-service-quarkus/pom.xml
@@ -141,6 +141,46 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Ensure data-index service binaries are built before running integration tests.
+         These are build-ordering sentinels only: type=pom + full exclusions means nothing
+         is added to the classpath. Without these edges the partial CI build skips the
+         service modules and the Testcontainer images are missing at runtime. -->
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>data-index-service-inmemory</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>data-index-service-mongodb</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>data-index-service-postgresql</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kogito-apps-quarkus/integration-tests-data-index-service-quarkus-parent/integration-tests-data-index-service-quarkus/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-data-index-service-quarkus-parent/integration-tests-data-index-service-quarkus/pom.xml
@@ -148,6 +148,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-inmemory</artifactId>
+      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>
@@ -160,6 +161,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-mongodb</artifactId>
+      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>
@@ -172,6 +174,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-postgresql</artifactId>
+      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>

--- a/kogito-apps-quarkus/integration-tests-data-index-service-quarkus-parent/integration-tests-data-index-service-quarkus/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-data-index-service-quarkus-parent/integration-tests-data-index-service-quarkus/pom.xml
@@ -148,7 +148,6 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-inmemory</artifactId>
-      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>
@@ -161,7 +160,6 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-mongodb</artifactId>
-      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>
@@ -174,7 +172,6 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-postgresql</artifactId>
-      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>

--- a/kogito-apps-springboot/integration-tests-data-index-service-springboot/pom.xml
+++ b/kogito-apps-springboot/integration-tests-data-index-service-springboot/pom.xml
@@ -141,7 +141,6 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-mongodb</artifactId>
-      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>
@@ -154,7 +153,6 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-postgresql</artifactId>
-      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>

--- a/kogito-apps-springboot/integration-tests-data-index-service-springboot/pom.xml
+++ b/kogito-apps-springboot/integration-tests-data-index-service-springboot/pom.xml
@@ -141,6 +141,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-mongodb</artifactId>
+      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>
@@ -153,6 +154,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>data-index-service-postgresql</artifactId>
+      <version>${project.version}</version>
       <type>pom</type>
       <scope>provided</scope>
       <exclusions>

--- a/kogito-apps-springboot/integration-tests-data-index-service-springboot/pom.xml
+++ b/kogito-apps-springboot/integration-tests-data-index-service-springboot/pom.xml
@@ -134,6 +134,34 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Ensure data-index service binaries are built before running integration tests.
+         These are build-ordering sentinels only: type=pom + full exclusions means nothing
+         is added to the classpath. Without these edges the partial CI build skips the
+         service modules and the Testcontainer images are missing at runtime. -->
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>data-index-service-mongodb</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>data-index-service-postgresql</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/script/ci/tests/scenarios-compute-build-scopes/12-quarkus-extension-pairing/expected-affected.txt
+++ b/script/ci/tests/scenarios-compute-build-scopes/12-quarkus-extension-pairing/expected-affected.txt
@@ -45,6 +45,7 @@ org.kie.kogito:data-index-storage-jpa-quarkus
 org.kie.kogito:data-index-storage-postgresql
 org.kie.kogito:data-index-storage-postgresql-reporting
 org.kie.kogito:integration-tests-data-index-service-quarkus
+org.kie.kogito:integration-tests-data-index-service-springboot
 org.kie.kogito:integration-tests-jobs
 org.kie.kogito:integration-tests-jobs-service-common-quarkus
 org.kie.kogito:integration-tests-jobs-service-quarkus

--- a/script/ci/tests/scenarios-compute-build-scopes/12-quarkus-extension-pairing/expected-upstream.txt
+++ b/script/ci/tests/scenarios-compute-build-scopes/12-quarkus-extension-pairing/expected-upstream.txt
@@ -8,6 +8,7 @@ org.drools:drools-codegen-common
 org.drools:drools-commands
 org.drools:drools-compiler
 org.drools:drools-core
+org.drools:drools-decisions-spring-boot-starter
 org.drools:drools-decisiontables
 org.drools:drools-drl
 org.drools:drools-drl-ast
@@ -34,6 +35,7 @@ org.drools:drools-quarkus-extension
 org.drools:drools-quarkus-integration-test-multimodule
 org.drools:drools-quarkus-integration-test-multimodule-dep
 org.drools:drools-quarkus-rules-extension
+org.drools:drools-rules-spring-boot-starter
 org.drools:drools-ruleunits
 org.drools:drools-ruleunits-api
 org.drools:drools-ruleunits-dsl
@@ -53,10 +55,13 @@ org.jbpm:jbpm-addons-mail
 org.jbpm:jbpm-addons-quarkus-mail-parent
 org.jbpm:jbpm-addons-quarkus-task-management-parent
 org.jbpm:jbpm-addons-quarkus-task-notification-parent
+org.jbpm:jbpm-addons-springboot-task-management
 org.jbpm:jbpm-addons-task-management
 org.jbpm:jbpm-addons-usertask-storage-jpa
 org.jbpm:jbpm-quarkus-extension
+org.jbpm:jbpm-spring-boot-starter
 org.jbpm:jbpm-with-drools-quarkus-extension
+org.jbpm:jbpm-with-drools-spring-boot-starter
 org.kie.kogito:apps-integration-tests
 org.kie.kogito:data-audit
 org.kie.kogito:data-audit-common
@@ -72,6 +77,7 @@ org.kie.kogito:data-index-graphql-quarkus
 org.kie.kogito:data-index-mutations
 org.kie.kogito:data-index-quarkus
 org.kie.kogito:data-index-service-common
+org.kie.kogito:data-index-service-mongodb
 org.kie.kogito:data-index-service-quarkus-common
 org.kie.kogito:data-index-shared-output-mutation
 org.kie.kogito:data-index-storage
@@ -134,6 +140,8 @@ org.kie.kogito:kogito-apps-bom
 org.kie.kogito:kogito-apps-build-parent
 org.kie.kogito:kogito-apps-quarkus
 org.kie.kogito:kogito-apps-quarkus-bom
+org.kie.kogito:kogito-apps-springboot
+org.kie.kogito:kogito-apps-springboot-bom
 org.kie.kogito:kogito-bom
 org.kie.kogito:kogito-build-no-bom-parent
 org.kie.kogito:kogito-build-parent
@@ -167,6 +175,8 @@ org.kie.kogito:kogito-quarkus-workflow-extension-common
 org.kie.kogito:kogito-rest-utils
 org.kie.kogito:kogito-rest-workitem
 org.kie.kogito:kogito-services
+org.kie.kogito:kogito-spring-boot-bom
+org.kie.kogito:kogito-spring-boot-test-utils
 org.kie.kogito:kogito-test-utils
 org.kie.kogito:kogito-timer
 org.kie.kogito:kogito-workitems
@@ -184,6 +194,7 @@ org.kie.kogito:persistence-commons-reporting-postgresql-base
 org.kie.kogito:process-serialization-protobuf
 org.kie.kogito:process-workitems
 org.kie.kogito:quarkus-extensions
+org.kie.kogito:spring-boot-starters
 org.kie.kogito:trusty
 org.kie.kogito:trusty-service
 org.kie.kogito:trusty-service-api
@@ -263,6 +274,14 @@ org.kie:kie-addons-quarkus-rest-exception-handler
 org.kie:kie-addons-quarkus-source-files-parent
 org.kie:kie-addons-rest-exception-handler
 org.kie:kie-addons-source-files
+org.kie:kie-addons-springboot-common-auth
+org.kie:kie-addons-springboot-events-parent
+org.kie:kie-addons-springboot-events-process-kafka
+org.kie:kie-addons-springboot-persistence-filesystem
+org.kie:kie-addons-springboot-persistence-parent
+org.kie:kie-addons-springboot-process-management
+org.kie:kie-addons-springboot-process-svg
+org.kie:kie-addons-springboot-rest-exception-handler
 org.kie:kie-addons-tracing-api
 org.kie:kie-addons-tracing-decision-common
 org.kie:kie-addons-tracing-parent
@@ -334,6 +353,7 @@ org.kie:kie-pmml-models-tree-compiler
 org.kie:kie-pmml-models-tree-evaluator
 org.kie:kie-pmml-models-tree-model
 org.kie:kie-pmml-trusty
+org.kie:kie-predictions-spring-boot-starter
 org.kie:kie-quarkus-build-parent
 org.kie:kie-quarkus-predictions-extension
 org.kie:kie-test-util
@@ -390,3 +410,5 @@ org.kie:kogito-addons-quarkus-knative-parent
 org.kie:kogito-addons-quarkus-marshallers-parent
 org.kie:kogito-addons-quarkus-parent
 org.kie:kogito-addons-quarkus-rest-callback
+org.kie:kogito-addons-springboot-common-parent
+org.kie:kogito-addons-springboot-parent


### PR DESCRIPTION
Needed by : https://github.com/apache/incubator-kie/pull/6861

**Problem**

The Data Index integration tests (`integration-tests-data-index-service-quarkus`,
`integration-tests-data-index-service-springboot`, and
`kogito-addons-quarkus-data-index-mongodb-persistence-integration-tests-process`)
fail when run as part of a partial CI build.

These ITs start real Data Index service instances via Testcontainers. The container
images are produced by the `data-index-service-mongodb`, `data-index-service-inmemory`,
and `data-index-service-postgresql` modules. However, those service modules were never
declared as dependencies of the IT modules, so the partial build's dep-graph has no
edge pulling them into the upstream pass — the service binaries are stale or missing
at runtime when the ITs execute.

This does not surface in a full build because reactor ordering always builds the
service modules first. It only appears in partial builds, where build scope is
determined entirely by declared dependency edges.

**Fix**

Add build-ordering sentinel `<dependency>` entries (the same pattern already used in
`kogito-apps-integration-tests/integration-tests-data-index-service/pom.xml`) to the
three affected IT modules. These are `type=pom`, `scope=provided`, with all transitive
dependencies excluded — nothing is added to the classpath, only the build ordering is
corrected.