### PR TITLE
[incubator-kie-6902]:  Replace relocated `quarkus-junit5*` artifacts with `quarkus-junit*` (quarkus upgrade)

### DIFF
--- a/drools-quarkus-extension/drools-quarkus-deployment/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-deployment/pom.xml
@@ -82,7 +82,7 @@
     <!-- test -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/pom.xml
@@ -61,7 +61,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-main/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-main/pom.xml
@@ -57,7 +57,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-integration-test/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/pom.xml
@@ -48,7 +48,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-ruleunits-deployment/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits-deployment/pom.xml
@@ -82,7 +82,7 @@
     <!-- test -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/drools-quarkus-extension/drools-quarkus-ruleunits/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits/pom.xml
@@ -89,7 +89,7 @@
         <!-- test -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/drools-quarkus-extension/drools-quarkus/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus/pom.xml
@@ -85,7 +85,7 @@
         <!-- test -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/kogito-apps-quarkus/data-audit-quarkus/data-audit-quarkus-service/pom.xml
+++ b/kogito-apps-quarkus/data-audit-quarkus/data-audit-quarkus-service/pom.xml
@@ -114,7 +114,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-apps-quarkus/data-audit-quarkus/kogito-addons-quarkus-data-audit/pom.xml
+++ b/kogito-apps-quarkus/data-audit-quarkus/kogito-addons-quarkus-data-audit/pom.xml
@@ -103,7 +103,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -123,7 +123,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-quarkus/data-index-service-inmemory/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/data-index-service-inmemory/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-quarkus/data-index-service-mongodb/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/data-index-service-mongodb/pom.xml
@@ -90,7 +90,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-quarkus/data-index-service-postgresql/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/data-index-service-postgresql/pom.xml
@@ -98,7 +98,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/integration-tests-process/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/deployment/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/deployment/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/integration-tests-process/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/deployment/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/deployment/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/integration-tests-process/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/deployment/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/deployment/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/integration-tests-process/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-jpa-quarkus/pom.xml
+++ b/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-jpa-quarkus/pom.xml
@@ -90,7 +90,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-mongodb/pom.xml
+++ b/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-mongodb/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-postgresql-reporting/pom.xml
+++ b/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-postgresql-reporting/pom.xml
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-postgresql/pom.xml
+++ b/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-postgresql/pom.xml
@@ -59,7 +59,7 @@
      </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/integration-tests-data-index-service-quarkus-parent/integration-tests-data-index-service-quarkus/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-data-index-service-quarkus-parent/integration-tests-data-index-service-quarkus/pom.xml
@@ -133,7 +133,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/integration-tests-jobs/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-jobs/pom.xml
@@ -104,7 +104,7 @@
     <!-- Test Dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/integration-tests-trusty-service-quarkus/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-trusty-service-quarkus/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/pom.xml
+++ b/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/pom.xml
@@ -101,7 +101,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-recipients/job-http-recipient/deployment/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-recipients/job-http-recipient/deployment/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-common/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-common/pom.xml
@@ -155,7 +155,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-infinispan/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-infinispan/pom.xml
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-inmemory/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-inmemory/pom.xml
@@ -79,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-messaging-http/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-messaging-http/pom.xml
@@ -83,7 +83,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-messaging-kafka/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-messaging-kafka/pom.xml
@@ -97,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-mongodb/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-mongodb/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-postgresql-common/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-postgresql-common/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-postgresql/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-postgresql/pom.xml
@@ -84,7 +84,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-storage-jpa/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-storage-jpa/pom.xml
@@ -93,7 +93,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/deployment/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/deployment/pom.xml
@@ -142,7 +142,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/jobs-service-quarkus/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/pom.xml
@@ -90,12 +90,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-jpa-base/pom.xml
+++ b/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-jpa-base/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-mongodb-quarkus/pom.xml
+++ b/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-mongodb-quarkus/pom.xml
@@ -46,7 +46,7 @@
       </dependency>
       <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-postgresql/pom.xml
