### PR TITLE
[main][incubator-kie-issues -2400] Fix CVE-2026-47857, CVE-2026-47863 in reactor-core

### DIFF
--- a/kogito-quarkus/bom/pom.xml
+++ b/kogito-quarkus/bom/pom.xml
@@ -63,7 +63,6 @@
     <version.org.graalvm.nativeimage>23.1.2</version.org.graalvm.nativeimage>
     <version.org.jredisearch>2.2.0</version.org.jredisearch>
     <version.org.json>20231013</version.org.json>
-    <!-- CVE fix: reactor-core CVE-2026-47857, CVE-2026-47863 -->
     <version.io.projectreactor>3.8.7</version.io.projectreactor>
 </properties>
   <dependencyManagement>
@@ -150,8 +149,6 @@
         <artifactId>quarkus-reactive-messaging-http-deployment</artifactId>
         <version>${version.io.quarkiverse.reactivemessaging.http}</version>
       </dependency>
-      <!-- CVE fix: reactor-core CVE-2026-47857, CVE-2026-47863 — upgrade from 3.5.0/3.8.6 to 3.8.7.
-           Must appear before quarkus-bom import to take precedence. -->
       <dependency>
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-core</artifactId>

--- a/kogito-quarkus/bom/pom.xml
+++ b/kogito-quarkus/bom/pom.xml
@@ -63,6 +63,8 @@
     <version.org.graalvm.nativeimage>23.1.2</version.org.graalvm.nativeimage>
     <version.org.jredisearch>2.2.0</version.org.jredisearch>
     <version.org.json>20231013</version.org.json>
+    <!-- CVE fix: reactor-core CVE-2026-47857, CVE-2026-47863 -->
+    <version.io.projectreactor>3.8.7</version.io.projectreactor>
 </properties>
   <dependencyManagement>
     <dependencies>
@@ -147,6 +149,13 @@
         <groupId>io.quarkiverse.reactivemessaging.http</groupId>
         <artifactId>quarkus-reactive-messaging-http-deployment</artifactId>
         <version>${version.io.quarkiverse.reactivemessaging.http}</version>
+      </dependency>
+      <!-- CVE fix: reactor-core CVE-2026-47857, CVE-2026-47863 — upgrade from 3.5.0/3.8.6 to 3.8.7.
+           Must appear before quarkus-bom import to take precedence. -->
+      <dependency>
+        <groupId>io.projectreactor</groupId>
+        <artifactId>reactor-core</artifactId>
+        <version>${version.io.projectreactor}</version>
       </dependency>
       <!-- CVE fix: quarkus-bom:3.33.x pins all MongoDB driver artifacts to 5.5.1.
            Override to match mongodb-driver-sync:${version.mongodb-driver-sync} already


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

**Thank you for submitting this pull request**
Upgrade io.projectreactor:reactor-core from 3.5.0/3.8.6 to 3.8.7 to address CVE-2026-47857 and CVE-2026-47863.


- Added <version.io.projectreactor>3.8.7</version.io.projectreactor> property to kogito-quarkus/bom/pom.xml
- Added io.projectreactor:reactor-core dependency management entry
Closes # https://github.com/apache/incubator-kie-issues/issues/2400

**NOTE!:** Double-check the target branch for this PR.
The default is `main`.

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

* [link](https://www.example.com)

**Issue**: _(please edit the GitHub Issues link if it exists)_

* [link](https://www.example.com)

**Referenced Pull Requests**: _(please edit the URLs of referenced pull requests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate the CI locally
</summary>

The CI does "simple" maven build(s). All commands can be run from the repository root.

**Quick build of just your changed modules and their dependents** (mirrors what CI does on a PR):

```shell
# 1. Build upstream dependencies of your changes (skip tests for speed)
mvn -T 1C --batch-mode -fae -DskipTests -DskipITs \
    -Denforcer.skip=true -Dcheckstyle.skip=true -Dformatter.skip=true -Darchunit.skip=true \
    -pl <upstream-modules> install

# 2. Build your changed modules and their transitive dependents (with tests)
mvn --batch-mode -fae -Dreproducible \
    -pl <affected-modules> install
```

To compute `<upstream-modules>` and `<affected-modules>` automatically (requires [JBang](https://www.jbang.dev/)):

```shell
jbang script/ci/CiComputeBuildScopes.java \
    <changed-files.txt> \
    <upstream-modules.txt> \
    <affected-modules.txt> \
    <changed-modules.txt>
```

**Full build** (equivalent to what runs on every push to `main`):

```shell
mvn --batch-mode -fae -Dfull -Dreproducible install
```

`-Dfull` additionally builds the distribution modules and generates Javadoc JARs.

**Useful flags:**

| Flag | Effect |
|---|---|
| `-Dquickly` | Skip tests, Checkstyle, formatter, Enforcer, ArchUnit |
| `-DskipTests` | Skip unit tests |
| `-DskipITs` | Skip integration tests |
| `-Denforcer.skip=true` | Skip Enforcer plugin |
| `-Dcheckstyle.skip=true` | Skip Checkstyle |
| `-Dformatter.skip=true` | Skip formatter |
| `-Darchunit.skip=true` | Skip ArchUnit |

</details>

<details>
<summary>
How to retest this PR or trigger a specific build
</summary>

- To **re-run CI**: push a new commit to the PR (an empty commit is enough: `git commit --allow-empty -m "re-trigger CI"`).

</details>
