### PR TITLE
[incubator-kie-7106] fix(`kogito-quarkus-workflow-extension-common`): scope the UnitOfWorkManager bean to the application, not to the JVM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,4 +180,4 @@ package-lock.json
 !.rat-excludes
 
 # Jobs Service ITs
-apps-integration-tests/integration-tests-jobs-service/**/src/main/resources/shared/
+kogito-apps-quarkus/integration-tests-jobs-service-quarkus/**/src/main/resources/shared/

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/pom.xml
@@ -80,6 +80,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kogito-addons-quarkus-data-index-postgresql-deployment</artifactId>
       <type>pom</type>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/src/main/resources/timerresume.bpmn
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/src/main/resources/timerresume.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   xmlns:drools="http://www.jboss.org/drools"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   id="_timerResumeDefinitions"
+                   targetNamespace="http://www.omg.org/bpmn20">
+  <!-- Parks on a timer so the instance is persisted and resumed by the scheduler. Guards #3869. -->
+  <bpmn2:process id="timerResume" drools:packageName="org.kie.kogito.addons.quarkus.data.index.it"
+                 drools:version="1.0" drools:adHoc="false" name="timerResume"
+                 isExecutable="true" processType="Public">
+    <bpmn2:startEvent id="_timerResumeStart">
+      <bpmn2:outgoing>_timerResumeFlow1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:intermediateCatchEvent id="_timerResumeWait" name="Wait">
+      <bpmn2:incoming>_timerResumeFlow1</bpmn2:incoming>
+      <bpmn2:outgoing>_timerResumeFlow2</bpmn2:outgoing>
+      <bpmn2:timerEventDefinition id="_timerResumeTimerDef">
+        <bpmn2:timeDuration xsi:type="bpmn2:tFormalExpression">PT1S</bpmn2:timeDuration>
+      </bpmn2:timerEventDefinition>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:endEvent id="_timerResumeEnd">
+      <bpmn2:incoming>_timerResumeFlow2</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_timerResumeFlow1" sourceRef="_timerResumeStart" targetRef="_timerResumeWait"/>
+    <bpmn2:sequenceFlow id="_timerResumeFlow2" sourceRef="_timerResumeWait" targetRef="_timerResumeEnd"/>
+  </bpmn2:process>
+</bpmn2:definitions>

--- a/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/src/test/java/org/kie/kogito/addons/quarkus/data/index/it/JPAQuarkusAddonDataIndexTimerResumeIT.java
+++ b/kogito-apps-quarkus/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/src/test/java/org/kie/kogito/addons/quarkus/data/index/it/JPAQuarkusAddonDataIndexTimerResumeIT.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.quarkus.data.index.it;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+/**
+ * Regression test for <a href="https://github.com/apache/incubator-kie-kogito-runtimes/issues/3869">#3869</a>:
+ * events emitted after a persisted instance is resumed must reach the data index.
+ */
+@QuarkusIntegrationTest
+class JPAQuarkusAddonDataIndexTimerResumeIT {
+
+    private static final String PROCESS_ID = "timerResume";
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    void testEventsAfterTimerResumeReachDataIndex() {
+        String processInstanceId = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .post("/" + PROCESS_ID)
+                .then()
+                .statusCode(201)
+                .body("id", is(notNullValue()))
+                .extract().path("id");
+
+        // Parked on the timer: indexed, but not finished yet.
+        queryState(processInstanceId).body("data.ProcessInstances.size()", is(1))
+                .body("data.ProcessInstances[0].state", is("ACTIVE"));
+
+        // The timer fires, the instance is resumed off the request thread and completes. If the
+        // resuming path publishes into a UnitOfWorkManager that carries no publishers, the data
+        // index never learns about it and this never becomes COMPLETED.
+        await().atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofSeconds(1))
+                .untilAsserted(() -> queryState(processInstanceId)
+                        .body("data.ProcessInstances.size()", is(1))
+                        .body("data.ProcessInstances[0].state", is("COMPLETED")));
+    }
+
+    private static ValidatableResponse queryState(String processInstanceId) {
+        return given().contentType(ContentType.JSON)
+                .body("{ \"query\" : \"{ProcessInstances(where: { id: {equal: \\\"" + processInstanceId
+                        + "\\\"}}){ id, state, processId } }\" }")
+                .when().post("/graphql")
+                .then().statusCode(200);
+    }
+}

