### PR TITLE
[incubator-kie-issues#2394] replace data-isolation inline VALUES constructor

### DIFF
--- a/kogito-addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
+++ b/kogito-addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
@@ -88,24 +88,23 @@ public class GenericRepository extends Repository {
      * @param processIds Collection of process IDs to include in the CTE
      * @return The wrapped query with CTE and data isolation filtering
      */
-    private String buildQueryWithProcessFiltering(String baseQuery, Collection<Process<? extends Model>> processIds) {
+    private String buildQueryWithProcessFiltering(String baseQuery, Collection<Process<? extends Model>> processIds, String fromTable) {
         if (!isFilterByLocalProcess()) {
             return baseQuery;
         }
 
-        String valueTuples = java.util.stream.IntStream.range(0, processIds.size())
+        String anchorBlock = "WITH anchor_row AS (SELECT MIN(id) as target_id FROM " + fromTable + ")";
+        String unionSelects = java.util.stream.IntStream.range(0, processIds.size())
                 .mapToObj(i -> {
                     if (i == 0) {
-                        return "(CAST(? AS VARCHAR(255)), CAST(? AS VARCHAR(255)))";
+                        return "SELECT CAST(? AS VARCHAR(255)), CAST(? AS VARCHAR(255)) FROM " + fromTable + " WHERE id = (SELECT target_id FROM anchor_row)";
                     } else {
-                        return "(?, ?)";
+                        return "SELECT ?, ? FROM " + fromTable + " WHERE id = (SELECT target_id FROM anchor_row)";
                     }
                 })
-                .collect(Collectors.joining(", "));
+                .collect(Collectors.joining(" UNION ALL "));
 
-        String cte = "WITH allowed_processes (process_id, process_version) AS (" +
-                "  SELECT * FROM (VALUES " + valueTuples + ") AS temp(pid, pver)" +
-                ") ";
+        String cte = anchorBlock + ", allowed_processes (process_id, process_version) AS (" + unionSelects + ") ";
 
         // Determine if we need WHERE or AND
         String whereClause = baseQuery.toLowerCase().contains(" where ") ? " AND " : " WHERE ";
@@ -274,7 +273,7 @@ public class GenericRepository extends Repository {
     Optional<Record> findByIdInternal(String processId, String processVersion, UUID id) {
         Collection<Process<? extends Model>> processIds = getProcessIdsForFiltering();
         String baseQuery = sqlIncludingVersion(FIND_BY_ID, processVersion);
-        String query = buildQueryWithProcessFiltering(baseQuery, processIds);
+        String query = buildQueryWithProcessFiltering(baseQuery, processIds, "process_instances");
 
         try (Connection connection = dataSource.getConnection();
                 PreparedStatement statement = connection.prepareStatement(query)) {
@@ -299,7 +298,7 @@ public class GenericRepository extends Repository {
     Stream<Record> findAllInternalWaitingFor(String processId, String processVersion, String eventType) {
         Collection<Process<? extends Model>> processIds = getProcessIdsForFiltering();
         String baseQuery = sqlIncludingVersion(FIND_ALL_WAITING_FOR_EVENT_TYPE, processVersion);
-        String query = buildQueryWithProcessFiltering(baseQuery, processIds);
+        String query = buildQueryWithProcessFiltering(baseQuery, processIds, "process_instances");
 
         try (Connection connection = dataSource.getConnection();
                 PreparedStatement statement = connection.prepareStatement(query)) {
@@ -326,7 +325,7 @@ public class GenericRepository extends Repository {
     Optional<Record> findByBusinessKey(String processId, String processVersion, String businessKey) {
         Collection<Process<? extends Model>> processIds = getProcessIdsForFiltering();
         String baseQuery = sqlIncludingVersion(FIND_BY_BUSINESS_KEY, processVersion);
-        String query = buildQueryWithProcessFiltering(baseQuery, processIds);
+        String query = buildQueryWithProcessFiltering(baseQuery, processIds, "process_instances");
 
         try (Connection connection = dataSource.getConnection();
                 PreparedStatement statement = connection.prepareStatement(query)) {
@@ -384,7 +383,7 @@ public class GenericRepository extends Repository {
     Stream<Record> findAllInternal(String processId, String processVersion) {
         Collection<Process<? extends Model>> processIds = getProcessIdsForFiltering();
         String baseQuery = sqlIncludingVersion(FIND_ALL, processVersion);
-        String query = buildQueryWithProcessFiltering(baseQuery, processIds);
+        String query = buildQueryWithProcessFiltering(baseQuery, processIds, "process_instances");
 
         CloseableWrapper close = new CloseableWrapper();
         try {

--- a/kogito-addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
+++ b/kogito-addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
@@ -84,7 +84,7 @@ public class GenericRepository extends Repository {
      * Wraps a base SQL query with a CTE for data isolation filtering.
      * The CTE creates an allowed_processes table with multiple process IDs.
      *
-     * @param baseQuery  The base SQL query to wrap
+     * @param baseQuery The base SQL query to wrap
      * @param processIds Collection of process IDs to include in the CTE
      * @return The wrapped query with CTE and data isolation filtering
      */

--- a/kogito-addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
+++ b/kogito-addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
@@ -22,6 +22,7 @@ import java.sql.*;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -95,7 +96,7 @@ public class GenericRepository extends Repository {
 
         String processInstancesTable = "process_instances";
         String anchorBlock = "WITH anchor_row AS (SELECT MIN(id) as target_id FROM " + processInstancesTable + ")";
-        String unionSelects = java.util.stream.IntStream.range(0, processIds.size())
+        String unionSelects = IntStream.range(0, processIds.size())
                 .mapToObj(i -> {
                     if (i == 0) {
                         return "SELECT CAST(? AS VARCHAR(255)), CAST(? AS VARCHAR(255)) FROM " + processInstancesTable + " WHERE id = (SELECT target_id FROM anchor_row)";

--- a/kogito-addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
+++ b/kogito-addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
@@ -84,22 +84,23 @@ public class GenericRepository extends Repository {
      * Wraps a base SQL query with a CTE for data isolation filtering.
      * The CTE creates an allowed_processes table with multiple process IDs.
      *
-     * @param baseQuery The base SQL query to wrap
+     * @param baseQuery  The base SQL query to wrap
      * @param processIds Collection of process IDs to include in the CTE
      * @return The wrapped query with CTE and data isolation filtering
      */
-    private String buildQueryWithProcessFiltering(String baseQuery, Collection<Process<? extends Model>> processIds, String fromTable) {
+    private String buildQueryWithProcessFiltering(String baseQuery, Collection<Process<? extends Model>> processIds) {
         if (!isFilterByLocalProcess()) {
             return baseQuery;
         }
 
-        String anchorBlock = "WITH anchor_row AS (SELECT MIN(id) as target_id FROM " + fromTable + ")";
+        String processInstancesTable = "process_instances";
+        String anchorBlock = "WITH anchor_row AS (SELECT MIN(id) as target_id FROM " + processInstancesTable + ")";
         String unionSelects = java.util.stream.IntStream.range(0, processIds.size())
                 .mapToObj(i -> {
                     if (i == 0) {
-                        return "SELECT CAST(? AS VARCHAR(255)), CAST(? AS VARCHAR(255)) FROM " + fromTable + " WHERE id = (SELECT target_id FROM anchor_row)";
+                        return "SELECT CAST(? AS VARCHAR(255)), CAST(? AS VARCHAR(255)) FROM " + processInstancesTable + " WHERE id = (SELECT target_id FROM anchor_row)";
                     } else {
-                        return "SELECT ?, ? FROM " + fromTable + " WHERE id = (SELECT target_id FROM anchor_row)";
+                        return "SELECT ?, ? FROM " + processInstancesTable + " WHERE id = (SELECT target_id FROM anchor_row)";
                     }
                 })
                 .collect(Collectors.joining(" UNION ALL "));
@@ -273,7 +274,7 @@ public class GenericRepository extends Repository {
     Optional<Record> findByIdInternal(String processId, String processVersion, UUID id) {
         Collection<Process<? extends Model>> processIds = getProcessIdsForFiltering();
         String baseQuery = sqlIncludingVersion(FIND_BY_ID, processVersion);
-        String query = buildQueryWithProcessFiltering(baseQuery, processIds, "process_instances");
+        String query = buildQueryWithProcessFiltering(baseQuery, processIds);
 
         try (Connection connection = dataSource.getConnection();
                 PreparedStatement statement = connection.prepareStatement(query)) {
@@ -298,7 +299,7 @@ public class GenericRepository extends Repository {
     Stream<Record> findAllInternalWaitingFor(String processId, String processVersion, String eventType) {
         Collection<Process<? extends Model>> processIds = getProcessIdsForFiltering();
         String baseQuery = sqlIncludingVersion(FIND_ALL_WAITING_FOR_EVENT_TYPE, processVersion);
-        String query = buildQueryWithProcessFiltering(baseQuery, processIds, "process_instances");
+        String query = buildQueryWithProcessFiltering(baseQuery, processIds);
 
         try (Connection connection = dataSource.getConnection();
                 PreparedStatement statement = connection.prepareStatement(query)) {
@@ -325,7 +326,7 @@ public class GenericRepository extends Repository {
     Optional<Record> findByBusinessKey(String processId, String processVersion, String businessKey) {
         Collection<Process<? extends Model>> processIds = getProcessIdsForFiltering();
         String baseQuery = sqlIncludingVersion(FIND_BY_BUSINESS_KEY, processVersion);
-        String query = buildQueryWithProcessFiltering(baseQuery, processIds, "process_instances");
+        String query = buildQueryWithProcessFiltering(baseQuery, processIds);
 
         try (Connection connection = dataSource.getConnection();
                 PreparedStatement statement = connection.prepareStatement(query)) {
@@ -383,7 +384,7 @@ public class GenericRepository extends Repository {
     Stream<Record> findAllInternal(String processId, String processVersion) {
         Collection<Process<? extends Model>> processIds = getProcessIdsForFiltering();
         String baseQuery = sqlIncludingVersion(FIND_ALL, processVersion);
-        String query = buildQueryWithProcessFiltering(baseQuery, processIds, "process_instances");
+        String query = buildQueryWithProcessFiltering(baseQuery, processIds);
 
         CloseableWrapper close = new CloseableWrapper();
         try {

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/integration-tests-process/pom.xml
@@ -92,6 +92,22 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Ensure data-index-service-postgresql binary is built before running integration tests.
+         Build-ordering sentinel only: type=pom + full exclusions adds nothing to classpath.
+         Without this edge the partial CI build skips the service module and the
+         DataIndexPostgreSqlContainer image is missing at runtime. -->
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>data-index-service-postgresql</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/kogito-data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
+++ b/kogito-data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -155,11 +157,29 @@ public abstract class JPAAbstractQuery<R> {
             return baseQuery;
         }
 
-        String valueRows = IntStream.range(0, allowedKeys.size())
-                .mapToObj(i -> "(:processId" + i + ", :processVersion" + i + ")")
-                .collect(Collectors.joining(", "));
+        Pattern fromPattern = Pattern.compile("(?i)\\bFROM\\s+([^\\s,)(]+)");
+        Matcher matcher = fromPattern.matcher(baseQuery);
+        if (!matcher.find()) {
+            throw new IllegalArgumentException("Invalid base SQL query structure: Could not parse target table from 'FROM' clause.");
+        }
+        String fromTable = matcher.group(1);
+        if (matcher.find()) {
+            throw new IllegalArgumentException("Ambiguous SQL query structure: Multiple 'FROM' clauses or targets detected.");
+        }
 
-        String cte = "WITH _allowed_processes (processId, processVersion) AS (VALUES " + valueRows + ") ";
+        String anchorBlock = "WITH anchor_row AS (SELECT MIN(id) as target_id FROM " + fromTable + ")";
+
+        String unionSelects = java.util.stream.IntStream.range(0, allowedKeys.size())
+                .mapToObj(i -> {
+                    if (i == 0) {
+                        return "SELECT CAST(:processId" + i + " AS VARCHAR(255)) AS processId, CAST(:processVersion" + i + " AS VARCHAR(255)) AS processVersion FROM " + fromTable + " WHERE id = (SELECT target_id FROM anchor_row)";
+                    } else {
+                        return "SELECT :processId" + i + ", :processVersion" + i + " FROM " + fromTable + " WHERE id = (SELECT target_id FROM anchor_row)";
+                    }
+                })
+                .collect(Collectors.joining(" UNION ALL "));
+
+        String cte = anchorBlock + ", _allowed_processes (processId, processVersion) AS (" + unionSelects + ") ";
 
         String isolationPredicate;
         if (rootProcessIdColumn != null) {
@@ -187,12 +207,15 @@ public abstract class JPAAbstractQuery<R> {
 
         String upperQuery = baseQuery.toUpperCase();
         int orderByIdx = upperQuery.lastIndexOf("ORDER BY");
+
+        String queryConditionKeyword = upperQuery.contains(" WHERE ") ? " AND " : " WHERE ";
+
         if (orderByIdx >= 0) {
             return cte + baseQuery.substring(0, orderByIdx).stripTrailing()
-                    + " AND " + isolationPredicate + " "
+                    + queryConditionKeyword + isolationPredicate + " "
                     + baseQuery.substring(orderByIdx);
         }
-        return cte + baseQuery.stripTrailing() + " AND " + isolationPredicate;
+        return cte + baseQuery.stripTrailing() + queryConditionKeyword + isolationPredicate;
     }
 
     private void bindIsolationParameters(Query jpaQuery, List<ProcessKey> allowedKeys) {

--- a/kogito-data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
+++ b/kogito-data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
@@ -169,7 +169,7 @@ public abstract class JPAAbstractQuery<R> {
 
         String anchorBlock = "WITH anchor_row AS (SELECT MIN(id) as target_id FROM " + fromTable + ")";
 
-        String unionSelects = java.util.stream.IntStream.range(0, allowedKeys.size())
+        String unionSelects = IntStream.range(0, allowedKeys.size())
                 .mapToObj(i -> {
                     if (i == 0) {
                         return "SELECT CAST(:processId" + i + " AS VARCHAR(255)) AS processId, CAST(:processVersion" + i + " AS VARCHAR(255)) AS processVersion FROM " + fromTable

--- a/kogito-data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
+++ b/kogito-data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
@@ -179,28 +179,28 @@ public abstract class JPAAbstractQuery<R> {
                 })
                 .collect(Collectors.joining(" UNION ALL "));
 
-        String cte = anchorBlock + ", _allowed_processes (processId, processVersion) AS (" + unionSelects + ") ";
+        String cte = anchorBlock + ", allowed_processes (processId, processVersion) AS (" + unionSelects + ") ";
 
         String isolationPredicate;
         if (rootProcessIdColumn != null) {
             String preFilter = "("
-                    + processIdColumn + " IN (SELECT ap.processId FROM _allowed_processes ap)"
-                    + " OR " + rootProcessIdColumn + " IN (SELECT ap.processId FROM _allowed_processes ap)"
+                    + processIdColumn + " IN (SELECT ap.processId FROM allowed_processes ap)"
+                    + " OR " + rootProcessIdColumn + " IN (SELECT ap.processId FROM allowed_processes ap)"
                     + ")";
             String versionCheck = "("
                     + processVersionColumn + " IS NULL"
-                    + " OR EXISTS (SELECT 1 FROM _allowed_processes ap WHERE ap.processId = " + rootProcessIdColumn
+                    + " OR EXISTS (SELECT 1 FROM allowed_processes ap WHERE ap.processId = " + rootProcessIdColumn
                     + " AND ap.processVersion = " + rootProcessVersionColumn + ")"
                     + " OR (" + rootProcessIdColumn + " IS NULL"
-                    + " AND EXISTS (SELECT 1 FROM _allowed_processes ap WHERE ap.processId = " + processIdColumn
+                    + " AND EXISTS (SELECT 1 FROM allowed_processes ap WHERE ap.processId = " + processIdColumn
                     + " AND ap.processVersion = " + processVersionColumn + "))"
                     + ")";
             isolationPredicate = preFilter + " AND " + versionCheck;
         } else {
-            isolationPredicate = processIdColumn + " IN (SELECT ap.processId FROM _allowed_processes ap)"
+            isolationPredicate = processIdColumn + " IN (SELECT ap.processId FROM allowed_processes ap)"
                     + " AND ("
                     + processVersionColumn + " IS NULL"
-                    + " OR EXISTS (SELECT 1 FROM _allowed_processes ap WHERE ap.processId = " + processIdColumn
+                    + " OR EXISTS (SELECT 1 FROM allowed_processes ap WHERE ap.processId = " + processIdColumn
                     + " AND ap.processVersion = " + processVersionColumn + ")"
                     + ")";
         }

--- a/kogito-data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
+++ b/kogito-data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
@@ -172,7 +172,8 @@ public abstract class JPAAbstractQuery<R> {
         String unionSelects = java.util.stream.IntStream.range(0, allowedKeys.size())
                 .mapToObj(i -> {
                     if (i == 0) {
-                        return "SELECT CAST(:processId" + i + " AS VARCHAR(255)) AS processId, CAST(:processVersion" + i + " AS VARCHAR(255)) AS processVersion FROM " + fromTable + " WHERE id = (SELECT target_id FROM anchor_row)";
+                        return "SELECT CAST(:processId" + i + " AS VARCHAR(255)) AS processId, CAST(:processVersion" + i + " AS VARCHAR(255)) AS processVersion FROM " + fromTable
+                                + " WHERE id = (SELECT target_id FROM anchor_row)";
                     } else {
                         return "SELECT :processId" + i + ", :processVersion" + i + " FROM " + fromTable + " WHERE id = (SELECT target_id FROM anchor_row)";
                     }


### PR DESCRIPTION
Closes apache/incubator-kie-issues#2394

Making CTE more robust for
* plain JDBC
* JPA native query

Where VALUES constructor is not ANSI standard and not all DBs support its multi-value form.
This is a cheap, performance neutral, change to make CTE SQL query more robust.