### PR TITLE
[NO-ISSUE] chore: upgrade logback to 1.6.3 to address CVE

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -86,7 +86,7 @@
     <version.black.ninia>4.2.0</version.black.ninia>
     <version.build.helper.maven.plugin>3.4.0</version.build.helper.maven.plugin>
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.ch.qos.logback>1.5.35</version.ch.qos.logback>
+    <version.ch.qos.logback>1.6.3</version.ch.qos.logback>
     <version.com.fasterxml.jackson>2.22.1</version.com.fasterxml.jackson>
     <version.com.fasterxml.jackson.annotations>2.22</version.com.fasterxml.jackson.annotations>
     <version.com.fasterxml.jackson.databind>2.22.1</version.com.fasterxml.jackson.databind>

--- a/optaplanner-build/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build/optaplanner-build-parent/pom.xml
@@ -42,7 +42,7 @@
     <version.org.drools>${project.version}</version.org.drools>
 
     <!-- Normal dependency versions -->
-    <version.ch.qos.logback>1.5.35</version.ch.qos.logback>
+    <version.ch.qos.logback>1.6.3</version.ch.qos.logback>
     <!-- CVE-2026-49844: log4j-api versions below 2.25.5 are vulnerable. Upgrade log4j to 2.26.1.
          This covers log4j-to-slf4j (explicitly managed) and log4j-api (promoted by quarkus-bom to 2.25.1).
          https://logging.apache.org/security.html#CVE-2026-49844 -->


### PR DESCRIPTION
 upgrade logback to 1.6.3 to address CVE