### PR TITLE
[NO-ISSUE] chore(deps): upgrade Gradle wrapper to 9.7.1

### DIFF
--- a/kie-parent/pom.xml
+++ b/kie-parent/pom.xml
@@ -212,13 +212,13 @@
     <!-- New and overwritten dependencies -->
     <!-- ################################################################################ -->
     <version.org.antlr4>4.13.2</version.org.antlr4>
-    <version.org.apache.ant>1.10.11</version.org.apache.ant>
+    <version.org.apache.ant>1.10.17</version.org.apache.ant>
     <version.org.apache.avro>1.12.1</version.org.apache.avro>
     <version.org.apache.commons>3.19.0</version.org.apache.commons>
     <version.org.apache.commons.csv>1.10.0</version.org.apache.commons.csv>
     <version.org.apache.commons.lang3>3.19.0</version.org.apache.commons.lang3>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
-    <version.org.apache.groovy>4.0.29</version.org.apache.groovy>
+    <version.org.apache.groovy>4.0.32</version.org.apache.groovy>
     <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.kafka>4.1.2</version.org.apache.kafka>
     <!-- CVE-2026-49844: poi-ooxml:5.4.1 pulls log4j-api:2.24.3 transitively via log4j-bom:2.24.3.

--- a/kogito-gradle-plugin-test/gradle/wrapper/gradle-wrapper.properties
+++ b/kogito-gradle-plugin-test/gradle/wrapper/gradle-wrapper.properties
@@ -20,7 +20,7 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/kogito-gradle-plugin/pom.xml
+++ b/kogito-gradle-plugin/pom.xml
@@ -126,33 +126,6 @@
     <dependency>
       <groupId>dev.gradleplugins</groupId>
       <artifactId>gradle-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-testng</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-all</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.groovy</groupId>
-      <artifactId>groovy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.groovy</groupId>
-      <artifactId>groovy-json</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.groovy</groupId>
-      <artifactId>groovy-ant</artifactId>
     </dependency>
 
     <dependency>
@@ -195,16 +168,6 @@
       <groupId>dev.gradleplugins</groupId>
       <artifactId>gradle-test-kit</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-all</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
With Quarkus 3.33, Gradle 9.7.1 is suggested for new projects --> https://quarkus.io/guides/gradle-tooling/
SpringBoot 4.0.8 supports any 9.x version --> https://docs.spring.io/spring-boot/4.0/gradle-plugin/index.html

- https://github.com/apache/incubator-kie/pull/7091
- https://github.com/apache/incubator-kie-examples/pull/2247