--- a/kogito-quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/src/main/java/org/kie/kogito/quarkus/workflow/KogitoBeanProducer.java
+++ b/kogito-quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/src/main/java/org/kie/kogito/quarkus/workflow/KogitoBeanProducer.java
@@ -31,7 +31,8 @@ import org.kie.kogito.process.version.ProjectVersionProcessVersionResolver;
 import org.kie.kogito.services.jobs.impl.InMemoryJobContext;
 import org.kie.kogito.services.jobs.impl.InMemoryJobService;
 import org.kie.kogito.services.jobs.impl.InMemoryProcessJobExecutorFactory;
-import org.kie.kogito.services.uow.StaticUnitOfWorkManger;
+import org.kie.kogito.services.uow.CollectingUnitOfWorkFactory;
+import org.kie.kogito.services.uow.DefaultUnitOfWorkManager;
 import org.kie.kogito.uow.UnitOfWorkManager;
 import org.kie.kogito.usertask.UserTasks;
 
@@ -41,6 +42,7 @@ import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 @ApplicationScoped
 public class KogitoBeanProducer {
@@ -57,10 +59,12 @@ public class KogitoBeanProducer {
         return new DefaultCorrelationService();
     }
 
+    // Must stay a per-application singleton: a JVM-wide static outlives a dev-mode reload. See incubator-kie#7106.
     @DefaultBean
     @Produces
+    @Singleton
     UnitOfWorkManager unitOfWorkManager() {
-        return StaticUnitOfWorkManger.staticUnitOfWorkManager();
+        return new DefaultUnitOfWorkManager(new CollectingUnitOfWorkFactory());
     }
 
     @DefaultBean


### PR DESCRIPTION
**Issue**:

* https://github.com/apache/incubator-kie/issues/7106

**Referenced Pull Requests**:

* https://github.com/apache/incubator-kie-kogito-runtimes/pull/3870 (context only — see "Relationship to `#3870`" below)

---

## TL;DR

This fixes a bug I faced while running a Kogito application in dev mode. After changing a BPMN asset a few times, the runtime would fail and throw the following error:
```
IllegalStateException: EntityManagerFactory is closed
```

Removing the data-index JPA add-on made the error stop. The changes to `KogitoBeanProducer` fixed it, and I was able to add the add-on back again.

Read below if you want a deeply technical AI-generated description of the underlying issue.

## What this fixes

`KogitoBeanProducer` builds the CDI `UnitOfWorkManager` bean by returning a static singleton: `StaticUnitOfWorkManger.staticUnitOfWorkManager()`. There is one of those per JVM. The class that holds it comes from a dependency JAR, so Quarkus loads it with the base runtime ClassLoader. A dev-mode live reload does not recreate that ClassLoader, so the manager stays in memory after the application it belongs to has stopped.

That means every reload reuses the same manager, and the same `BaseEventManager` inside it. On each restart `AbstractProcessConfig` adds the new application's `EventPublisher`s and `UnitOfWorkEventListener`s to it. Both `addPublisher` and `register` only add — there is no remove. So the set of publishers grows by one per reload, and `publish()` ends up calling publishers that belong to applications which already shut down. Those old publishers still point at an `EntityManagerFactory` that was closed when their application stopped, and that is the `IllegalStateException: EntityManagerFactory is closed`.

A probe recorded object identities across five dev-mode starts. `Application` is a new object every time, as it should be. The manager and its event manager never are, and the publisher count goes up by one each reload:

| Start | `Application` | `UnitOfWorkManager` | `BaseEventManager` | Publishers |
|---|---|---|---|---|
| restart no:0 | `@2b15af5c` | `DefaultUnitOfWorkManager@135ba` | `@78f53ca9` | 1 |
| restart no:1 | `@41d76578` | `DefaultUnitOfWorkManager@135ba` | `@78f53ca9` | 2 |
| restart no:2 | `@266a08bf` | `DefaultUnitOfWorkManager@135ba` | `@78f53ca9` | 3 |
| restart no:3 | `@6637bbb9` | `DefaultUnitOfWorkManager@135ba` | `@78f53ca9` | 4 |
| restart no:4 | `@72a2ae1f` | `DefaultUnitOfWorkManager@135ba` | `@78f53ca9` | 5 |

The fix gives the producer the `@Singleton` scope and returns a new `DefaultUnitOfWorkManager`. The manager then lives and dies with the application, and nothing from an old reload survives.

Reproducer (public dependencies only, plus the full analysis): https://github.com/thiagoelg/quarkus-dev-mode-emf-closed-repro

## Relationship to [#3870](https://github.com/apache/incubator-kie-kogito-runtimes/pull/3870) — this is not a revert

This changes the line that dcaca447 ([`[Fix #3869] Using the same work and event manager`](https://github.com/apache/incubator-kie-kogito-runtimes/pull/3870)) introduced, so it is worth being explicit about the difference.

Before dcaca447 the producer was a bare `@Produces`, which means `@Dependent`. With that scope **every injection point gets its own manager**, and only the one held by `ProcessConfig` had the publishers on it. That is [#3869](https://github.com/apache/incubator-kie-kogito-runtimes/issues/3869): any code that got its manager from a different injection point sent its events to a manager with no publishers, so those events were lost.

So the real problem in [#3869](https://github.com/apache/incubator-kie-kogito-runtimes/issues/3869) was the **missing scope**. dcaca447 made every injection point share one object by using a static field. This PR makes them share one object through the CDI container instead. What dcaca447 fixed stays fixed; only the lifetime of the object changes.

`@Singleton` is used rather than `@ApplicationScoped` because ArC does not create a client proxy for it. Each injection point gets the object directly, so the unit-of-work path keeps the same shape it had before.

This also explains why dcaca447 only needed to touch Quarkus: Spring `@Bean` methods are singleton-scoped by default, so Spring Boot never had #3869. Its producer still reads `new DefaultUnitOfWorkManager(new CollectingUnitOfWorkFactory())`.

`LightProcessRuntimeServiceProvider` is deliberately left exactly as dcaca447 set it.

## Regression test for [#3869](https://github.com/apache/incubator-kie-kogito-runtimes/issues/3869)

PR [#3870](https://github.com/apache/incubator-kie-kogito-runtimes/pull/3870) shipped no test, so nothing in CI catches this. This PR adds one in `kogito-addons-quarkus-data-index-jpa/integration-tests-process`. The `timerResume` process stops at an intermediate timer, so the instance is saved to the database and then resumed by the job scheduler rather than by the request thread. The test checks that the data index sees the instance complete.

The test was checked in both directions first — a test that cannot fail proves nothing:

| Build | `UnitOfWorkManager` identities | Test |
|---|---|---|
| Pre-dcaca447 (reverse-applied) | config `@3c11533` (1 publisher), fresh lookup `@7fd0231` — a **different object** — static `@4c1a14df` (0 publishers) | **Fails** (`ConditionTimeoutException`, instance holds `ACTIVE`) |
| `main` | all one object, 1 publisher | Passes |
| This PR | config == fresh, 1 publisher | Passes |

## Validation

- Dev-mode reproducer: without the fix it breaks from reload `#2` and never recovers. With the fix, 11 starts out of 11 are clean and the log has no `EntityManagerFactory is closed`.
- The data index really does receive the events. This matters because a change that simply disconnected the publishers would also look clean: no error, HTTP 201. 5 instances were started across 5 generations, and exactly 5 were indexed, all `COMPLETED`.
- `kogito-quarkus-processes-integration-test` (10 tests), `integration-tests-quarkus-usertasks` (22 tests) and `kogito-addons-quarkus-data-index-jpa/integration-tests-process` (4 tests) all pass.

The user-task module is the important one there. `UserTaskConfig` shares the `UnitOfWorkManager` bean with `ProcessConfig`, so a wrong scope shows up in that module.

## Note on the second commit

`[NO-ISSUE] chore: fix the jobs-service IT shared/ ignore rule...` has nothing to do with #7106. The four jobs-service IT modules copy shared BPMN files into `src/main/resources/shared` during the build. There is already a `.gitignore` rule for them, but it still points at `apps-integration-tests/...`, the path used before `kogito-apps` was merged into this repository. It has matched nothing since that merge, so a working copy that has been built shows 24 generated files as untracked. Happy to split it into its own PR if preferred.

---

Disclaimer: Claude Opus 5 was used in the process of research, development, testing, and writing the description of this PR.
