### PR TITLE
[incubator-kie-6902] Align RESTEasy with quarkus-bom 3.33 in kogito-quarkus-bom

### DIFF
--- a/kogito-quarkus/bom/pom.xml
+++ b/kogito-quarkus/bom/pom.xml
@@ -47,6 +47,7 @@
     <version.io.smallrye.mutiny>3.1.1</version.io.smallrye.mutiny>
     <version.org.hibernate>7.2.19.Final</version.org.hibernate>
     <version.org.postgresql>42.7.13</version.org.postgresql>
+    <version.org.jboss.resteasy>6.2.18.Final</version.org.jboss.resteasy>
     <!-- Quarkus 3.33 hard requirements: smallrye-config 3.16 (quarkus-core/junit-config reference io.smallrye.config.Config)
          and jandex 3.5 (arc-processor uses MethodParameterInfo.nameOrDefault). The two smallrye-config properties are one
          artifact family in kie-parent (they map to smallrye-config-core / smallrye-config) and must move together. -->


### PR DESCRIPTION
## What

Pin `version.org.jboss.resteasy` to `6.2.18.Final` in `kogito-quarkus/bom/pom.xml`.

## Why

`quarkus-bom:3.33.3.2` manages RESTEasy `6.2.18.Final`, while `kie-parent` pins
`6.2.12.Final` (the version `quarkus-bom:3.27.5.1` shipped). After the Quarkus 3.33
upgrade that pin silently downgrades RESTEasy on the Quarkus side.

`kie-parent` declares `resteasy-client`, `resteasy-jackson2-provider` and
`resteasy-multipart-provider`, which are shared with the Spring Boot tree, so the
override is scoped to the Quarkus BOM instead of bumping `kie-parent`. Same pattern
as the existing `mongodb-driver-sync` and `smallrye-open-api` alignment pins.

## Verification

Effective POMs:

| BOM | `version.org.jboss.resteasy` | managed artifacts |
|---|---|---|
| `kogito-quarkus-bom` | 6.2.18.Final | all 34 at 6.2.18.Final |
| `kogito-springboot-bom` | 6.2.12.Final | unchanged |

Matches `quarkus-bom:3.33.3.2` exactly; Spring Boot resolution is unaffected.
