### PR TITLE
[incubator-kie-7074] Spring-boot-maven-plugin repackage overwrites original JAR in SpringBoot integration-test modules - use exec classifier to fix

### DIFF
--- a/kogito-apps-springboot/data-index-springboot/kogito-addons-springboot-data-index-persistence/kogito-addons-springboot-data-index-persistence-jpa-parent/integration-tests-process/pom.xml
+++ b/kogito-apps-springboot/data-index-springboot/kogito-addons-springboot-data-index-persistence/kogito-addons-springboot-data-index-persistence-jpa-parent/integration-tests-process/pom.xml
@@ -154,6 +154,9 @@
                         <goals>
                             <goal>repackage</goal>
                         </goals>
+                        <configuration>
+                            <classifier>exec</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/kogito-apps-springboot/data-index-springboot/kogito-addons-springboot-data-index/kogito-addons-springboot-data-index-jpa-parent/integration-tests-process/pom.xml
+++ b/kogito-apps-springboot/data-index-springboot/kogito-addons-springboot-data-index/kogito-addons-springboot-data-index-jpa-parent/integration-tests-process/pom.xml
@@ -154,6 +154,9 @@
                         <goals>
                             <goal>repackage</goal>
                         </goals>
+                        <configuration>
+                            <classifier>exec</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/kogito-apps-springboot/integration-tests-data-index-service-springboot/pom.xml
+++ b/kogito-apps-springboot/integration-tests-data-index-service-springboot/pom.xml
@@ -204,6 +204,9 @@
             <goals>
               <goal>repackage</goal>
             </goals>
+            <configuration>
+              <classifier>exec</classifier>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/kogito-apps-springboot/integration-tests-jobs-service-springboot/pom.xml
+++ b/kogito-apps-springboot/integration-tests-jobs-service-springboot/pom.xml
@@ -141,6 +141,9 @@
             <goals>
               <goal>repackage</goal>
             </goals>
+            <configuration>
+              <classifier>exec</classifier>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie/issues/7074

When using `spring-boot-maven-plugin` to repackage a JAR in SpringBoot integration-test modules, the plugin by default **replaces the original artifact** with the fat repackaged JAR. This breaks downstream Maven builds that depend on the original (thin) JAR - for example, when another module or step tries to use the JAR as a dependency or classpath artifact.

The fix is to configure the `repackage` goal with the `exec` classifier, which makes the plugin produce the fat JAR as a _secondary_ artifact (e.g., `*-exec.jar`) while keeping the original JAR as the primary Maven artifact.