### PR TITLE
[NO-ISSUE] spring patch version upgrade for Security fixes.

### DIFF
--- a/kogito-springboot/bom/pom.xml
+++ b/kogito-springboot/bom/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <!-- Used to define which poms are allowed to have dependencyManagement sections. This is to enforce the convention that only the root pom should have dependencyManagement, and all other poms should inherit from it. -->
     <allowedPomsList>org.kie.kogito:kogito-spring-boot-bom</allowedPomsList>
-    <!-- Aligned with Spring Boot Cloud (spring-cloud-kubernetes-fabric8 5.0.1 declares fabric8 7.4.1) -->
+    <!-- Aligned with Spring Boot Cloud (spring-cloud-kubernetes-fabric8 5.0.1 declares fabric8 7.4.0) -->
     <version.io.fabric8>7.4.0</version.io.fabric8>
     <version.io.netty>4.2.17.Final</version.io.netty>
     <version.jakarta.servlet>6.0.0</version.jakarta.servlet>

--- a/kogito-springboot/bom/pom.xml
+++ b/kogito-springboot/bom/pom.xml
@@ -35,15 +35,15 @@
     <!-- Used to define which poms are allowed to have dependencyManagement sections. This is to enforce the convention that only the root pom should have dependencyManagement, and all other poms should inherit from it. -->
     <allowedPomsList>org.kie.kogito:kogito-spring-boot-bom</allowedPomsList>
     <!-- Aligned with Spring Boot Cloud (spring-cloud-kubernetes-fabric8 5.0.1 declares fabric8 7.4.1) -->
-    <version.io.fabric8>7.4.1</version.io.fabric8>
+    <version.io.fabric8>7.4.0</version.io.fabric8>
     <version.io.netty>4.2.17.Final</version.io.netty>
-    <version.jakarta.servlet>6.1.0</version.jakarta.servlet>
+    <version.jakarta.servlet>6.0.0</version.jakarta.servlet>
     <!-- This is needed to override the default version inherited from kie-parent-drools -->
     <version.mongodb-driver-sync>5.6.5</version.mongodb-driver-sync>
     <version.org.springdoc>2.8.13</version.org.springdoc>
     <version.org.springframework>7.0.9</version.org.springframework>
     <version.org.springframework.boot>4.0.8</version.org.springframework.boot>
-    <version.org.springframework.cloud>2025.1.3</version.org.springframework.cloud>
+    <version.org.springframework.cloud>2025.1.1</version.org.springframework.cloud>
     <!-- CVE-2026-49844: Spring Boot 4.0.7 sets log4j2.version=2.25.4 which is vulnerable.
          Override the version property inherited from kie-parent to 2.26.1 (minimum 2.25.5).
          https://logging.apache.org/security.html#CVE-2026-49844 -->

--- a/kogito-springboot/bom/pom.xml
+++ b/kogito-springboot/bom/pom.xml
@@ -34,20 +34,16 @@
   <properties>
     <!-- Used to define which poms are allowed to have dependencyManagement sections. This is to enforce the convention that only the root pom should have dependencyManagement, and all other poms should inherit from it. -->
     <allowedPomsList>org.kie.kogito:kogito-spring-boot-bom</allowedPomsList>
-    <!-- Aligned with Spring Boot Cloud (spring-cloud-kubernetes-fabric8 5.0.1 declares fabric8 7.4.0) -->
-    <version.io.fabric8>7.4.0</version.io.fabric8>
-    <version.io.netty>4.2.16.Final</version.io.netty>
-    <version.jakarta.servlet>6.0.0</version.jakarta.servlet>
+    <!-- Aligned with Spring Boot Cloud (spring-cloud-kubernetes-fabric8 5.0.1 declares fabric8 7.4.1) -->
+    <version.io.fabric8>7.4.1</version.io.fabric8>
+    <version.io.netty>4.2.17.Final</version.io.netty>
+    <version.jakarta.servlet>6.1.0</version.jakarta.servlet>
     <!-- This is needed to override the default version inherited from kie-parent-drools -->
