### PR TITLE
[NO-ISSUE]: chore: upgrade Maven from 3.9.11 to 3.9.16

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -105,5 +105,5 @@ jenkins:
         args: --privileged --group-add docker
   default_tools:
     jdk: jdk_17_latest
-    maven: maven_3.9.11
+    maven: maven_3.9.16
     sonar_jdk: jdk_17_latest

--- a/devbox.json
+++ b/devbox.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
   "packages": [
     "jdk@21",
-    "maven@3.9.11"
+    "maven@3.9.16"
   ]
 }

--- a/kie-no-dependency-management-enforcer-rule/pom.xml
+++ b/kie-no-dependency-management-enforcer-rule/pom.xml
@@ -39,7 +39,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.enforcer.api>3.6.2</version.enforcer.api>
-    <version.org.apache.maven>3.9.11</version.org.apache.maven>
+    <version.org.apache.maven>3.9.16</version.org.apache.maven>
     <version.org.assertj>3.27.7</version.org.assertj>
     <version.org.mockito>5.18.0</version.org.mockito>
     <version.sisu.maven.plugin>1.0.0</version.sisu.maven.plugin>

--- a/kie-no-external-managed-dependency-enforcer-rule/pom.xml
+++ b/kie-no-external-managed-dependency-enforcer-rule/pom.xml
@@ -39,7 +39,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.enforcer.api>3.6.2</version.enforcer.api>
-    <version.org.apache.maven>3.9.11</version.org.apache.maven>
+    <version.org.apache.maven>3.9.16</version.org.apache.maven>
     <version.sisu.maven.plugin>1.0.0</version.sisu.maven.plugin>
   </properties>
 

--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -198,7 +198,7 @@
     <version.maven.min>3.8.1</version.maven.min>
     <version.maven.plugin>3.15.1</version.maven.plugin>
     <version.maven.project>2.2.1</version.maven.project>
-    <version.maven.resolver.api>1.7.3</version.maven.resolver.api>
+    <version.maven.resolver.api>1.9.27</version.maven.resolver.api>
     <version.mongodb-driver-sync>5.5.1</version.mongodb-driver-sync>
     <version.nashorn>15.3</version.nashorn>
     <version.native2ascii-maven-plugin>1.0-beta-1</version.native2ascii-maven-plugin>
@@ -230,8 +230,8 @@
     <version.org.apache.logging.log4j>2.26.1</version.org.apache.logging.log4j>
     <!-- CVE-2026-56624: Apache MINA SSHD fixed version -->
     <version.org.apache.sshd>2.19.0</version.org.apache.sshd>
-    <version.org.apache.maven>3.9.11</version.org.apache.maven>
-    <version.org.apache.maven.resolver>1.7.3</version.org.apache.maven.resolver>
+    <version.org.apache.maven>3.9.16</version.org.apache.maven>
+    <version.org.apache.maven.resolver>1.9.27</version.org.apache.maven.resolver>
     <version.org.apache.maven.wagon>3.5.3</version.org.apache.maven.wagon>
     <version.org.apache.openjpa>4.0.0</version.org.apache.openjpa>
     <version.org.apache.opennlp>2.5.11</version.org.apache.opennlp>

--- a/script/ci/dep-graph-extractor/pom.xml
+++ b/script/ci/dep-graph-extractor/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.9.11</version>
+            <version>3.9.16</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Update version.org.apache.maven to 3.9.16 in kie-parent/pom.xml
- Update version.org.apache.maven.resolver to 1.9.27 (bundled with Maven 3.9.16)
- Update version.maven.resolver.api to 1.9.27 (was stale 1.7.3)
- Update maven-core version in dep-graph-extractor/pom.xml
- Update kie-no-dependency-management-enforcer-rule/pom.xml
- Update kie-no-external-managed-dependency-enforcer-rule/pom.xml
- Update Jenkins CI tool config: maven_3.9.11 -> maven_3.9.16
- Update devbox.json: maven@3.9.11 -> maven@3.9.16