+++ b/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-postgresql/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-redis/pom.xml
+++ b/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-redis/pom.xml
@@ -66,7 +66,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-reporting-parent/persistence-commons-reporting-postgresql-generic/pom.xml
+++ b/kogito-apps-quarkus/persistence-commons-quarkus/persistence-commons-reporting-parent/persistence-commons-reporting-postgresql-generic/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-apps-quarkus/security-commons/pom.xml
+++ b/kogito-apps-quarkus/security-commons/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-explainability/explainability-service-messaging/pom.xml
+++ b/kogito-explainability/explainability-service-messaging/pom.xml
@@ -94,12 +94,12 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-explainability/explainability-service-rest/pom.xml
+++ b/kogito-explainability/explainability-service-rest/pom.xml
@@ -71,7 +71,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-jitexecutor/jitexecutor-bpmn/pom.xml
+++ b/kogito-jitexecutor/jitexecutor-bpmn/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-jitexecutor/jitexecutor-dmn/pom.xml
+++ b/kogito-jitexecutor/jitexecutor-dmn/pom.xml
@@ -89,7 +89,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-jitexecutor/jitexecutor-runner/pom.xml
+++ b/kogito-jitexecutor/jitexecutor-runner/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/common/reactive-messaging/pom.xml
+++ b/kogito-quarkus/addons/common/reactive-messaging/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/addons/events/mongodb/runtime/pom.xml
+++ b/kogito-quarkus/addons/events/mongodb/runtime/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-quarkus/addons/events/process/runtime/pom.xml
+++ b/kogito-quarkus/addons/events/process/runtime/pom.xml
@@ -86,7 +86,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-quarkus/addons/explainability/integration-tests/pom.xml
+++ b/kogito-quarkus/addons/explainability/integration-tests/pom.xml
@@ -83,12 +83,12 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/explainability/runtime/pom.xml
+++ b/kogito-quarkus/addons/explainability/runtime/pom.xml
@@ -61,7 +61,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,7 +81,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kogito-quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
+++ b/kogito-quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
@@ -83,7 +83,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/addons/jbpm-usertask-storage-jpa/deployment/pom.xml
+++ b/kogito-quarkus/addons/jbpm-usertask-storage-jpa/deployment/pom.xml
@@ -67,7 +67,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -87,7 +87,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kogito-quarkus/addons/jbpm-usertask-storage-jpa/runtime/pom.xml
+++ b/kogito-quarkus/addons/jbpm-usertask-storage-jpa/runtime/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -93,7 +93,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/addons/jobs/common/messaging/pom.xml
+++ b/kogito-quarkus/addons/jobs/common/messaging/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/jobs/common/rest-callback/pom.xml
+++ b/kogito-quarkus/addons/jobs/common/rest-callback/pom.xml
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/jobs/knative-eventing/deployment/pom.xml
+++ b/kogito-quarkus/addons/jobs/knative-eventing/deployment/pom.xml
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/jobs/knative-eventing/runtime/pom.xml
+++ b/kogito-quarkus/addons/jobs/knative-eventing/runtime/pom.xml
@@ -90,7 +90,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/jobs/messaging/runtime/pom.xml
+++ b/kogito-quarkus/addons/jobs/messaging/runtime/pom.xml
@@ -91,7 +91,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/knative/eventing/deployment/pom.xml
+++ b/kogito-quarkus/addons/knative/eventing/deployment/pom.xml
@@ -83,7 +83,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/knative/eventing/integration-tests/pom.xml
+++ b/kogito-quarkus/addons/knative/eventing/integration-tests/pom.xml
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/addons/knative/eventing/runtime/pom.xml
+++ b/kogito-quarkus/addons/knative/eventing/runtime/pom.xml
@@ -63,7 +63,7 @@
     <!-- Testing dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/kubernetes/deployment/pom.xml