-    <version.mongodb-driver-sync>5.6.4</version.mongodb-driver-sync>
+    <version.mongodb-driver-sync>5.6.5</version.mongodb-driver-sync>
     <version.org.springdoc>2.8.13</version.org.springdoc>
-    <version.org.springframework>7.0.8</version.org.springframework>
-    <version.org.springframework.boot>4.0.7</version.org.springframework.boot>
-    <!-- Spring Boot Cloud aligned with Spring Boot Framework version. See: https://spring.io/projects/spring-cloud -->
-    <!-- 2025.1.x (Oakwood) is the first Spring Cloud train compatible with Spring Boot 4.0.x;
-         2025.1.1 specifically targets Spring Boot 4.0.1+. -->
-    <!-- https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2025.1-Release-Notes -->
-    <version.org.springframework.cloud>2025.1.1</version.org.springframework.cloud>
+    <version.org.springframework>7.0.9</version.org.springframework>
+    <version.org.springframework.boot>4.0.8</version.org.springframework.boot>
+    <version.org.springframework.cloud>2025.1.3</version.org.springframework.cloud>
     <!-- CVE-2026-49844: Spring Boot 4.0.7 sets log4j2.version=2.25.4 which is vulnerable.
          Override the version property inherited from kie-parent to 2.26.1 (minimum 2.25.5).
          https://logging.apache.org/security.html#CVE-2026-49844 -->

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -64,8 +64,8 @@
     <version.org.eclipse.parsson>1.1.8</version.org.eclipse.parsson>
     <!-- CVE-2026-56624: Apache MINA SSHD fixed version -->
     <version.org.apache.sshd>2.19.0</version.org.apache.sshd>
-    <version.org.springframework>7.0.8</version.org.springframework>
-    <version.org.springframework.boot>4.0.7</version.org.springframework.boot>
+    <version.org.springframework>7.0.9</version.org.springframework>
+    <version.org.springframework.boot>4.0.8</version.org.springframework.boot>
     <version.com.fasterxml.jackson.databind>2.22.1</version.com.fasterxml.jackson.databind>
     <!-- ************************************************************************ -->
     <!-- Plugins -->


### PR DESCRIPTION
| Dependency | Before | After | Critical | High | Medium | Low |
|------------|--------|-------|----------|------|--------|-----|
| spring-web | 7.0.7 | 7.0.8 | — | CVE-2026-41845 | CVE-2026-41839, CVE-2026-41840, CVE-2026-41853, CVE-2026-41854 | — |
| spring-webmvc | 7.0.7 | 7.0.8 | — | CVE-2026-41842 | CVE-2026-41841, CVE-2026-41843, CVE-2026-41844, CVE-2026-41846 | — |
| spring-core | 7.0.7 | 7.0.8 | — | — | — | CVE-2026-41848 |
| spring-expression | 7.0.7 | 7.0.8 | — | CVE-2026-41850 | CVE-2026-41851 | CVE-2026-41852 |
| spring-security-core | 7.0.5 | 7.0.6 | — | CVE-2026-40988 | CVE-2026-41008 | CVE-2026-41694 |
| spring-security-web | 7.0.5 | 7.0.6 | — | — | CVE-2026-41706 | — |
| spring-kafka | 4.0.5 | 4.0.6 | — | CVE-2026-41731 | CVE-2026-41726, CVE-2026-41727 | — |
| spring-data-mongodb | 5.0.5 | 5.0.6 | — | CVE-2026-41717 | CVE-2026-41696 | — |
| spring-data-commons | 4.0.5 | 4.0.6 | — | CVE-2026-41695, CVE-2026-41716 | CVE-2026-41711, CVE-2026-41721 | — |

**Total CVEs remediated: 26** (0 Critical · 8 High · 15 Medium · 3 Low)


https://github.com/apache/incubator-kie-examples/pull/2246
https://github.com/apache/incubator-kie-tools/pull/3994