### PR TITLE
[incubator-kie-6235] Support rule attributes in RuleUnit DSL

### DIFF
--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleFactory.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/RuleFactory.java
@@ -33,6 +33,22 @@ import org.drools.ruleunits.impl.datasources.ConsequenceDataStore;
  */
 public interface RuleFactory {
 
+    RuleFactory salience(int value);
+
+    RuleFactory noLoop();
+
+    RuleFactory enabled(boolean value);
+
+    RuleFactory activationGroup(String group);
+
+    RuleFactory timer(String expr);
+
+    RuleFactory calendars(String... calendars);
+
+    RuleFactory dateEffective(String date);
+
+    RuleFactory dateExpires(String date);
+
     <A> Pattern1Def<A> on(DataSource<A> dataSource);
 
     RuleFactory not(Function1<RuleFactory, PatternDef> patternBuilder);

--- a/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/util/RuleDefinition.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/main/java/org/drools/ruleunits/dsl/util/RuleDefinition.java
@@ -22,6 +22,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -54,6 +56,7 @@ import org.drools.ruleunits.dsl.patterns.Pattern2DefImpl;
 import org.drools.ruleunits.dsl.patterns.PatternDef;
 import org.drools.ruleunits.impl.datasources.ConsequenceDataStore;
 import org.drools.ruleunits.impl.datasources.ConsequenceDataStoreImpl;
+import org.drools.util.DateUtils;
 import org.kie.api.runtime.rule.RuleContext;
 
 import static org.drools.model.DSL.declarationOf;
@@ -66,6 +69,7 @@ public class RuleDefinition implements RuleFactory {
     private final RuleUnitDefinition unit;
     private final RulesFactory.UnitGlobals globals;
 
+    private final Map<Rule.Attribute, Object> attributes = new IdentityHashMap<>();
     private final List<InternalPatternDef> patterns = new ArrayList<>();
     private RuleItemBuilder consequence;
 
@@ -75,6 +79,58 @@ public class RuleDefinition implements RuleFactory {
         this.name = name;
         this.globals = globals;
         this.unit = unit;
+    }
+
+    @Override
+    public RuleFactory salience(int value) {
+        attributes.put(Rule.Attribute.SALIENCE, value);
+        return this;
+    }
+
+    @Override
+    public RuleFactory noLoop() {
+        attributes.put(Rule.Attribute.NO_LOOP, true);
+        return this;
+    }
+
+    @Override
+    public RuleFactory enabled(boolean value) {
+        attributes.put(Rule.Attribute.ENABLED, value);
+        return this;
+    }
+
+    @Override
+    public RuleFactory activationGroup(String group) {
+        attributes.put(Rule.Attribute.ACTIVATION_GROUP, group);
+        return this;
+    }
+
+    @Override
+    public RuleFactory timer(String expr) {
+        attributes.put(Rule.Attribute.TIMER, expr);
+        return this;
+    }
+
+    @Override
+    public RuleFactory calendars(String... calendars) {
+        attributes.put(Rule.Attribute.CALENDARS, calendars);
+        return this;
+    }
+
+    @Override
+    public RuleFactory dateEffective(String date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(DateUtils.parseDate(date));
+        attributes.put(Rule.Attribute.DATE_EFFECTIVE, cal);
+        return this;
+    }
+
+    @Override
+    public RuleFactory dateExpires(String date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(DateUtils.parseDate(date));
+        attributes.put(Rule.Attribute.DATE_EXPIRES, cal);
+        return this;
     }
 
     public void addPattern(InternalPatternDef pattern) {
@@ -162,8 +218,13 @@ public class RuleDefinition implements RuleFactory {
         return globals.asGlobal(globalField, globalObject);
     }
 
+    @SuppressWarnings("unchecked")
     public Rule toRule() {
         RuleBuilder ruleBuilder = rule(unit.getClass().getCanonicalName(), name).unit(unit.getClass());
+
+        for (Map.Entry<Rule.Attribute, Object> entry : attributes.entrySet()) {
+            ruleBuilder.attribute((Rule.Attribute) entry.getKey(), entry.getValue());
+        }
 
         List<RuleItemBuilder> items = new ArrayList<>();
 

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/ActivationGroupUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/ActivationGroupUnit.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.ruleunits.dsl.attribute;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.dsl.RuleUnitDefinition;
+import org.drools.ruleunits.dsl.RulesFactory;
+
+import static org.drools.model.Index.ConstraintType.EQUAL;
+
+public class ActivationGroupUnit implements RuleUnitDefinition {
+
+    private final DataStore<String> strings;
+    private final List<String> results = new ArrayList<>();
+
+    public ActivationGroupUnit() {
+        this(DataSource.createStore());
+    }
+
+    public ActivationGroupUnit(DataStore<String> strings) {
+        this.strings = strings;
+    }
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+
+    @Override
+    public void defineRules(RulesFactory rulesFactory) {
+        rulesFactory.rule("GroupLow")
+                    .activationGroup("exclusive")
+                    .salience(1)
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("groupLow"));
+
+        rulesFactory.rule("GroupHigh")
+                    .activationGroup("exclusive")
+                    .salience(10)
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("groupHigh"));
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/CalendarsUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/CalendarsUnit.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.ruleunits.dsl.attribute;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.dsl.RuleUnitDefinition;
+import org.drools.ruleunits.dsl.RulesFactory;
+
+import static org.drools.model.Index.ConstraintType.EQUAL;
+
+public class CalendarsUnit implements RuleUnitDefinition {
+
+    private final DataStore<String> strings;
+    private final List<String> results = new ArrayList<>();
+
+    public CalendarsUnit() {
+        this(DataSource.createStore());
+    }
+
+    public CalendarsUnit(DataStore<String> strings) {
+        this.strings = strings;
+    }
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+
+    @Override
+    public void defineRules(RulesFactory rulesFactory) {
+        rulesFactory.rule("CalendarRule")
+                    .calendars("myCalendar")
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("calendar fired"));
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/DateAttributeUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/DateAttributeUnit.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.ruleunits.dsl.attribute;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.dsl.RuleUnitDefinition;
+import org.drools.ruleunits.dsl.RulesFactory;
+
+import static org.drools.model.Index.ConstraintType.EQUAL;
+
+public class DateAttributeUnit implements RuleUnitDefinition {
+
+    private final DataStore<String> strings;
+    private final List<String> results = new ArrayList<>();
+
+    public DateAttributeUnit() {
+        this(DataSource.createStore());
+    }
+
+    public DateAttributeUnit(DataStore<String> strings) {
+        this.strings = strings;
+    }
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+
+    @Override
+    public void defineRules(RulesFactory rulesFactory) {
+        rulesFactory.rule("ExpiredRule")
+                    .dateEffective("1-Jan-2020")
+                    .dateExpires("1-Jan-2021")
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("expired"));
+
+        rulesFactory.rule("ActiveRule")
+                    .dateEffective("1-Jan-2020")
+                    .dateExpires("1-Jan-2099")
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("active"));
+
+        rulesFactory.rule("NotYetEffectiveRule")
+                    .dateEffective("1-Jan-2099")
+                    .dateExpires("1-Jan-2100")
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("notYetEffective"));
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/EnabledUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/EnabledUnit.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.ruleunits.dsl.attribute;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.dsl.RuleUnitDefinition;
+import org.drools.ruleunits.dsl.RulesFactory;
+
+import static org.drools.model.Index.ConstraintType.EQUAL;
+
+public class EnabledUnit implements RuleUnitDefinition {
+
+    private final DataStore<String> strings;
+    private final List<String> results = new ArrayList<>();
+
+    public EnabledUnit() {
+        this(DataSource.createStore());
+    }
+
+    public EnabledUnit(DataStore<String> strings) {
+        this.strings = strings;
+    }
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+
+    @Override
+    public void defineRules(RulesFactory rulesFactory) {
+        rulesFactory.rule("DisabledRule")
+                    .enabled(false)
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("disabled"));
+
+        rulesFactory.rule("EnabledRule")
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("enabled"));
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/NoLoopUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/NoLoopUnit.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.ruleunits.dsl.attribute;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.dsl.RuleUnitDefinition;
+import org.drools.ruleunits.dsl.RulesFactory;
+import org.drools.ruleunits.dsl.domain.Person;
+
+import static org.drools.model.Index.ConstraintType.GREATER_OR_EQUAL;
+
+public class NoLoopUnit implements RuleUnitDefinition {
+
+    private final DataStore<Person> persons;
+    private final List<String> results = new ArrayList<>();
+
+    public NoLoopUnit() {
+        this(DataSource.createStore());
+    }
+
+    public NoLoopUnit(DataStore<Person> persons) {
+        this.persons = persons;
+    }
+
+    public DataStore<Person> getPersons() {
+        return persons;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+
+    @Override
+    public void defineRules(RulesFactory rulesFactory) {
+        rulesFactory.rule("NoLoopRule")
+                    .noLoop()
+                    .on(persons)
+                    .filter("age", p -> p.getAge(), GREATER_OR_EQUAL, 18)
+                    .executeOnDataStore(persons, (ps, p) -> {
+                        results.add("fired-" + p.getAge());
+                        p.setAge(p.getAge() + 1);
+                        ps.update(p, "age");
+                    });
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/RuleUnitsAttributesTest.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/RuleUnitsAttributesTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.ruleunits.dsl.attribute;
+
+import org.drools.core.common.ReteEvaluator;
+import org.drools.ruleunits.api.RuleUnitInstance;
+import org.drools.ruleunits.api.RuleUnitProvider;
+import org.drools.ruleunits.dsl.domain.Person;
+import org.drools.ruleunits.impl.AbstractRuleUnitInstance;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RuleUnitsAttributesTest {
+
+    @Test
+    public void timer() {
+        // incubator-kie#6911: RuleUnit DSL does not apply RuleConfig clock type, so pseudo clock cannot be used here.
+        // When fixed, use pseudo clock to advance time and verify the timer rule fires after the delay.
+        TimerUnit unit = new TimerUnit();
+        unit.getStrings().add("Hello Timer");
+
+        try (RuleUnitInstance<TimerUnit> unitInstance = RuleUnitProvider.get().createRuleUnitInstance(unit)) {
+            assertThat(unitInstance.fire()).isZero();
+            assertThat(unit.getResults()).isEmpty();
+        }
+    }
+
+    @Test
+    public void calendars() {
+        // incubator-kie#6911: RuleUnit DSL does not apply RuleConfig clock type, so pseudo clock cannot be used here.
+        // When fixed, use pseudo clock to also test calendar + timer combination.
+        CalendarsUnit unit = new CalendarsUnit();
+
+        try (RuleUnitInstance<CalendarsUnit> unitInstance = RuleUnitProvider.get().createRuleUnitInstance(unit)) {
+            ReteEvaluator evaluator = (ReteEvaluator) ((AbstractRuleUnitInstance) unitInstance).getEvaluator();
+            evaluator.getCalendars().set("myCalendar", timestamp -> false);
+
+            unit.getStrings().add("Hello World");
+            assertThat(unitInstance.fire()).isZero();
+            assertThat(unit.getResults()).isEmpty();
+        }
+    }
+
+    @Test
+    public void dateEffectiveAndDateExpires() {
+        DateAttributeUnit unit = new DateAttributeUnit();
+        unit.getStrings().add("Hello World");
+
+        try (RuleUnitInstance<DateAttributeUnit> unitInstance = RuleUnitProvider.get().createRuleUnitInstance(unit)) {
+            assertThat(unitInstance.fire()).isEqualTo(1);
+            assertThat(unit.getResults()).containsExactly("active");
+        }
+    }
+
+    @Test
+    public void activationGroup() {
+        ActivationGroupUnit unit = new ActivationGroupUnit();
+        unit.getStrings().add("Hello World");
+
+        try (RuleUnitInstance<ActivationGroupUnit> unitInstance = RuleUnitProvider.get().createRuleUnitInstance(unit)) {
+            assertThat(unitInstance.fire()).isEqualTo(1);
+            assertThat(unit.getResults()).containsExactly("groupHigh");
+        }
+    }
+
+    @Test
+    public void enabled() {
+        EnabledUnit unit = new EnabledUnit();
+        unit.getStrings().add("Hello World");
+
+        try (RuleUnitInstance<EnabledUnit> unitInstance = RuleUnitProvider.get().createRuleUnitInstance(unit)) {
+            assertThat(unitInstance.fire()).isEqualTo(1);
+            assertThat(unit.getResults()).containsExactly("enabled");
+        }
+    }
+
+    @Test
+    public void noLoop() {
+        NoLoopUnit unit = new NoLoopUnit();
+        unit.getPersons().add(new Person("Mario", 40));
+
+        try (RuleUnitInstance<NoLoopUnit> unitInstance = RuleUnitProvider.get().createRuleUnitInstance(unit)) {
+            assertThat(unitInstance.fire()).isEqualTo(1);
+            assertThat(unit.getResults()).containsExactly("fired-40");
+        }
+    }
+
+    @Test
+    public void salience() {
+        SalienceUnit unit = new SalienceUnit();
+        unit.getStrings().add("Hello World");
+
+        try (RuleUnitInstance<SalienceUnit> unitInstance = RuleUnitProvider.get().createRuleUnitInstance(unit)) {
+            assertThat(unitInstance.fire()).isEqualTo(2);
+            assertThat(unit.getResults()).containsExactly("high", "low");
+        }
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/SalienceUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/SalienceUnit.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.ruleunits.dsl.attribute;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.dsl.RuleUnitDefinition;
+import org.drools.ruleunits.dsl.RulesFactory;
+
+import static org.drools.model.Index.ConstraintType.EQUAL;
+
+public class SalienceUnit implements RuleUnitDefinition {
+
+    private final DataStore<String> strings;
+    private final List<String> results = new ArrayList<>();
+
+    public SalienceUnit() {
+        this(DataSource.createStore());
+    }
+
+    public SalienceUnit(DataStore<String> strings) {
+        this.strings = strings;
+    }
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+
+    @Override
+    public void defineRules(RulesFactory rulesFactory) {
+        rulesFactory.rule("LowSalience")
+                    .salience(1)
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("low"));
+
+        rulesFactory.rule("HighSalience")
+                    .salience(10)
+                    .on(strings)
+                    .filter(EQUAL, "Hello World")
+                    .execute(results, r -> r.add("high"));
+    }
+}

--- a/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/TimerUnit.java
+++ b/drools-ruleunits/drools-ruleunits-dsl/src/test/java/org/drools/ruleunits/dsl/attribute/TimerUnit.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.ruleunits.dsl.attribute;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.ruleunits.api.DataSource;
+import org.drools.ruleunits.api.DataStore;
+import org.drools.ruleunits.dsl.RuleUnitDefinition;
+import org.drools.ruleunits.dsl.RulesFactory;
+
+import static org.drools.model.Index.ConstraintType.EQUAL;
+
+public class TimerUnit implements RuleUnitDefinition {
+
+    private final DataStore<String> strings;
+    private final List<String> results = new ArrayList<>();
+
+    public TimerUnit() {
+        this(DataSource.createStore());
+    }
+
+    public TimerUnit(DataStore<String> strings) {
+        this.strings = strings;
+    }
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+
+    @Override
+    public void defineRules(RulesFactory rulesFactory) {
+        rulesFactory.rule("TimerRule")
+                    .timer("int: 30m")
+                    .on(strings)
+                    .filter(EQUAL, "Hello Timer")
+                    .execute(results, r -> r.add("timer fired"));
+    }
+}


### PR DESCRIPTION
Add fluent rule attribute methods to RuleFactory interface and RuleDefinition implementation: salience, noLoop, enabled, activationGroup, timer, calendars, dateEffective, dateExpires.

Excluded: agenda-group, ruleflow-group (banned by RuleValidator), lock-on-active, auto-focus (useless without agenda-group, not supported).

Closes https://github.com/apache/incubator-kie/issues/6235