+++ b/kogito-quarkus/addons/kubernetes/deployment/pom.xml
@@ -54,12 +54,12 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/kubernetes/integration-tests/pom.xml
+++ b/kogito-quarkus/addons/kubernetes/integration-tests/pom.xml
@@ -72,7 +72,7 @@
         <!-- Test -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/addons/kubernetes/runtime/pom.xml
+++ b/kogito-quarkus/addons/kubernetes/runtime/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/kubernetes/test-utils/pom.xml
+++ b/kogito-quarkus/addons/kubernetes/test-utils/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/kogito-quarkus/addons/mail/runtime/pom.xml
+++ b/kogito-quarkus/addons/mail/runtime/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/messaging/common/pom.xml
+++ b/kogito-quarkus/addons/messaging/common/pom.xml
@@ -93,7 +93,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -103,7 +103,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/messaging/integration-tests/pom.xml
+++ b/kogito-quarkus/addons/messaging/integration-tests/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/persistence/infinispan/health/pom.xml
+++ b/kogito-quarkus/addons/persistence/infinispan/health/pom.xml
@@ -51,7 +51,7 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/kogito-quarkus/addons/persistence/jdbc/runtime/pom.xml
+++ b/kogito-quarkus/addons/persistence/jdbc/runtime/pom.xml
@@ -58,7 +58,7 @@
     <!-- Test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -99,7 +99,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-quarkus/addons/process-instance-migration/integration-tests/pom.xml
+++ b/kogito-quarkus/addons/process-instance-migration/integration-tests/pom.xml
@@ -37,7 +37,7 @@
   <dependencies>
 	<dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/process-management/integration-tests/pom.xml
+++ b/kogito-quarkus/addons/process-management/integration-tests/pom.xml
@@ -37,7 +37,7 @@
   <dependencies>
 	<dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/process-svg/runtime/pom.xml
+++ b/kogito-quarkus/addons/process-svg/runtime/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/source-files/runtime/pom.xml
+++ b/kogito-quarkus/addons/source-files/runtime/pom.xml
@@ -77,7 +77,7 @@
         <!-- Test -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/addons/task-management/runtime/pom.xml
+++ b/kogito-quarkus/addons/task-management/runtime/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/task-notification/runtime/pom.xml
+++ b/kogito-quarkus/addons/task-notification/runtime/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/tracing-decision/integration-tests/pom.xml
+++ b/kogito-quarkus/addons/tracing-decision/integration-tests/pom.xml
@@ -60,12 +60,12 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/addons/tracing-decision/runtime/pom.xml
+++ b/kogito-quarkus/addons/tracing-decision/runtime/pom.xml
@@ -91,7 +91,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -111,7 +111,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-quarkus/bom/pom.xml
+++ b/kogito-quarkus/bom/pom.xml
@@ -179,7 +179,7 @@
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-junit5</artifactId>
+        <artifactId>quarkus-junit</artifactId>
         <version>${version.io.quarkus.quarkus-test}</version>
         <exclusions>
           <exclusion>
@@ -190,7 +190,7 @@
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-junit5-internal</artifactId>
+        <artifactId>quarkus-junit-internal</artifactId>
         <version>${version.io.quarkus.quarkus-test}</version>
         <exclusions>
           <exclusion>

--- a/kogito-quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
@@ -67,12 +67,12 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
@@ -53,12 +53,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
@@ -114,7 +114,7 @@
     <!-- test -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
@@ -74,7 +74,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/classic-inst/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/classic-inst/pom.xml
@@ -61,7 +61,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/simple-dmn/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/simple-dmn/pom.xml
@@ -61,7 +61,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
@@ -54,12 +54,12 @@
          </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
@@ -58,12 +58,12 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
@@ -56,7 +56,7 @@
     <!-- test -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
@@ -76,12 +76,12 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml
@@ -80,12 +80,12 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
@@ -72,12 +72,12 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
+++ b/kogito-quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
@@ -56,12 +56,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-kogito-plugin/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-kogito-plugin/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/kogito-quarkus/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
@@ -67,7 +67,7 @@
         <!--tests -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-decisions/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-decisions/pom.xml
@@ -61,7 +61,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-legacy-rules/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-legacy-rules/pom.xml
@@ -64,7 +64,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-norest/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-norest/pom.xml
@@ -56,7 +56,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-predictions/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-predictions/pom.xml
@@ -59,7 +59,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-filesystem/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-filesystem/pom.xml
@@ -60,7 +60,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
@@ -63,7 +63,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
@@ -92,7 +92,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
@@ -84,7 +84,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
@@ -88,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
@@ -88,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
@@ -60,7 +60,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -100,7 +100,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-resteasy-classic/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-resteasy-classic/pom.xml
@@ -56,7 +56,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-resteasy-reactive/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-resteasy-reactive/pom.xml
@@ -56,7 +56,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-rules/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-rules/pom.xml
@@ -64,7 +64,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-transactions/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-transactions/pom.xml
@@ -77,7 +77,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-usertask-listeners-rollback/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-usertask-listeners-rollback/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-usertasks/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-usertasks/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/integration-tests/integration-tests-quarkus-wshumantasks/pom.xml
+++ b/kogito-quarkus/integration-tests/integration-tests-quarkus-wshumantasks/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus/test/pom.xml
+++ b/kogito-quarkus/test/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/kogito-trusty/trusty-service/trusty-service-common/pom.xml
+++ b/kogito-trusty/trusty-service/trusty-service-common/pom.xml
@@ -110,7 +110,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -120,7 +120,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-trusty/trusty-service/trusty-service-postgresql/pom.xml
+++ b/kogito-trusty/trusty-service/trusty-service-postgresql/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-trusty/trusty-service/trusty-service-redis/pom.xml
+++ b/kogito-trusty/trusty-service/trusty-service-redis/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-trusty/trusty-storage/trusty-storage-redis/pom.xml
+++ b/kogito-trusty/trusty-storage/trusty-storage-redis/pom.xml
@@ -50,12 +50,12 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
@@ -59,7 +59,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/integration-test/pom.xml
@@ -59,7 +59,7 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
@@ -63,7 +63,7 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
@@ -63,7 +63,7 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
@@ -59,7 +59,7 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/pom.xml
@@ -55,7 +55,7 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/pom.xml
@@ -55,7 +55,7 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Renames every Quarkus JUnit test-support dependency to the coordinates introduced in Quarkus 3.31.0:

| Old artifactId | New artifactId | Occurrences |
|---|---|---|
| `quarkus-junit5` | `quarkus-junit` | 120 |
| `quarkus-junit5-internal` | `quarkus-junit-internal` | 27 |
| `quarkus-junit5-mockito` | `quarkus-junit-mockito` | 20 |

167 replacements across 142 `pom.xml` files. All are `groupId: io.quarkus`.

## Why

Quarkus renamed these artifacts in **3.31.0** — the `5` was dropped from the names because they are no
longer tied to a single JUnit major version. This repository builds against **Quarkus 3.33.3.2**
(`version.io.quarkus` in `kie-quarkus-build-parent` and `optaplanner-build-parent`), so it is past that
rename and is currently resolving the old coordinates through relocation stubs.

The old coordinates still publish, but only as relocation POMs:

```xml
<!-- io/quarkus/quarkus-junit5/3.33.3/quarkus-junit5-3.33.3.pom -->
<name>Quarkus - Relocations - quarkus-junit5</name>
<distributionManagement>
  <relocation>
    <artifactId>quarkus-junit</artifactId>
    <message>Update the artifactId in your project build file. Refer to
             https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31 for more information.</message>
  </relocation>
</distributionManagement>
```

Depending on relocations means every module logs a relocation warning during resolution, and the build
stays exposed to the stubs being dropped in a future Quarkus release. This change moves to the real
coordinates as the migration guide instructs.
